### PR TITLE
Fix React Native build classpath and verify MVP implementation

- Corrected `ReactNativeBuildStep.kt` to use `resolver.resolvedClasspath` instead of the resolver's output message string, fixing a critical compilation error.
- Verified `SimpleJsBundler` implementation against the MVP requirements (single file, regex-based source mapping).
- Confirmed that the recently added `BuildCacheManager` automatically enables incremental builds for React Native projects via `KotlincCompile` and `D8Compile`.

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/ideaz/buildlogic/ReactNativeBuildStep.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/buildlogic/ReactNativeBuildStep.kt
@@ -77,8 +77,8 @@ class ReactNativeBuildStep(
         val steps = listOf(
             Aapt2Compile(aapt2Path, shellResDir.absolutePath, compiledResDir.absolutePath, MIN_SDK, TARGET_SDK),
             Aapt2Link(aapt2Path, compiledResDir.absolutePath, androidJarPath, shellManifest.absolutePath, File(buildDir, "app.apk").absolutePath, shellGenDir.absolutePath, MIN_SDK, TARGET_SDK),
-            KotlincCompile(kotlincJarPath, androidJarPath, shellJavaDir.absolutePath, shellClassesDir, resolverResult.output, javaBinaryPath),
-            D8Compile(d8Path, javaBinaryPath, androidJarPath, shellClassesDir.absolutePath, shellClassesDir.absolutePath, resolverResult.output),
+            KotlincCompile(kotlincJarPath, androidJarPath, shellJavaDir.absolutePath, shellClassesDir, resolver.resolvedClasspath, javaBinaryPath),
+            D8Compile(d8Path, javaBinaryPath, androidJarPath, shellClassesDir.absolutePath, shellClassesDir.absolutePath, resolver.resolvedClasspath),
             ApkBuild(File(buildDir, "app-signed.apk").absolutePath, File(buildDir, "app.apk").absolutePath, shellClassesDir.absolutePath),
             ApkSign(apkSignerPath, javaBinaryPath, keystorePath, "android", "androiddebugkey", File(buildDir, "app-signed.apk").absolutePath)
         )


### PR DESCRIPTION
## Summary by Sourcery

Fix React Native build classpath usage and validate related build behavior against MVP expectations.

Bug Fixes:
- Correct the React Native build step to pass the resolver's resolved classpath into Kotlin and D8 compilation to fix a compilation failure.

Enhancements:
- Verify the SimpleJsBundler implementation against the MVP requirements for single-file bundling and regex-based source mapping.
- Confirm that BuildCacheManager enables incremental builds for React Native projects via KotlincCompile and D8Compile.