### PR TITLE
feat(project): Populate Clone tab and address review feedback

This commit populates the "Clone" tab with sources and sessions, and incorporates feedback from the code review to improve code quality and user experience.

- **Populate Clone Tab:** Fetches and displays available sources (repositories) and sessions from the Jules CLI.
- **Refactor Data Fetching:** Abstracts the CLI data fetching logic in `MainViewModel` into a generic, reusable `fetchAndParse` function to reduce code duplication.
- **Improve UI/UX:**
    - Implements parallel fetching for sources and sessions to improve performance.
    - Adds loading and error states to the "Clone" tab to provide better user feedback.
    - Improves the fallback text for session names to include a unique ID, making it easier to distinguish between untitled sessions.
- **Build Fix:** Corrects the flags passed to the `aapt2` command to resolve a build failure.
- **Fixes Compilation Error:** Adds missing coroutine imports to resolve a compilation error.

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/ideaz/api/JulesCliClient.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/api/JulesCliClient.kt
@@ -79,4 +79,11 @@ object JulesCliClient {
         return executeCommand(context, command)
     }
     // --- END NEW ---
+
+    // --- NEW: Function to list available sessions ---
+    fun listSessions(context: Context): String? {
+        val command = "remote list --session --format=json"
+        return executeCommand(context, command)
+    }
+    // --- END NEW ---
 }

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/buildlogic/Aapt2Compile.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/buildlogic/Aapt2Compile.kt
@@ -23,10 +23,7 @@ class Aapt2Compile(
             aapt2Path,
             "compile",
             "--dir", resDir,
-            "-o", compiledResDir,
-            // --- ADDED Flags ---
-            "--min-sdk-version", minSdk.toString(),
-            "--target-sdk-version", targetSdk.toString()
+            "-o", compiledResDir
         )
         val processResult = ProcessExecutor.execute(command)
         return BuildResult(processResult.exitCode == 0, processResult.output)

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/buildlogic/Aapt2Link.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/buildlogic/Aapt2Link.kt
@@ -36,9 +36,8 @@ class Aapt2Link(
             "--manifest", manifestPath,
             "--java", outputJavaPath,
             "--auto-add-overlay",
-            // --- FIX: Corrected flag names as you specified ---
-            "--minsdk", minSdk.toString(),
-            "--targetsdk", targetSdk.toString()
+            "--min-sdk-version", minSdk.toString(),
+            "--target-sdk-version", targetSdk.toString()
         )
         command.addAll(compiledFiles)
 

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/MainViewModel.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/MainViewModel.kt
@@ -32,6 +32,7 @@ import com.hereliesaz.ideaz.api.SourceContext
 import java.io.FileOutputStream
 import java.io.IOException
 import com.hereliesaz.ideaz.utils.ToolManager
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.serialization.json.Json
@@ -64,6 +65,11 @@ class MainViewModel(
     // --- NEW: State for Owned Sources (GitHub Repos) ---
     private val _ownedSources = MutableStateFlow<List<Source>>(emptyList())
     val ownedSources = _ownedSources.asStateFlow()
+    // --- END NEW ---
+
+    // --- NEW: State for Owned Sessions ---
+    private val _ownedSessions = MutableStateFlow<List<com.hereliesaz.ideaz.api.Session>>(emptyList())
+    val ownedSessions = _ownedSessions.asStateFlow()
     // --- END NEW ---
 
     // --- Cancel Dialog State ---
@@ -371,6 +377,17 @@ class MainViewModel(
     }
     // --- END NEW ---
 
+    // --- NEW: Function to fetch sessions ---
+    fun fetchOwnedSessions() {
+        viewModelScope.fetchAndParse(
+            fetcher = JulesCliClient::listSessions,
+            stateFlow = _ownedSessions,
+            dataExtractor = { response: com.hereliesaz.ideaz.api.ListSessionsResponse -> response.sessions },
+            logTag = "fetchOwnedSessions"
+        )
+    }
+    // --- END NEW ---
+
     // --- CONTEXTLESS AI (Global Log) ---
     fun sendPrompt(prompt: String?, isInitialization: Boolean = false) {
         Log.d(TAG, "sendPrompt called with prompt: '$prompt', isInitialization: $isInitialization")
@@ -617,26 +634,40 @@ class MainViewModel(
 
     // --- NEW: Function to fetch GitHub repos ---
     fun fetchOwnedSources() {
-        viewModelScope.launch {
-            Log.d(TAG, "fetchOwnedSources: Fetching sources...")
-            val sourcesJson = JulesCliClient.listSources(getApplication())
-            if (sourcesJson != null) {
-                try {
-                    val response = json.decodeFromString<ListSourcesResponse>(sourcesJson)
-                    _ownedSources.value = response.sources
-                    Log.d(TAG, "fetchOwnedSources: Success. Found ${response.sources.size} sources.")
-                } catch (e: Exception) {
-                    Log.e(TAG, "fetchOwnedSources: Failed to parse JSON", e)
-                    _ownedSources.value = emptyList()
-                }
-            } else {
-                Log.e(TAG, "fetchOwnedSources: CLI command failed or returned null")
-                _ownedSources.value = emptyList()
-            }
-        }
+        viewModelScope.fetchAndParse(
+            fetcher = JulesCliClient::listSources,
+            stateFlow = _ownedSources,
+            dataExtractor = { response: ListSourcesResponse -> response.sources },
+            logTag = "fetchOwnedSources"
+        )
     }
     // --- END NEW ---
 
+    private inline fun <reified T, R> CoroutineScope.fetchAndParse(
+        crossinline fetcher: (Context) -> String?,
+        stateFlow: MutableStateFlow<List<R>>,
+        crossinline dataExtractor: (T) -> List<R>,
+        logTag: String
+    ): Job {
+        return launch {
+            Log.d(TAG, "$logTag: Fetching data...")
+            val jsonString = fetcher(getApplication())
+            if (jsonString != null) {
+                try {
+                    val response = json.decodeFromString<T>(jsonString)
+                    val data = dataExtractor(response)
+                    stateFlow.value = data
+                    Log.d(TAG, "$logTag: Success. Found ${data.size} items.")
+                } catch (e: Exception) {
+                    Log.e(TAG, "$logTag: Failed to parse JSON", e)
+                    stateFlow.value = emptyList()
+                }
+            } else {
+                Log.e(TAG, "$logTag: CLI command failed or returned null")
+                stateFlow.value = emptyList()
+            }
+        }
+    }
 
     fun debugBuild() {
         Log.d(TAG, "debugBuild called")

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/ProjectSettingsScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/ProjectSettingsScreen.kt
@@ -32,6 +32,8 @@ import com.hereliesaz.aznavrail.AzForm
 import com.hereliesaz.aznavrail.AzTextBox
 import com.hereliesaz.aznavrail.model.AzButtonShape
 import com.hereliesaz.ideaz.utils.mapSaver
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.async
 
 private const val TAG = "ProjectSettingsScreen"
 
@@ -59,11 +61,27 @@ fun ProjectSettingsScreen(
     // State for "Clone" tab
     var cloneUrl by remember { mutableStateOf("") }
     val projectList = settingsViewModel.getProjectList()
+    var isLoading by remember { mutableStateOf(true) }
+    var errorMessage by remember { mutableStateOf<String?>(null) }
 
     // --- FIX: Observe sources from ViewModel ---
     val ownedSources by viewModel.ownedSources.collectAsState()
+    val ownedSessions by viewModel.ownedSessions.collectAsState()
     LaunchedEffect(Unit) {
-        viewModel.fetchOwnedSources()
+        isLoading = true
+        errorMessage = null
+        try {
+            coroutineScope {
+                val sourcesJob = async { viewModel.fetchOwnedSources() }
+                val sessionsJob = async { viewModel.fetchOwnedSessions() }
+                sourcesJob.await()
+                sessionsJob.await()
+            }
+        } catch (e: Exception) {
+            errorMessage = "Failed to load data: ${e.message}"
+        } finally {
+            isLoading = false
+        }
     }
     // --- END FIX ---
 
@@ -164,23 +182,50 @@ fun ProjectSettingsScreen(
                         }
 
                         Spacer(modifier = Modifier.height(24.dp))
-                        Text("Your Available Repositories", color = MaterialTheme.colorScheme.onBackground)
-                        if (ownedSources.isEmpty()) {
-                            Text("No other repositories found on your Jules account.", color = MaterialTheme.colorScheme.onBackground)
+
+                        if (isLoading) {
+                            Text("Loading...", color = MaterialTheme.colorScheme.onBackground)
+                        } else if (errorMessage != null) {
+                            Text("Error: $errorMessage", color = MaterialTheme.colorScheme.error)
                         } else {
-                            ownedSources.forEach { source ->
-                                val repo = source.githubRepo!!
-                                AzButton(
-                                    onClick = {
-                                        appName = repo.repo
-                                        githubUser = repo.owner
-                                        branchName = repo.defaultBranch.displayName
-                                        Toast.makeText(context, "Config loaded. Go to 'Create' tab to save.", Toast.LENGTH_LONG).show()
-                                        tabIndex = 0 // Switch to Create tab
-                                    },
-                                    text = "${repo.owner}/${repo.repo} (Branch: ${repo.defaultBranch.displayName})",
-                                    modifier = Modifier.padding(bottom = 8.dp).fillMaxWidth()
-                                )
+                            Text("Your Available Repositories", color = MaterialTheme.colorScheme.onBackground)
+                            if (ownedSources.isEmpty()) {
+                                Text("No other repositories found on your Jules account.", color = MaterialTheme.colorScheme.onBackground)
+                            } else {
+                                ownedSources.forEach { source ->
+                                    val repo = source.githubRepo!!
+                                    AzButton(
+                                        onClick = {
+                                            appName = repo.repo
+                                            githubUser = repo.owner
+                                            branchName = repo.defaultBranch.displayName
+                                            Toast.makeText(context, "Config loaded. Go to 'Create' tab to save.", Toast.LENGTH_LONG).show()
+                                            tabIndex = 0 // Switch to Create tab
+                                        },
+                                        text = "${repo.owner}/${repo.repo} (Branch: ${repo.defaultBranch.displayName})",
+                                        modifier = Modifier.padding(bottom = 8.dp).fillMaxWidth()
+                                    )
+                                }
+                            }
+
+                            Spacer(modifier = Modifier.height(24.dp))
+                            Text("Your Available Sessions", color = MaterialTheme.colorScheme.onBackground)
+                            if (ownedSessions.isEmpty()) {
+                                Text("No other sessions found on your Jules account.", color = MaterialTheme.colorScheme.onBackground)
+                            } else {
+                                ownedSessions.forEach { session ->
+                                    AzButton(
+                                        onClick = {
+                                            // TODO: Implement session loading
+                                            Toast.makeText(context, "Loading sessions is not yet implemented.", Toast.LENGTH_SHORT).show()
+                                        },
+                                    text = session.title
+                                        ?: session.name
+                                        ?: "Untitled Session" +
+                                            (session.id?.let { " (ID: $it)" } ?: ""),
+                                        modifier = Modifier.padding(bottom = 8.dp).fillMaxWidth()
+                                    )
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
## Summary by Sourcery

Populate the Clone tab with repository and session listings, refactor data fetching, enhance loading/error handling, and fix build and compilation issues.

New Features:
- Display available repositories and sessions in the Clone tab
- Add fetchOwnedSessions function and listSessions CLI command for session retrieval

Bug Fixes:
- Correct aapt2 compile and link flags to resolve the build failure
- Add missing coroutine imports to fix compilation errors

Enhancements:
- Introduce generic fetchAndParse method in MainViewModel to consolidate CLI data fetching
- Perform sources and sessions fetching in parallel with loading and error states in the UI
- Improve fallback text for untitled sessions to include unique IDs