### PR TITLE
Fix(build): Correct aapt2 command flags

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/ideaz/buildlogic/Aapt2Compile.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/buildlogic/Aapt2Compile.kt
@@ -23,10 +23,7 @@ class Aapt2Compile(
             aapt2Path,
             "compile",
             "--dir", resDir,
-            "-o", compiledResDir,
-            // --- ADDED Flags ---
-            "--min-sdk-version", minSdk.toString(),
-            "--target-sdk-version", targetSdk.toString()
+            "-o", compiledResDir
         )
         val processResult = ProcessExecutor.execute(command)
         return BuildResult(processResult.exitCode == 0, processResult.output)

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/buildlogic/Aapt2Link.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/buildlogic/Aapt2Link.kt
@@ -36,9 +36,8 @@ class Aapt2Link(
             "--manifest", manifestPath,
             "--java", outputJavaPath,
             "--auto-add-overlay",
-            // --- FIX: Corrected flag names as you specified ---
-            "--minsdk", minSdk.toString(),
-            "--targetsdk", targetSdk.toString()
+            "--min-sdk-version", minSdk.toString(),
+            "--target-sdk-version", targetSdk.toString()
         )
         command.addAll(compiledFiles)
 


### PR DESCRIPTION
The build was failing at the `Aapt2Compile` step due to an "unknown option '--min-sdk-version'" error. The `--min-sdk-version` and `--target-sdk-version` flags are not valid for the `aapt2 compile` command.

This commit removes these invalid flags from `Aapt2Compile.kt` and moves them to `Aapt2Link.kt`, where they are valid. It also corrects the flag names in `Aapt2Link.kt` from `--minsdk` and `--targetsdk` to the correct `--min-sdk-version` and `--target-sdk-version` syntax.

## Summary by Sourcery

Correct aapt2 command flags to resolve build failures due to unsupported options

Bug Fixes:
- Remove unsupported --min-sdk-version and --target-sdk-version flags from the aapt2 compile command
- Move and correct the min-sdk-version and target-sdk-version flags in the aapt2 link command to use the proper syntax