### PR TITLE
feat: Add log verbosity setting

Adds a three-tier log verbosity setting to the settings screen.

- The user can now select between "Build Log", "AI Log", and "Combined" log verbosity levels.
- The selected level is saved to SharedPreferences and exposed as a StateFlow from the SettingsViewModel.
- The MainViewModel now consumes this StateFlow to filter the log stream displayed in the bottom sheet.

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/IdeBottomSheet.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/IdeBottomSheet.kt
@@ -4,12 +4,8 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Clear
-import androidx.compose.material.icons.filled.ContentCopy
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
+import com.hereliesaz.aznavrail.AzButton
+import com.hereliesaz.aznavrail.model.AzButtonShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -41,7 +37,7 @@ fun IdeBottomSheet(
 ) {
     val isChatVisible = sheetState.currentDetent == peekDetent || sheetState.currentDetent == halfwayDetent
     val isHalfwayExpanded = sheetState.currentDetent == halfwayDetent
-    val logMessages by viewModel.combinedLog.collectAsState(initial = "")
+    val logMessages by viewModel.filteredLog.collectAsState(initial = "")
     val clipboardManager = LocalClipboardManager.current
     val coroutineScope = rememberCoroutineScope()
 
@@ -51,7 +47,7 @@ fun IdeBottomSheet(
     ) {
         Box(modifier = Modifier.fillMaxSize()) {
             LiveOutputBottomCard(
-                logStream = viewModel.combinedLog,
+                logStream = viewModel.filteredLog,
                 modifier = Modifier.fillMaxSize(),
                 bottomPadding = if (isChatVisible) chatHeight else 0.dp
             )
@@ -62,20 +58,16 @@ fun IdeBottomSheet(
                         .align(Alignment.TopEnd)
                         .padding(16.dp)
                 ) {
-                    IconButton(onClick = { coroutineScope.launch { clipboardManager.setText(AnnotatedString(logMessages)) } }) {
-                        Icon(
-                            imageVector = Icons.Default.ContentCopy,
-                            contentDescription = "Copy Log",
-                            tint = MaterialTheme.colorScheme.onSurface
-                        )
-                    }
-                    IconButton(onClick = { viewModel.clearLog() }) {
-                        Icon(
-                            imageVector = Icons.Default.Clear,
-                            contentDescription = "Clear Log",
-                            tint = MaterialTheme.colorScheme.onSurface
-                        )
-                    }
+                    AzButton(
+                        onClick = { coroutineScope.launch { clipboardManager.setText(AnnotatedString(logMessages)) } },
+                        text = "Copy",
+                        shape = AzButtonShape.RECTANGLE
+                    )
+                    AzButton(
+                        onClick = { viewModel.clearLog() },
+                        text = "Clear",
+                        shape = AzButtonShape.RECTANGLE
+                    )
                 }
             }
         }

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/IdeNavRail.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/IdeNavRail.kt
@@ -39,7 +39,7 @@ fun IdeNavRail(
             isChecked = isIdeVisible, // isIdeVisible is true when sheet is up (Selection Mode)
             toggleOnText = "Interact", // Button text for Selection Mode
             toggleOffText = "Select",   // Button text for Interaction Mode
-            shape = AzButtonShape.NONE, // Explicitly adding null for the optional shape parameter
+            shape = AzButtonShape.RECTANGLE,
             onClick = {
                 handleActionClick {
                     onModeToggleClick() // Call the lambda from MainScreen

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/MainScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/MainScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import com.hereliesaz.aznavrail.AzButton
+import com.hereliesaz.aznavrail.model.AzButtonShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -149,10 +150,10 @@ fun MainScreen(
             title = { Text("Cancel Task") },
             text = { Text("Are you sure you want to cancel this task? All AI progress will be lost.") },
             confirmButton = {
-                AzButton(onClick = { viewModel.confirmCancelTask() }, text = "Confirm")
+                AzButton(onClick = { viewModel.confirmCancelTask() }, text = "Confirm", shape = AzButtonShape.RECTANGLE)
             },
             dismissButton = {
-                AzButton(onClick = { viewModel.dismissCancelTask() }, text = "Dismiss")
+                AzButton(onClick = { viewModel.dismissCancelTask() }, text = "Dismiss", shape = AzButtonShape.RECTANGLE)
             }
         )
     }

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/MainViewModel.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/MainViewModel.kt
@@ -46,8 +46,16 @@ class MainViewModel : ViewModel() {
     private val _aiLog = MutableStateFlow("")
     private val aiLog = _aiLog.asStateFlow()
 
-    val combinedLog: StateFlow<String> = combine(buildLog, aiLog) { build, ai ->
-        "$build\n$ai"
+    val filteredLog: StateFlow<String> = combine(
+        buildLog,
+        aiLog,
+        settingsViewModel.logVerbosity
+    ) { build, ai, verbosity ->
+        when (verbosity) {
+            SettingsViewModel.LOG_VERBOSITY_BUILD -> build
+            SettingsViewModel.LOG_VERBOSITY_AI -> ai
+            else -> "$build\n$ai"
+        }
     }.stateIn(viewModelScope, SharingStarted.Lazily, "")
 
 
@@ -556,8 +564,6 @@ class MainViewModel : ViewModel() {
             } catch (e: Exception) {
                 logTo(logTarget, "Error polling for patch: ${e.message}")
                 if (logTarget == "OVERLAY") sendOverlayBroadcast(Intent("com.hereliesaz.ideaz.TASK_FINISHED"))
-
-                    if (logTarget == "OVERLAY") sendOverlayBroadcast(Intent("com.hereliesaz.ideaz.TASK_FINISHED"))
             }
         }
     }

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/SettingsScreen.kt
@@ -11,11 +11,13 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import com.hereliesaz.aznavrail.AzButton
+import com.hereliesaz.aznavrail.model.AzButtonShape
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.MaterialTheme
+import com.hereliesaz.aznavrail.AzTextBox
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.*
@@ -29,7 +31,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Checkbox
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.material3.Switch
 
 @Composable
@@ -63,46 +64,48 @@ fun SettingsScreen(
                 Spacer(modifier = Modifier.height(16.dp))
 
                 // Jules API Key
-                TextField(
-                    value = apiKey,
-                    onValueChange = { apiKey = it },
-                    label = { Text("Jules API Key") },
-                    visualTransformation = PasswordVisualTransformation(),
-                    modifier = Modifier.fillMaxWidth()
-                )
                 Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-                    AzButton(onClick = {
-                        settingsViewModel.saveApiKey(context, apiKey)
-                        Toast.makeText(context, "Jules Key Saved", Toast.LENGTH_SHORT).show()
-                    }, text = "Save")
+                    AzTextBox(
+                        modifier = Modifier.weight(1f),
+                        value = apiKey,
+                        onValueChange = { apiKey = it },
+                        hint = "Jules API Key",
+                        secret = true,
+                        onSubmit = {
+                            settingsViewModel.saveApiKey(context, apiKey)
+                            Toast.makeText(context, "Jules Key Saved", Toast.LENGTH_SHORT).show()
+                        },
+                        submitButtonContent = { Text("Save") }
+                    )
                     Spacer(modifier = Modifier.width(8.dp))
                     AzButton(onClick = {
                         val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://jules.google.com/settings"))
                         context.startActivity(intent)
-                    }, text = "Get Key")
+                    }, text = "Get Key", shape = AzButtonShape.RECTANGLE)
                 }
 
 
                 Spacer(modifier = Modifier.height(16.dp))
 
                 // Google AI Studio API Key
-                TextField(
-                    value = googleApiKey,
-                    onValueChange = { googleApiKey = it },
-                    label = { Text("Google AI Studio API Key") },
-                    visualTransformation = PasswordVisualTransformation(),
-                    modifier = Modifier.fillMaxWidth()
-                )
                 Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-                    AzButton(onClick = {
-                        settingsViewModel.saveGoogleApiKey(context, googleApiKey)
-                        Toast.makeText(context, "AI Studio Key Saved", Toast.LENGTH_SHORT).show()
-                    }, text = "Save")
+                    AzTextBox(
+                        modifier = Modifier.weight(1f),
+                        value = googleApiKey,
+                        onValueChange = { googleApiKey = it },
+                        hint = "Google AI Studio API Key",
+                        secret = true,
+                        onSubmit = {
+                            settingsViewModel.saveGoogleApiKey(context, googleApiKey)
+                            Toast.makeText(context, "AI Studio Key Saved", Toast.LENGTH_SHORT).show()
+                        },
+                        submitButtonContent = { Text("Save") }
+                    )
                     Spacer(modifier = Modifier.width(8.dp))
                     AzButton(onClick = {
                         val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://aistudio.google.com/app/api-keys"))
                         context.startActivity(intent)
-                    }, text = "Get Key")
+                    }, text = "Get Key", shape = AzButtonShape.RECTANGLE)
                 }
 
 
