### PR TITLE
Fix dependency resolution and enhance BuildService notifications

- Resolved `Could not initialize RepositorySystem` error in `DependencyResolver.kt` by manually registering `BasicRepositoryConnectorFactory` and `HttpTransporterFactory` to the `DefaultServiceLocator`.
- Enhanced `BuildService` notifications:
    - Made the main notification content intent clickable (opens `MainActivity`).
    - Added a "Sync & Exit" action button that triggers a background Git sync (commit & push) and stops the service.
- Verified changes with successful `./gradlew assembleDebug` and `./gradlew testDebugUnitTest`.

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/ideaz/buildlogic/DependencyResolver.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/buildlogic/DependencyResolver.kt
@@ -5,10 +5,15 @@ import org.apache.maven.repository.internal.MavenRepositorySystemUtils
 import org.eclipse.aether.RepositorySystem
 import org.eclipse.aether.artifact.DefaultArtifact
 import org.eclipse.aether.collection.CollectRequest
+import org.eclipse.aether.connector.basic.BasicRepositoryConnectorFactory
 import org.eclipse.aether.graph.Dependency
+import org.eclipse.aether.impl.DefaultServiceLocator
 import org.eclipse.aether.repository.LocalRepository
 import org.eclipse.aether.repository.RemoteRepository
 import org.eclipse.aether.resolution.DependencyRequest
+import org.eclipse.aether.spi.connector.RepositoryConnectorFactory
+import org.eclipse.aether.spi.connector.transport.TransporterFactory
+import org.eclipse.aether.transport.http.HttpTransporterFactory
 import org.eclipse.aether.util.filter.DependencyFilterUtils
 import java.io.File
 
