### PR TITLE
Fix release URL construction and refactor project loading

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/ProjectScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/ProjectScreen.kt
@@ -698,9 +698,12 @@ fun ProjectScreen(
                                     .padding(bottom = 8.dp)
                                     .fillMaxWidth()
                                     .clickable {
-                                        viewModel.loadProjectAndBuild(context, project.name)
-                                        Toast.makeText(context, "Loading and building project...", Toast.LENGTH_SHORT).show()
-                                        onBuildTriggered()
+                                        viewModel.loadProject(project.name) {
+                                            // After loading, go to Setup tab
+                                            val setupIndex = tabs.indexOf("Setup")
+                                            if (setupIndex != -1) tabIndex = setupIndex
+                                        }
+                                        Toast.makeText(context, "Project loaded.", Toast.LENGTH_SHORT).show()
                                     },
                                 colors = CardDefaults.cardColors(
                                     containerColor = MaterialTheme.colorScheme.surface,


### PR DESCRIPTION
- URL encode user and repo in release URL construction
- Separate loading logic from build initialization in MainViewModel
- Update ProjectScreen to navigate to Setup tab after loading instead of building

## Summary by Sourcery

Fix release URL construction and adjust project loading behavior.

Bug Fixes:
- Correct release API URL construction by URL-encoding GitHub user and repository names.

Enhancements:
- Decouple project loading from build initialization in the main view model to allow post-load actions.
- Update project selection flow to navigate to the Setup tab after a project is loaded instead of immediately starting a build.