@@ -167,6 +170,14 @@ fun SettingsScreen(
 
                 Spacer(modifier = Modifier.height(24.dp))
 
+                Text("Log Verbosity", color = MaterialTheme.colorScheme.onBackground)
+                LogVerbosityDropdown(
+                    settingsViewModel = settingsViewModel
+                )
+
+
+                Spacer(modifier = Modifier.height(24.dp))
+
                 // Display the list of sessions
                 Text("Active Sessions", color = MaterialTheme.colorScheme.onBackground)
                 if (sessions.isEmpty()) {
@@ -215,6 +226,55 @@ fun AiAssignmentDropdown(
                     text = { Text(model.displayName) },
                     onClick = {
                         onModelSelected(model)
+                        isExpanded = false
+                    }
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LogVerbosityDropdown(
+    settingsViewModel: SettingsViewModel
+) {
+    val context = LocalContext.current
+    var isExpanded by remember { mutableStateOf(false) }
+    var selectedVerbosity by remember { mutableStateOf(settingsViewModel.getLogVerbosity(context)) }
+
+    val verbosityOptions = mapOf(
+        SettingsViewModel.LOG_VERBOSITY_BUILD to "Build Log",
+        SettingsViewModel.LOG_VERBOSITY_AI to "AI Log",
+        SettingsViewModel.LOG_VERBOSITY_COMBINED to "Combined"
+    )
+
+    ExposedDropdownMenuBox(
+        expanded = isExpanded,
+        onExpandedChange = { isExpanded = it }
+    ) {
+        TextField(
+            value = verbosityOptions[selectedVerbosity] ?: "Combined",
+            onValueChange = { },
+            readOnly = true,
+            label = { Text("Log Output") },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = isExpanded) },
+            colors = ExposedDropdownMenuDefaults.textFieldColors(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .menuAnchor()
+        )
+
+        ExposedDropdownMenu(
+            expanded = isExpanded,
+            onDismissRequest = { isExpanded = false }
+        ) {
+            verbosityOptions.forEach { (key, value) ->
+                DropdownMenuItem(
+                    text = { Text(value) },
+                    onClick = {
+                        selectedVerbosity = key
+                        settingsViewModel.setLogVerbosity(context, key)
                         isExpanded = false
                     }
                 )

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/SettingsViewModel.kt
@@ -48,6 +48,14 @@ class SettingsViewModel : ViewModel() {
         const val KEY_SHOW_CANCEL_WARNING = "show_cancel_warning"
         const val KEY_DARK_MODE = "dark_mode"
 
+        // New key for log verbosity
+        const val KEY_LOG_VERBOSITY = "log_verbosity"
+
+        // Log verbosity levels
+        const val LOG_VERBOSITY_BUILD = "build"
+        const val LOG_VERBOSITY_AI = "ai"
+        const val LOG_VERBOSITY_COMBINED = "combined"
+
 
         val aiTasks = mapOf(
             KEY_AI_ASSIGNMENT_DEFAULT to "Default",
@@ -56,6 +64,9 @@ class SettingsViewModel : ViewModel() {
             KEY_AI_ASSIGNMENT_OVERLAY to "Overlay Chat"
         )
     }
+
+    private val _logVerbosity = MutableStateFlow(LOG_VERBOSITY_COMBINED)
+    val logVerbosity = _logVerbosity.asStateFlow()
 
     // --- Cancel Warning ---
 
@@ -78,6 +89,19 @@ class SettingsViewModel : ViewModel() {
     fun setDarkMode(context: Context, isDark: Boolean) {
         val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
         sharedPreferences.edit().putBoolean(KEY_DARK_MODE, isDark).apply()
+    }
+
+    // --- Log Verbosity ---
+
+    fun getLogVerbosity(context: Context): String {
+        val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
+        return sharedPreferences.getString(KEY_LOG_VERBOSITY, LOG_VERBOSITY_COMBINED) ?: LOG_VERBOSITY_COMBINED
+    }
+
+    fun setLogVerbosity(context: Context, verbosity: String) {
+        val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
+        sharedPreferences.edit().putString(KEY_LOG_VERBOSITY, verbosity).apply()
+        _logVerbosity.value = verbosity
     }
 
 


### PR DESCRIPTION
## Summary by Sourcery

Introduce a configurable log verbosity feature that lets users select and persist build-only, AI-only, or combined logs, and update the main and bottom sheet views to respect that setting while cleaning up UI components and minor code duplication

New Features:
- Add three-tier log verbosity setting in the Settings screen persisted via SharedPreferences
- Expose log verbosity as a StateFlow in SettingsViewModel
- Filter combined, build-only, or AI-only log output in MainViewModel based on the selected verbosity

Enhancements:
- Switch API key input fields to AzTextBox with inline save actions
- Update IdeBottomSheet to display the filtered log stream
- Standardize AzButton usage with rectangle shape across multiple UI components
- Remove redundant overlay broadcast in MainViewModel