@@ -43,6 +48,13 @@ class DependencyResolver(
 
     private fun newRepositorySystem(): RepositorySystem {
         val locator = MavenRepositorySystemUtils.newServiceLocator()
+        locator.addService(RepositoryConnectorFactory::class.java, BasicRepositoryConnectorFactory::class.java)
+        locator.addService(TransporterFactory::class.java, HttpTransporterFactory::class.java)
+        locator.setErrorHandler(object : DefaultServiceLocator.ErrorHandler() {
+            override fun serviceCreationFailed(type: Class<*>, impl: Class<*>, exception: Throwable) {
+                exception.printStackTrace()
+            }
+        })
         return locator.getService(RepositorySystem::class.java)
     }
 

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/services/BuildService.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/services/BuildService.kt
@@ -2,6 +2,7 @@ package com.hereliesaz.ideaz.services
 
 import android.app.NotificationChannel
 import android.app.NotificationManager
+import android.app.PendingIntent
 import android.app.Service
 import android.content.Intent
 import android.os.Build
@@ -11,13 +12,20 @@ import androidx.core.app.NotificationCompat
 import androidx.preference.PreferenceManager
 import com.hereliesaz.ideaz.IBuildCallback
 import com.hereliesaz.ideaz.IBuildService
+import com.hereliesaz.ideaz.MainActivity
 import com.hereliesaz.ideaz.buildlogic.*
+import com.hereliesaz.ideaz.git.GitManager
 import com.hereliesaz.ideaz.utils.ApkInstaller
 import com.hereliesaz.ideaz.utils.ToolManager
 import com.hereliesaz.ideaz.utils.ProjectAnalyzer
 import com.hereliesaz.ideaz.models.ProjectType
 import com.hereliesaz.ideaz.ui.SettingsViewModel
 import com.hereliesaz.ideaz.ui.web.WebRuntimeActivity
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
 import java.io.File
 import java.util.ArrayDeque
 
@@ -29,9 +37,12 @@ class BuildService : Service() {
         private const val MIN_SDK = 26
         private const val TARGET_SDK = 36
         private const val MAX_LOG_LINES = 5
+        private const val ACTION_SYNC_AND_EXIT = "SYNC_AND_EXIT"
     }
 
     private val logBuffer = ArrayDeque<String>(MAX_LOG_LINES)
+    private val serviceScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private var currentProjectPath: String? = null
 
     private val binder = object : IBuildService.Stub() {
         override fun startBuild(projectPath: String, callback: IBuildCallback) = this@BuildService.startBuild(projectPath, callback)
@@ -45,11 +56,19 @@ class BuildService : Service() {
         createNotificationChannel()
     }
 
+    override fun onDestroy() {
+        super.onDestroy()
+        serviceScope.cancel()
+    }
+
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        val notification = NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID)
-            .setContentTitle("IDEaz IDE")
+        if (intent?.action == ACTION_SYNC_AND_EXIT) {
+            handleSyncAndExit()
+            return START_NOT_STICKY
+        }
+
+        val notification = createNotificationBuilder()
             .setContentText("Build Service is running.")
-            .setSmallIcon(android.R.drawable.ic_dialog_info)
             .build()
         startForeground(NOTIFICATION_ID, notification)
         return START_STICKY
@@ -79,15 +98,66 @@ class BuildService : Service() {
         val latestLog = synchronized(logBuffer) { logBuffer.lastOrNull() } ?: "Processing..."
         val bigText = synchronized(logBuffer) { logBuffer.joinToString("\n") }
 
-        val notification = NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID)
-            .setContentTitle("IDEaz IDE")
+        val notification = createNotificationBuilder()
             .setContentText(latestLog)
             .setStyle(NotificationCompat.BigTextStyle().bigText(bigText))
-            .setSmallIcon(android.R.drawable.ic_dialog_info)
             .setOnlyAlertOnce(true)
             .build()
 
         getSystemService(NotificationManager::class.java).notify(NOTIFICATION_ID, notification)
+    }
+
+    private fun createNotificationBuilder(): NotificationCompat.Builder {
+        val contentIntent = PendingIntent.getActivity(
+            this, 0,
+            Intent(this, MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            },
+            PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val syncIntent = Intent(this, BuildService::class.java).apply {
+            action = ACTION_SYNC_AND_EXIT
+        }
+        val syncPendingIntent = PendingIntent.getService(
+            this, 1, syncIntent, PendingIntent.FLAG_IMMUTABLE
+        )
+
+        return NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID)
+            .setContentTitle("IDEaz IDE")
+            .setSmallIcon(android.R.drawable.ic_dialog_info)
+            .setContentIntent(contentIntent)
+            .addAction(android.R.drawable.ic_menu_save, "Sync & Exit", syncPendingIntent)
+    }
+
+    private fun handleSyncAndExit() {
+        val path = currentProjectPath
+        if (path == null) {
+            Log.w(TAG, "Cannot sync: Project path is null")
+            stopSelf()
+            return
+        }
+
+        updateNotification("Syncing and exiting...")
+
+        serviceScope.launch {
+            try {
+                val prefs = PreferenceManager.getDefaultSharedPreferences(this@BuildService)
+                val token = prefs.getString(SettingsViewModel.KEY_GITHUB_TOKEN, null)
+                val user = prefs.getString(SettingsViewModel.KEY_GITHUB_USER, null)
+
+                val git = GitManager(File(path))
+                git.addAll()
+                git.commit("Sync and Exit")
+                if (token != null) {
+                    git.push(user, token)
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Sync failed", e)
+            } finally {
+                stopSelf()
+            }
+        }
     }
 
     // Helper to check tool and log specifically to the user console
@@ -111,6 +181,7 @@ class BuildService : Service() {
     }
 
     private fun startBuild(projectPath: String, callback: IBuildCallback) {
+        currentProjectPath = projectPath
         synchronized(logBuffer) {
             logBuffer.clear()
         }


### PR DESCRIPTION
## Summary by Sourcery

Fix dependency resolution initialization and improve BuildService foreground notification behavior.

Bug Fixes:
- Resolve dependency resolver initialization failures by explicitly registering required Aether connector and transporter services.

Enhancements:
- Make the BuildService foreground notification open the main app when tapped and add a Sync & Exit action that syncs the current project via Git in the background before stopping the service.