### PR TITLE
feat: Implement AzTextBox and fix build errors

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -123,6 +123,7 @@ dependencies {
     implementation(libs.androidx.compose.ui.graphics)
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.material.icons.extended)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/MainActivity.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/MainActivity.kt
@@ -124,7 +124,7 @@ class MainActivity : ComponentActivity() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             registerReceiver(inspectionReceiver, filter, Context.RECEIVER_NOT_EXPORTED)
         } else {
-            registerReceiver(inspectionReceiver, filter)
+            registerReceiver(inspectionReceiver, filter, Context.RECEIVER_NOT_EXPORTED)
         }
     }
 

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/services/ScreenshotService.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/services/ScreenshotService.kt
@@ -129,6 +129,7 @@ class ScreenshotService : Service() {
 
                 // Send broadcast back to MainViewModel
                 val resultIntent = Intent("com.hereliesaz.ideaz.SCREENSHOT_TAKEN").apply {
+                    setPackage(packageName)
                     putExtra("BASE64_SCREENSHOT", base64String)
                 }
                 sendBroadcast(resultIntent)

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/services/UIInspectionService.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/services/UIInspectionService.kt
@@ -109,7 +109,7 @@ class UIInspectionService : AccessibilityService() {
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
             registerReceiver(commandReceiver, filter, Context.RECEIVER_NOT_EXPORTED)
         } else {
-            registerReceiver(commandReceiver, filter)
+            registerReceiver(commandReceiver, filter, Context.RECEIVER_NOT_EXPORTED)
         }
     }
 
@@ -248,7 +248,9 @@ class UIInspectionService : AccessibilityService() {
         promptContainer?.visibility = View.GONE
 
         cancelButton?.setOnClickListener {
-            val cancelIntent = Intent("com.hereliesaz.ideaz.CANCEL_TASK_REQUESTED")
+            val cancelIntent = Intent("com.hereliesaz.ideaz.CANCEL_TASK_REQUESTED").apply {
+                setPackage(packageName)
+            }
             sendBroadcast(cancelIntent)
         }
 
@@ -312,6 +314,7 @@ class UIInspectionService : AccessibilityService() {
                 // Send prompt back to ViewModel via broadcast
                 if (resourceId != null) {
                     val promptIntent = Intent("com.hereliesaz.ideaz.PROMPT_SUBMITTED_NODE").apply {
+                        setPackage(packageName)
                         putExtra("RESOURCE_ID", resourceId)
                         putExtra("PROMPT", prompt)
                         putExtra("BOUNDS", rect)
@@ -319,6 +322,7 @@ class UIInspectionService : AccessibilityService() {
                     sendBroadcast(promptIntent)
                 } else {
                     val promptIntent = Intent("com.hereliesaz.ideaz.PROMPT_SUBMITTED_RECT").apply {
+                        setPackage(packageName)
                         putExtra("RECT", rect)
                         putExtra("PROMPT", prompt)
                     }
@@ -328,7 +332,9 @@ class UIInspectionService : AccessibilityService() {
         }
 
         cancelButton?.setOnClickListener {
-            val cancelIntent = Intent("com.hereliesaz.ideaz.CANCEL_TASK_REQUESTED")
+            val cancelIntent = Intent("com.hereliesaz.ideaz.CANCEL_TASK_REQUESTED").apply {
+                setPackage(packageName)
+            }
             sendBroadcast(cancelIntent)
         }
 

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/ContextlessChatInput.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/ContextlessChatInput.kt
@@ -2,43 +2,31 @@ package com.hereliesaz.ideaz.ui
 
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Text
-import androidx.compose.runtime.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Send
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
-import androidx.compose.foundation.background
-import androidx.compose.material3.MaterialTheme
+import com.hereliesaz.aznavrail.AzTextBox
 
 @Composable
 fun ContextlessChatInput(
     modifier: Modifier = Modifier,
     onSend: (String) -> Unit
 ) {
-    var text by remember { mutableStateOf("") }
-
-    OutlinedTextField(
-        value = text,
-        onValueChange = { text = it },
-        label = { Text("Contextless Prompt...") },
+    AzTextBox(
         modifier = modifier
             .fillMaxWidth()
-            .padding(8.dp)
-            .background(MaterialTheme.colorScheme.surface), // Added opaque background
-        keyboardOptions = KeyboardOptions.Default.copy(
-            imeAction = ImeAction.Send
-        ),
-        keyboardActions = KeyboardActions(
-            onSend = {
-                if (text.isNotBlank()) {
-                    onSend(text)
-                    text = "" // Clear text after send
-                }
+            .padding(8.dp),
+        hint = "Contextless Prompt...",
+        onSubmit = {
+            if (it.isNotBlank()) {
+                onSend(it)
             }
-        ),
-        singleLine = true
+        },
+        submitButtonContent = {
+            Icon(Icons.Filled.Send, contentDescription = "Send")
+        }
     )
 }

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/PromptPopup.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/PromptPopup.kt
@@ -4,39 +4,35 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import com.hereliesaz.aznavrail.AzTextBox
 
 @Composable
 fun PromptPopup(
     onDismiss: () -> Unit,
     onSubmit: (String) -> Unit
 ) {
-    var text by remember { mutableStateOf("") }
-
     Dialog(onDismissRequest = onDismiss) {
         Card {
             Column(modifier = Modifier.padding(16.dp)) {
                 Text("Enter your prompt")
                 Spacer(modifier = Modifier.height(8.dp))
-                TextField(
-                    value = text,
-                    onValueChange = { text = it }
+                AzTextBox(
+                    hint = "Your prompt...",
+                    onSubmit = {
+                        if (it.isNotBlank()) {
+                            onSubmit(it)
+                        }
+                    },
+                    submitButtonContent = {
+                        Text("Submit")
+                    }
                 )
-                Spacer(modifier = Modifier.height(8.dp))
-                Button(onClick = { onSubmit(text) }) {
-                    Text("Submit")
-                }
             }
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 agp = "8.13.0"
-aznavrail = "4.4"
+aznavrail = "4.5"
 coreKtx = "1.17.0"
 googleGenai = "1.26.0"
 preferenceKtx = "1.2.1"
@@ -13,6 +13,7 @@ lifecycleRuntimeKtx = "2.9.4"
 activityCompose = "1.11.0"
 kotlin = "2.2.21"
 composeBom = "2025.11.00"
+materialIconsExtended = "1.6.1"
 localbroadcastmanager = "1.1.0"
 navigationCompose = "2.9.6"
 okhttp = "5.3.0"
@@ -49,6 +50,7 @@ androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "u
 androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended", version.ref = "materialIconsExtended" }
 compose-unstyled-core = { module = "com.composables:core", version.ref = "composeUnstyledCore" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }


### PR DESCRIPTION
- Updates AzNavRail to version 4.5.
- Replaces TextField with AzTextBox in ContextlessChatInput and PromptPopup.
- Adds material-icons-extended dependency.
- Fixes critical lint errors (UnspecifiedRegisterReceiverFlag, UnsafeImplicitIntentLaunch) that were preventing the build from succeeding.

## Summary by Sourcery

Implement the AzTextBox UI component, update key dependencies, and fix lint errors blocking the build

New Features:
- Replace Material3 text fields in ContextlessChatInput and PromptPopup with the new AzTextBox component

Bug Fixes:
- Add Context.RECEIVER_NOT_EXPORTED flag to registerReceiver calls to satisfy lint requirements
- Set package on broadcast Intents to avoid unsafe implicit Intent launches

Build:
- Upgrade AzNavRail dependency to v4.5
- Add material-icons-extended to the version catalog and app dependencies