### PR TITLE
Fix build failure by processing AAR dependencies

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/ideaz/buildlogic/Aapt2Link.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/buildlogic/Aapt2Link.kt
@@ -12,7 +12,8 @@ class Aapt2Link(
     private val outputApkPath: String,
     private val outputJavaPath: String,
     private val minSdk: Int,
-    private val targetSdk: Int
+    private val targetSdk: Int,
+    private val dependencyResources: List<String> = emptyList()
 ) : BuildStep {
 
     override fun execute(callback: IBuildCallback?): BuildResult {
@@ -49,6 +50,7 @@ class Aapt2Link(
             "--target-sdk-version", targetSdk.toString()
         )
         command.addAll(compiledFiles)
+        command.addAll(dependencyResources)
 
         val processResult = ProcessExecutor.execute(command)
         return BuildResult(processResult.exitCode == 0, processResult.output)

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/buildlogic/ProcessAars.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/buildlogic/ProcessAars.kt
@@ -1,0 +1,103 @@
+package com.hereliesaz.ideaz.buildlogic
+
+import com.hereliesaz.ideaz.IBuildCallback
+import com.hereliesaz.ideaz.utils.ProcessExecutor
+import java.io.File
+import java.util.zip.ZipFile
+
+class ProcessAars(
+    private val artifacts: List<File>,
+    private val buildDir: File,
+    private val aapt2Path: String
+) : BuildStep {
+
+    val compiledAars = mutableListOf<String>()
+    val jars = mutableListOf<String>()
+
+    override fun execute(callback: IBuildCallback?): BuildResult {
+        val explodedDir = File(buildDir, "exploded_aars")
+        explodedDir.mkdirs()
+        val compiledDir = File(buildDir, "compiled_aars")
+        compiledDir.mkdirs()
+
+        val aarFiles = artifacts.filter { it.isFile && it.extension == "aar" }
+
+        if (aarFiles.isEmpty()) {
+            return BuildResult(true, "No AARs found to process.")
+        }
+
+        callback?.onLog("Processing ${aarFiles.size} AARs...")
+
+        for (aar in aarFiles) {
+            val aarName = aar.nameWithoutExtension
+            // Using a hash of the path to ensure uniqueness
+            val uniqueName = "${aarName}_${aar.absolutePath.hashCode()}"
+            val uniqueDestDir = File(explodedDir, uniqueName)
+
+            if (!uniqueDestDir.exists()) {
+                try {
+                    unzip(aar, uniqueDestDir)
+                } catch (e: Exception) {
+                     return BuildResult(false, "Failed to extract ${aar.name}: ${e.message}")
+                }
+            }
+
+            // Check for classes.jar
+            val classesJar = File(uniqueDestDir, "classes.jar")
+            if (classesJar.exists()) {
+                jars.add(classesJar.absolutePath)
+            }
+
+            // Check for libs/*.jar (transitive/internal libs in AAR)
+            val libsDir = File(uniqueDestDir, "libs")
+            if (libsDir.exists() && libsDir.isDirectory) {
+                libsDir.walkTopDown()
+                    .filter { it.isFile && it.extension == "jar" }
+                    .forEach { jars.add(it.absolutePath) }
+            }
+
+            // Check for resources
+            val resDir = File(uniqueDestDir, "res")
+            if (resDir.exists() && resDir.isDirectory && resDir.list()?.isNotEmpty() == true) {
+                val outputFlata = File(compiledDir, "$uniqueName.flata")
+                // Compile resources
+                val command = listOf(
+                    aapt2Path,
+                    "compile",
+                    "--dir", resDir.absolutePath,
+                    "-o", outputFlata.absolutePath
+                )
+
+                val result = ProcessExecutor.execute(command)
+                if (result.exitCode != 0) {
+                     return BuildResult(false, "Failed to compile resources for ${aar.name}: ${result.output}")
+                }
+                compiledAars.add(outputFlata.absolutePath)
+            }
+        }
+
+        return BuildResult(true, "Processed ${aarFiles.size} AARs. Compiled ${compiledAars.size} resource packages.")
+    }
+
+    private fun unzip(zipFile: File, targetDir: File) {
+        ZipFile(zipFile).use { zip ->
+            zip.entries().asSequence().forEach { entry ->
+                val file = File(targetDir, entry.name)
+                val canonicalPath = file.canonicalPath
+                if (!canonicalPath.startsWith(targetDir.canonicalPath + File.separator)) {
+                    throw SecurityException("Zip Slip vulnerability detected: ${entry.name}")
+                }
+                if (entry.isDirectory) {
+                    file.mkdirs()
+                } else {
+                    file.parentFile.mkdirs()
+                    zip.getInputStream(entry).use { input ->
+                        file.outputStream().use { output ->
+                            input.copyTo(output)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/utils/ProcessExecutor.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/utils/ProcessExecutor.kt
@@ -11,7 +11,8 @@ object ProcessExecutor {
             val finalCommand: List<String>
 
             if (command.firstOrNull() != "java") {
-                finalCommand = listOf("/system/bin/sh", "-c", command.joinToString(" "))
+                // Use "sh" directly which is available in PATH on Android and Linux
+                finalCommand = listOf("sh", "-c", command.joinToString(" "))
             } else {
                 finalCommand = command
             }
@@ -44,7 +45,7 @@ object ProcessExecutor {
         try {
             val finalCommand: List<String>
             if (command.firstOrNull() != "java") {
-                finalCommand = listOf("/system/bin/sh", "-c", command.joinToString(" "))
+                finalCommand = listOf("sh", "-c", command.joinToString(" "))
             } else {
                 finalCommand = command
             }

--- a/app/src/test/java/com/hereliesaz/ideaz/buildlogic/ProcessAarsTest.kt
+++ b/app/src/test/java/com/hereliesaz/ideaz/buildlogic/ProcessAarsTest.kt
@@ -1,0 +1,76 @@
+package com.hereliesaz.ideaz.buildlogic
+
+import com.hereliesaz.ideaz.IBuildCallback
+import com.hereliesaz.ideaz.utils.ProcessExecutor
+import org.junit.Assert.*
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.io.FileOutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+class ProcessAarsTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    @Test
+    fun testProcessAars_extractsAndCompiles() {
+        // Setup
+        val localRepoDir = tempFolder.newFolder("local-repo")
+        val buildDir = tempFolder.newFolder("build")
+        val aapt2Path = "echo" // Mock aapt2
+
+        // Create a dummy AAR
+        val aarFile = File(localRepoDir, "test-lib.aar")
+        createDummyAar(aarFile)
+
+        val processAars = ProcessAars(listOf(aarFile), buildDir, aapt2Path)
+
+        // Implement Interface directly to avoid Stub/Binder issues in unit test
+        val callback = object : IBuildCallback {
+            override fun onLog(message: String) {
+                println(message)
+            }
+            override fun onSuccess(apkPath: String) {}
+            override fun onFailure(error: String) {}
+            override fun asBinder(): android.os.IBinder? = null
+        }
+
+        // Execute
+        val result = processAars.execute(callback)
+
+        // Verify
+        assertTrue("Build step should succeed", result.success)
+        assertTrue("Should find jars", processAars.jars.isNotEmpty())
+        assertTrue("Should find compiled resources", processAars.compiledAars.isNotEmpty())
+
+        // Verify extraction
+        val explodedDir = File(buildDir, "exploded_aars")
+        assertTrue(explodedDir.exists())
+        val children = explodedDir.listFiles()
+        assertNotNull(children)
+        assertTrue(children!!.any { it.name.startsWith("test-lib") })
+    }
+
+    private fun createDummyAar(file: File) {
+        ZipOutputStream(FileOutputStream(file)).use { zip ->
+            // classes.jar
+            zip.putNextEntry(ZipEntry("classes.jar"))
+            zip.write("dummy content".toByteArray())
+            zip.closeEntry()
+
+            // res/values/strings.xml
+            zip.putNextEntry(ZipEntry("res/values/strings.xml"))
+            zip.write("<resources></resources>".toByteArray())
+            zip.closeEntry()
+
+            // libs/internal.jar
+            zip.putNextEntry(ZipEntry("libs/internal.jar"))
+            zip.write("dummy internal lib".toByteArray())
+            zip.closeEntry()
+        }
+    }
+}


### PR DESCRIPTION
- Created `ProcessAars` build step to extract AARs, compile their resources using aapt2, and extract classes.jar.
- Updated `DependencyResolver` to expose a list of resolved artifacts.
- Updated `BuildService` to orchestrate the new AAR processing step and construct a complete classpath (JARs + AAR classes).
- Updated `Aapt2Link` to accept and link against compiled AAR resources.
- Improved `ProcessExecutor` to use `sh` for better portability.
- Fixed potential Zip Slip vulnerability in AAR extraction logic.
- Added `ProcessAarsTest` to verify extraction and resource compilation logic.

## Summary by Sourcery

Process Android AAR dependencies during the build to fix missing classes and resources from library artifacts.

New Features:
- Introduce a ProcessAars build step to extract AARs, collect embedded JARs, and compile their resources for inclusion in the build.

Bug Fixes:
- Ensure the build includes classes and resources from AAR dependencies by wiring their compiled outputs and classpath into the existing compilation and packaging steps.
- Prevent potential Zip Slip directory traversal when extracting AAR contents.

Enhancements:
- Expose resolved artifact files from DependencyResolver for downstream build steps and de-duplicate them.
- Extend Aapt2Link to accept compiled dependency resource packages for linking.
- Improve ProcessExecutor portability by invoking commands via sh instead of a hardcoded Android shell path.

Tests:
- Add ProcessAarsTest to verify AAR extraction, resource compilation, and output collection behavior.