### PR TITLE
Add Android CI with Jules debugging workflow to IDEaz repo

- Added `.github/workflows/android_ci_jules.yml` to the repository to verify the workflow's functionality.
- This workflow compiles the app on push/PR and invokes Jules via GitHub Issue/Comment on failure, using the "Jules, @google-labs-jules" trigger.

### DIFF
--- a/.github/workflows/android_ci_jules.yml
+++ b/.github/workflows/android_ci_jules.yml
@@ -1,0 +1,84 @@
+name: Android CI with Jules AI Debugging
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: gradle
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+
+    - name: Build with Gradle
+      id: gradle-build
+      # capture output while still failing if build fails (but continue-on-error handles the workflow flow)
+      run: |
+        set +e
+        ./gradlew assembleDebug > build.log 2>&1
+        EXIT_CODE=$?
+        echo "exit_code=$EXIT_CODE" >> $GITHUB_OUTPUT
+        cat build.log
+        exit $EXIT_CODE
+      continue-on-error: true
+
+    - name: Upload APK
+      if: steps.gradle-build.outcome == 'success'
+      uses: actions/upload-artifact@v4
+      with:
+        name: app-debug
+        path: app/build/outputs/apk/debug/app-debug.apk
+
+    - name: Report Failure to Jules
+      if: steps.gradle-build.outcome == 'failure'
+      uses: actions/github-script@v7
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const fs = require('fs');
+          let logTail = 'Log file not found.';
+          try {
+            const log = fs.readFileSync('build.log', 'utf8');
+            logTail = log.slice(-4000); // Capture last 4000 chars
+          } catch (e) {
+            console.log('Error reading build.log', e);
+          }
+
+          const body = `Build failed on ${context.eventName === 'pull_request' ? 'PR #' + context.issue.number : context.ref}.\n\n**Log Output:**\n\`\`\`\n${logTail}\n\`\`\`\n\nJules, @google-labs-jules, please debug and fix this build failure.`;
+
+          if (context.eventName === 'pull_request') {
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: body
+            });
+          } else {
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Build Failure on ${context.ref}`,
+              body: body
+            });
+          }
+
+    - name: Fail Job if Build Failed
+      if: steps.gradle-build.outcome == 'failure'
+      run: exit 1

--- a/app/src/main/assets/project/.github/workflows/android_ci_jules.yml
+++ b/app/src/main/assets/project/.github/workflows/android_ci_jules.yml
@@ -1,0 +1,84 @@
+name: Android CI with Jules AI Debugging
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: gradle
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+
+    - name: Build with Gradle
+      id: gradle-build
+      # capture output while still failing if build fails (but continue-on-error handles the workflow flow)
+      run: |
+        set +e
+        ./gradlew assembleDebug > build.log 2>&1
+        EXIT_CODE=$?
+        echo "exit_code=$EXIT_CODE" >> $GITHUB_OUTPUT
+        cat build.log
+        exit $EXIT_CODE
+      continue-on-error: true
+
+    - name: Upload APK
+      if: steps.gradle-build.outcome == 'success'
+      uses: actions/upload-artifact@v4
+      with:
+        name: app-debug
+        path: app/build/outputs/apk/debug/app-debug.apk
+
+    - name: Report Failure to Jules
+      if: steps.gradle-build.outcome == 'failure'
+      uses: actions/github-script@v7
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const fs = require('fs');
+          let logTail = 'Log file not found.';
+          try {
+            const log = fs.readFileSync('build.log', 'utf8');
+            logTail = log.slice(-4000); // Capture last 4000 chars
+          } catch (e) {
+            console.log('Error reading build.log', e);
+          }
+
+          const body = `Build failed on ${context.eventName === 'pull_request' ? 'PR #' + context.issue.number : context.ref}.\n\n**Log Output:**\n\`\`\`\n${logTail}\n\`\`\`\n\nJules, @google-labs-jules, please debug and fix this build failure.`;
+
+          if (context.eventName === 'pull_request') {
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: body
+            });
+          } else {
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Build Failure on ${context.ref}`,
+              body: body
+            });
+          }
+
+    - name: Fail Job if Build Failed
+      if: steps.gradle-build.outcome == 'failure'
+      run: exit 1

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/git/GitManager.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/git/GitManager.kt
@@ -43,6 +43,12 @@ class GitManager(private val projectDir: File) {
         }
     }
 
+    fun hasChanges(): Boolean {
+        Git.open(projectDir).use { git ->
+            return !git.status().call().isClean
+        }
+    }
+
     fun addAll() {
         Git.open(projectDir).use { git ->
             git.add().addFilepattern(".").call()

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/services/BuildService.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/services/BuildService.kt
@@ -2,6 +2,7 @@ package com.hereliesaz.ideaz.services
 
 import android.app.NotificationChannel
 import android.app.NotificationManager
+import android.app.PendingIntent
 import android.app.Service
 import android.content.Intent
 import android.os.Build
@@ -11,13 +12,20 @@ import androidx.core.app.NotificationCompat
 import androidx.preference.PreferenceManager
 import com.hereliesaz.ideaz.IBuildCallback
 import com.hereliesaz.ideaz.IBuildService
+import com.hereliesaz.ideaz.MainActivity
 import com.hereliesaz.ideaz.buildlogic.*
+import com.hereliesaz.ideaz.git.GitManager
 import com.hereliesaz.ideaz.utils.ApkInstaller
 import com.hereliesaz.ideaz.utils.ToolManager
 import com.hereliesaz.ideaz.utils.ProjectAnalyzer
 import com.hereliesaz.ideaz.models.ProjectType
 import com.hereliesaz.ideaz.ui.SettingsViewModel
 import com.hereliesaz.ideaz.ui.web.WebRuntimeActivity
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
 import java.io.File
 import java.util.ArrayDeque
 
@@ -29,9 +37,12 @@ class BuildService : Service() {
         private const val MIN_SDK = 26
         private const val TARGET_SDK = 36
         private const val MAX_LOG_LINES = 5
+        private const val ACTION_SYNC_AND_EXIT = "SYNC_AND_EXIT"
     }
 
     private val logBuffer = ArrayDeque<String>(MAX_LOG_LINES)
+    private val serviceScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private var currentProjectPath: String? = null
 
     private val binder = object : IBuildService.Stub() {
         override fun startBuild(projectPath: String, callback: IBuildCallback) = this@BuildService.startBuild(projectPath, callback)
@@ -45,11 +56,19 @@ class BuildService : Service() {
         createNotificationChannel()
     }
 
+    override fun onDestroy() {
+        super.onDestroy()
+        serviceScope.cancel()
+    }
+
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        val notification = NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID)
-            .setContentTitle("IDEaz IDE")
+        if (intent?.action == ACTION_SYNC_AND_EXIT) {
+            handleSyncAndExit()
+            return START_NOT_STICKY
+        }
+
+        val notification = createNotificationBuilder()
             .setContentText("Build Service is running.")
-            .setSmallIcon(android.R.drawable.ic_dialog_info)
             .build()
         startForeground(NOTIFICATION_ID, notification)
         return START_STICKY
@@ -79,15 +98,68 @@ class BuildService : Service() {
         val latestLog = synchronized(logBuffer) { logBuffer.lastOrNull() } ?: "Processing..."
         val bigText = synchronized(logBuffer) { logBuffer.joinToString("\n") }
 
-        val notification = NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID)
-            .setContentTitle("IDEaz IDE")
+        val notification = createNotificationBuilder()
             .setContentText(latestLog)
             .setStyle(NotificationCompat.BigTextStyle().bigText(bigText))
-            .setSmallIcon(android.R.drawable.ic_dialog_info)
             .setOnlyAlertOnce(true)
             .build()
 
         getSystemService(NotificationManager::class.java).notify(NOTIFICATION_ID, notification)
+    }
+
+    private fun createNotificationBuilder(): NotificationCompat.Builder {
+        val contentIntent = PendingIntent.getActivity(
+            this, 0,
+            Intent(this, MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            },
+            PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val syncIntent = Intent(this, BuildService::class.java).apply {
+            action = ACTION_SYNC_AND_EXIT
+        }
+        val syncPendingIntent = PendingIntent.getService(
+            this, 1, syncIntent, PendingIntent.FLAG_IMMUTABLE
+        )
+
+        return NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID)
+            .setContentTitle("IDEaz IDE")
+            .setSmallIcon(android.R.drawable.ic_dialog_info)
+            .setContentIntent(contentIntent)
+            .addAction(android.R.drawable.ic_menu_save, "Sync & Exit", syncPendingIntent)
+    }
+
+    private fun handleSyncAndExit() {
+        val path = currentProjectPath
+        if (path == null) {
+            Log.w(TAG, "Cannot sync: Project path is null")
+            stopSelf()
+            return
+        }
+
+        updateNotification("Syncing and exiting...")
+
+        serviceScope.launch {
+            try {
+                val prefs = PreferenceManager.getDefaultSharedPreferences(this@BuildService)
+                val token = prefs.getString(SettingsViewModel.KEY_GITHUB_TOKEN, null)
+                val user = prefs.getString(SettingsViewModel.KEY_GITHUB_USER, null)
+
+                val git = GitManager(File(path))
+                if (git.hasChanges()) {
+                    git.addAll()
+                    git.commit("Sync and Exit")
+                }
+                if (token != null) {
+                    git.push(user, token)
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Sync failed", e)
+            } finally {
+                stopSelf()
+            }
+        }
     }
 
     // Helper to check tool and log specifically to the user console
@@ -111,6 +183,7 @@ class BuildService : Service() {
     }
 
     private fun startBuild(projectPath: String, callback: IBuildCallback) {
+        currentProjectPath = projectPath
         synchronized(logBuffer) {
             logBuffer.clear()
         }

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/utils/GithubIssueReporter.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/utils/GithubIssueReporter.kt
@@ -24,8 +24,18 @@ object GithubIssueReporter {
      * 1. Tries to use the GitHub API to auto-post the issue (if token provided).
      * 2. Falls back to opening a browser with pre-filled data.
      */
-    suspend fun reportError(context: Context, token: String?, error: Throwable, contextMessage: String): String {
+    suspend fun reportError(context: Context, token: String?, error: Throwable, contextMessage: String, logContent: String? = null): String {
         val stackTrace = error.stackTraceToString()
+
+        val logSection = if (logContent != null) {
+            """
+
+            **Log Output:**
+            ```
+            ${logContent.takeLast(2000)}
+            ```
+            """.trimIndent()
+        } else ""
 
         // Truncate for safety (API limit is roughly 65k chars, URL limit 2k-8k)
         val bodyContent = """
@@ -37,6 +47,9 @@ object GithubIssueReporter {
             ```
             ${stackTrace.take(3000)}
             ```
+            $logSection
+
+            @google-labs-jules please look into this.
         """.trimIndent()
 
         val titleContent = "IDE Error: ${error::class.simpleName} - ${error.message?.take(50) ?: "Unknown"}"


### PR DESCRIPTION
## Summary by Sourcery

Introduce automated Android CI with AI-assisted failure debugging and enhance in-app build diagnostics and sync workflows.

New Features:
- Add an Android GitHub Actions workflow that builds the app on push/PR, uploads debug APKs, and reports failures to an AI assistant via issues or PR comments.
- Provide a foreground build service notification action that syncs the current project to GitHub and exits the service.
- Automatically capture recent logcat output when reporting internal IDE errors to GitHub for richer diagnostics.

Bug Fixes:
- Ensure Maven dependency resolution configures the required connector and transporter services to prevent repository initialization failures.
- Improve build failure classification to correctly treat infrastructure/tooling errors as IDE issues rather than user code problems.

Enhancements:
- Refine build service notifications with a shared builder, main-activity deep link, and an explicit Sync & Exit action.
- Extend GitHub error reports with truncated log output and an explicit AI-assistance mention to aid automated debugging.
- Add a Git manager helper to detect working tree changes before committing and pushing.

CI:
- Add reusable Android CI workflow files at the repo root and in the project template that run Gradle builds and, on failure, invoke an AI assistant via GitHub issues or PR comments.