### PR TITLE
feat: Implement UI changes, fix bugs, and add settings screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kotlin.serialization)
 }
 
 android {
@@ -90,6 +91,7 @@ dependencies {
     implementation(libs.androidx.navigation.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.compose.runtime.livedata)
+    implementation(libs.androidx.preference.ktx)
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/SettingsScreen.kt
@@ -1,0 +1,40 @@
+package com.hereliesaz.ideaz.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+
+@Composable
+fun SettingsScreen(
+    settingsViewModel: SettingsViewModel = viewModel()
+) {
+    val context = LocalContext.current
+    var apiKey by remember { mutableStateOf(settingsViewModel.getApiKey(context) ?: "") }
+
+    Column {
+        Spacer(modifier = Modifier.weight(0.2f))
+        Column(modifier = Modifier.weight(0.8f)) {
+            Text("Settings")
+            Spacer(modifier = Modifier.height(16.dp))
+            TextField(
+                value = apiKey,
+                onValueChange = { apiKey = it },
+                label = { Text("Jules API Key") }
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Button(onClick = {
+                settingsViewModel.saveApiKey(context, apiKey)
+            }) {
+                Text("Save")
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/SettingsViewModel.kt
@@ -1,0 +1,18 @@
+package com.hereliesaz.ideaz.ui
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.preference.PreferenceManager
+
+class SettingsViewModel : ViewModel() {
+
+    fun saveApiKey(context: Context, apiKey: String) {
+        val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
+        sharedPreferences.edit().putString("api_key", apiKey).apply()
+    }
+
+    fun getApiKey(context: Context): String? {
+        val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
+        return sharedPreferences.getString("api_key", null)
+    }
+}

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/theme/Theme.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/theme/Theme.kt
@@ -8,18 +8,34 @@ import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 
 private val DarkColorScheme = darkColorScheme(
     primary = Purple80,
     secondary = PurpleGrey80,
-    tertiary = Pink80
+    tertiary = Pink80,
+    background = Color.Black,
+    surface = Color.Black,
+    onPrimary = Color.White,
+    onSecondary = Color.White,
+    onTertiary = Color.White,
+    onBackground = Color.White,
+    onSurface = Color.White,
 )
 
 private val LightColorScheme = lightColorScheme(
     primary = Purple40,
     secondary = PurpleGrey40,
-    tertiary = Pink40
+    tertiary = Pink40,
+    background = Color.Black,
+    surface = Color.Black,
+    onPrimary = Color.White,
+    onSecondary = Color.White,
+    onTertiary = Color.White,
+    onBackground = Color.White,
+    onSurface = Color.White,
+
 
     /* Other default colors to override
     background = Color(0xFFFFFBFE),
@@ -34,9 +50,9 @@ private val LightColorScheme = lightColorScheme(
 
 @Composable
 fun IDEazTheme(
-    darkTheme: Boolean = isSystemInDarkTheme(),
+    darkTheme: Boolean = true,
     // Dynamic color is available on Android 12+
-    dynamicColor: Boolean = true,
+    dynamicColor: Boolean = false,
     content: @Composable () -> Unit
 ) {
     val colorScheme = when {

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/utils/ToolManager.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/utils/ToolManager.kt
@@ -17,13 +17,15 @@ object ToolManager {
         TOOLS.forEach { toolName ->
             val toolFile = File(toolDir, toolName)
             if (!toolFile.exists()) {
-                context.assets.open(toolName).use { inputStream ->
+                context.assets.open("tools/$toolName").use { inputStream ->
                     FileOutputStream(toolFile).use { outputStream ->
                         inputStream.copyTo(outputStream)
                     }
                 }
             }
-            toolFile.setExecutable(true, false)
+            val success = toolFile.setExecutable(true, false)
+            android.util.Log.d("ToolManager", "Set executable for ${toolFile.absolutePath}: $success")
+
         }
     }
 
@@ -34,6 +36,8 @@ object ToolManager {
     private const val TOOL_DIR = "tools"
 
     private fun getToolDir(context: Context): File {
-        return File(context.filesDir, TOOL_DIR)
+        val toolDir = File(context.filesDir, TOOL_DIR)
+        android.util.Log.d("ToolManager", "Tool directory: ${toolDir.absolutePath}")
+        return toolDir
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 agp = "8.13.0"
 aznavrail = "4.3"
 coreKtx = "1.17.0"
+preferenceKtx = "1.2.1"
 jcabiAether = "0.10.1"
 junit = "4.13.2"
 junitVersion = "1.3.0"
@@ -25,6 +26,7 @@ slf4jSimple = "2.0.17"
 [libraries]
 androidx-compose-runtime-livedata = { module = "androidx.compose.runtime:runtime-livedata", version.ref = "runtimeLivedata" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-preference-ktx = { group = "androidx.preference", name = "preference-ktx", version.ref = "preferenceKtx" }
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycleRuntimeKtx" }
 androidx-localbroadcastmanager = { module = "androidx.localbroadcastmanager:localbroadcastmanager", version.ref = "localbroadcastmanager" }
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
@@ -56,3 +58,4 @@ slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4jSimple" 
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }


### PR DESCRIPTION
This commit introduces several updates to the IDEaz application:

- Implemented a global UI change to set the background of all screens to black.
- Adjusted the layout of all screens to reserve the top 20% of the screen, pushing all content down.
- Fixed a bug where build tools were not being extracted to the correct directory, causing permission errors.
- Resolved a Retrofit conversion error by adding the necessary serialization plugin and ensuring all data models are serializable.
- Added a new settings screen where users can input and save their Jules API key.
- Integrated the settings screen into the main navigation.
- Updated the API client to use the saved API key for all requests.

## Summary by Sourcery

Implement UI enhancements with a dark theme and new layout structure, add navigation for Settings and session controls, fix tool extraction path and permissions, and update build configuration for serialization and preference support.

New Features:
- Introduce a Settings screen for entering and saving the Jules API key
- Integrate a "Settings" entry into the main navigation rail
- Add "Inspect" toggle and "Refresh Sessions" actions to the navigation rail

Bug Fixes:
- Correct asset extraction path for build tools and ensure executable permissions are applied

Enhancements:
- Enforce a global dark theme with black backgrounds and reserve the top 20% of each screen
- Refactor the main UI to use NavHost for composable navigation and adjust content layout spacing
- Disable dynamic color and force dark mode in the theme configuration

Build:
- Add Kotlin serialization plugin and include Preference KTX library dependency