### PR TITLE
Enable data persistence on uninstall and add backup options

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
 
     <application
         android:allowBackup="true"
+        android:hasFragileUserData="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/SettingsScreen.kt
@@ -155,6 +155,28 @@ fun SettingsScreen(
         }
     )
 
+    val exportLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.CreateDocument("application/zip")
+    ) { uri ->
+        if (uri != null) {
+            Toast.makeText(context, "Exporting...", Toast.LENGTH_SHORT).show()
+            settingsViewModel.exportData(context, uri) { success ->
+                Toast.makeText(context, if (success) "Export successful" else "Export failed", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    val importLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenDocument()
+    ) { uri ->
+        if (uri != null) {
+            Toast.makeText(context, "Importing...", Toast.LENGTH_SHORT).show()
+            settingsViewModel.importData(context, uri) { success ->
+                Toast.makeText(context, if (success) "Import successful" else "Import failed", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
     val hazeState = rememberHazeState()
 
     Box(
@@ -480,6 +502,26 @@ fun SettingsScreen(
                 Text("Log Level", color = MaterialTheme.colorScheme.onBackground)
                 LogLevelDropdown(
                     settingsViewModel = settingsViewModel
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+                Text("Backup & Restore", color = MaterialTheme.colorScheme.onBackground, style = MaterialTheme.typography.titleLarge)
+                Spacer(modifier = Modifier.height(16.dp))
+
+                AzButton(
+                    onClick = { exportLauncher.launch("ideaz_backup.zip") },
+                    text = "Export Data to Zip",
+                    shape = AzButtonShape.RECTANGLE,
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                AzButton(
+                    onClick = { importLauncher.launch(arrayOf("application/zip")) },
+                    text = "Import Data from Zip",
+                    shape = AzButtonShape.RECTANGLE,
+                    modifier = Modifier.fillMaxWidth()
                 )
 
                 Spacer(modifier = Modifier.height(24.dp))

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/SettingsViewModel.kt
@@ -6,12 +6,15 @@ import android.content.Intent
 import android.net.Uri
 import android.util.Log
 import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.saveable.Saver
 import androidx.preference.PreferenceManager
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import com.hereliesaz.ideaz.api.AuthInterceptor
+import com.hereliesaz.ideaz.utils.BackupManager
 import java.io.File
 import java.io.FileOutputStream
 
@@ -353,5 +356,24 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
 
     fun setProjectType(type: String) {
         sharedPreferences.edit().putString(KEY_PROJECT_TYPE, type).apply()
+    }
+
+    // --- Backup & Restore ---
+
+    fun exportData(context: Context, uri: Uri, onComplete: (Boolean) -> Unit) {
+        viewModelScope.launch {
+            val success = BackupManager.exportData(context, uri)
+            onComplete(success)
+        }
+    }
+
+    fun importData(context: Context, uri: Uri, onComplete: (Boolean) -> Unit) {
+        viewModelScope.launch {
+            val success = BackupManager.importData(context, uri)
+            if (success) {
+                loadLocalProjects() // Refresh project list
+            }
+            onComplete(success)
+        }
     }
 }

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/utils/BackupManager.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/utils/BackupManager.kt
@@ -1,0 +1,93 @@
+package com.hereliesaz.ideaz.utils
+
+import android.content.Context
+import android.net.Uri
+import android.util.Log
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+import java.util.zip.ZipEntry
+import java.util.zip.ZipInputStream
+import java.util.zip.ZipOutputStream
+
+object BackupManager {
+    private const val TAG = "BackupManager"
+
+    suspend fun exportData(context: Context, uri: Uri): Boolean {
+        return withContext(Dispatchers.IO) {
+            try {
+                val filesDir = context.filesDir
+                context.contentResolver.openOutputStream(uri)?.use { outputStream ->
+                    ZipOutputStream(outputStream).use { zipOut ->
+                        filesDir.walkTopDown().forEach { file ->
+                            if (file.isFile) {
+                                val relativePath = file.relativeTo(filesDir).path
+                                // Basic filtering
+                                if (!shouldSkip(relativePath)) {
+                                    val entry = ZipEntry(relativePath)
+                                    zipOut.putNextEntry(entry)
+                                    file.inputStream().use { input ->
+                                        input.copyTo(zipOut)
+                                    }
+                                    zipOut.closeEntry()
+                                }
+                            }
+                        }
+                    }
+                }
+                true
+            } catch (e: Exception) {
+                Log.e(TAG, "Export failed", e)
+                false
+            }
+        }
+    }
+
+    suspend fun importData(context: Context, uri: Uri): Boolean {
+        return withContext(Dispatchers.IO) {
+            try {
+                val filesDir = context.filesDir
+                context.contentResolver.openInputStream(uri)?.use { inputStream ->
+                    ZipInputStream(inputStream).use { zipIn ->
+                        var entry = zipIn.nextEntry
+                        while (entry != null) {
+                            val filePath = File(filesDir, entry.name)
+                            // Zip Slip check
+                            if (!filePath.canonicalPath.startsWith(filesDir.canonicalPath)) {
+                                throw IOException("Zip entry is outside of the target dir: ${entry.name}")
+                            }
+
+                            if (entry.isDirectory) {
+                                filePath.mkdirs()
+                            } else {
+                                filePath.parentFile?.mkdirs()
+                                FileOutputStream(filePath).use { output ->
+                                    zipIn.copyTo(output)
+                                }
+                            }
+                            zipIn.closeEntry()
+                            entry = zipIn.nextEntry
+                        }
+                    }
+                }
+                true
+            } catch (e: Exception) {
+                Log.e(TAG, "Import failed", e)
+                false
+            }
+        }
+    }
+
+    private fun shouldSkip(path: String): Boolean {
+        // Filter out common build artifacts and large dependencies
+        // Keep git history
+        return path.contains("/build/") ||
+               path.contains("/.gradle/") ||
+               path.startsWith("build/") ||
+               path.startsWith(".gradle/") ||
+               path.contains("/node_modules/") ||
+               path.startsWith("node_modules/")
+    }
+}

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,13 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-   Sample backup rules file; uncomment and customize as necessary.
-   See https://developer.android.com/guide/topics/data/autobackup
-   for details.
-   Note: This file is ignored for devices older than API 31
-   See https://developer.android.com/about/versions/12/backup-restore
--->
+<?xml version="1.0" encoding="utf-8"?>
 <full-backup-content>
-    <!--
-   <include domain="sharedpref" path="."/>
-   <exclude domain="sharedpref" path="device.xml"/>
--->
+    <!-- Include everything in files directory (projects) -->
+    <include domain="file" path="."/>
+    <!-- Include shared preferences (settings) -->
+    <include domain="sharedpref" path="."/>
 </full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,19 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-   Sample data extraction rules file; uncomment and customize as necessary.
-   See https://developer.android.com/about/versions/12/backup-restore#xml-changes
-   for details.
--->
+<?xml version="1.0" encoding="utf-8"?>
 <data-extraction-rules>
     <cloud-backup>
-        <!-- TODO: Use <include> and <exclude> to control what is backed up.
-        <include .../>
-        <exclude .../>
-        -->
+        <include domain="file" path="."/>
+        <include domain="sharedpref" path="."/>
     </cloud-backup>
-    <!--
     <device-transfer>
-        <include .../>
-        <exclude .../>
+        <include domain="file" path="."/>
+        <include domain="sharedpref" path="."/>
     </device-transfer>
-    -->
 </data-extraction-rules>


### PR DESCRIPTION
- Added `android:hasFragileUserData="true"` to manifest to prompt users to keep data on uninstall.
- Configured auto-backup rules to include the `files/` directory (project storage).
- Implemented `BackupManager` to export/import project data to/from a Zip archive.
- Added "Backup & Restore" controls to the Settings screen.

## Summary by Sourcery

Add user-facing backup and restore capabilities for app data and ensure it is included and preserved by Android backup mechanisms.

New Features:
- Expose Backup & Restore actions in Settings to export app data to a Zip archive and import it back from user-selected files.
- Introduce a BackupManager utility to handle zipping and unzipping app files for manual data export and import.

Enhancements:
- Configure application backup metadata so files and shared preferences are included in cloud backup and device transfer, and mark the app as containing fragile user data to prompt users during uninstall.