### PR TITLE
feat: Determine default branch and fix workflow

### DIFF
--- a/.github/workflows/android_ci_jules.yml
+++ b/.github/workflows/android_ci_jules.yml
@@ -74,7 +74,7 @@ jobs:
           gh release edit $TAG_NAME \
             --prerelease \
             --title "Latest Debug Build" \
-            --body "Automatic build from commit $GITHUB_SHA" \
+            --notes "Automatic build from commit $GITHUB_SHA" \
             --target $GITHUB_SHA
 
           gh release upload $TAG_NAME $APK_FILE --clobber
@@ -83,7 +83,7 @@ jobs:
           gh release create $TAG_NAME $APK_FILE \
             --prerelease \
             --title "Latest Debug Build" \
-            --body "Automatic build from commit $GITHUB_SHA" \
+            --notes "Automatic build from commit $GITHUB_SHA" \
             --target $GITHUB_SHA
         fi
 

--- a/app/src/main/assets/templates/flutter/.github/workflows/flutter_ci_jules.yml
+++ b/app/src/main/assets/templates/flutter/.github/workflows/flutter_ci_jules.yml
@@ -63,7 +63,7 @@ jobs:
           gh release edit $TAG_NAME \
             --prerelease \
             --title "Latest Debug Build" \
-            --body "Automatic build from commit $GITHUB_SHA" \
+            --notes "Automatic build from commit $GITHUB_SHA" \
             --target $GITHUB_SHA
 
           gh release upload $TAG_NAME $APK_FILE --clobber
@@ -72,7 +72,7 @@ jobs:
           gh release create $TAG_NAME $APK_FILE \
             --prerelease \
             --title "Latest Debug Build" \
-            --body "Automatic build from commit $GITHUB_SHA" \
+            --notes "Automatic build from commit $GITHUB_SHA" \
             --target $GITHUB_SHA
         fi
 

--- a/app/src/main/assets/templates/react_native/.github/workflows/react_native_ci_jules.yml
+++ b/app/src/main/assets/templates/react_native/.github/workflows/react_native_ci_jules.yml
@@ -74,7 +74,7 @@ jobs:
           gh release edit $TAG_NAME \
             --prerelease \
             --title "Latest Debug Build" \
-            --body "Automatic build from commit $GITHUB_SHA" \
+            --notes "Automatic build from commit $GITHUB_SHA" \
             --target $GITHUB_SHA
 
           gh release upload $TAG_NAME $APK_FILE --clobber
@@ -83,7 +83,7 @@ jobs:
           gh release create $TAG_NAME $APK_FILE \
             --prerelease \
             --title "Latest Debug Build" \
-            --body "Automatic build from commit $GITHUB_SHA" \
+            --notes "Automatic build from commit $GITHUB_SHA" \
             --target $GITHUB_SHA
         fi
 

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/git/GitManager.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/git/GitManager.kt
@@ -199,6 +199,22 @@ class GitManager(private val projectDir: File) {
         }
     }
 
+    fun getDefaultBranch(): String? {
+        return try {
+            Git.open(projectDir).use { git ->
+                val remoteHead = git.repository.findRef("refs/remotes/origin/HEAD")
+                if (remoteHead != null && remoteHead.isSymbolic) {
+                    // The target is refs/remotes/origin/main, we want the last part
+                    remoteHead.target.name.substringAfterLast('/')
+                } else {
+                    null // Fallback if not found or not symbolic
+                }
+            }
+        } catch (e: Exception) {
+            null
+        }
+    }
+
     private class SimpleProgressMonitor(private val callback: (Int, String) -> Unit) : ProgressMonitor {
         private var totalWork = 0
         private var currentWork = 0

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/SettingsViewModel.kt
@@ -347,6 +347,10 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
         return sharedPreferences.getString(KEY_BRANCH_NAME, "main")!!
     }
 
+    fun saveBranchName(branchName: String) {
+        sharedPreferences.edit().putString(KEY_BRANCH_NAME, branchName).apply()
+    }
+
     fun getProjectType(): String {
         return sharedPreferences.getString(KEY_PROJECT_TYPE, "UNKNOWN") ?: "UNKNOWN"
     }


### PR DESCRIPTION
- Updated GitManager to determine the default branch of a repository.
- Modified MainViewModel to store the default branch name in settings upon project load.
- Updated the project initialization logic to use the stored default branch name when committing and pushing workflow files.
- Replaced the `--body` flag with `--notes` in all `gh release` commands in the CI workflow files to fix a breaking change in the GitHub CLI.

## Summary by Sourcery

Determine and persist each project's default Git branch and update workflows to use it when syncing, while adapting CI release commands to the latest GitHub CLI flags.

New Features:
- Detect the repository's default branch via Git and store it in application settings on project load.
- Use the stored default branch when checking out, committing, and pushing workflow synchronization changes.

Enhancements:
- Load and persist the branch name from project configuration when available to keep settings in sync with project metadata.

CI:
- Replace deprecated gh release --body usage with --notes across Android, Flutter, and React Native CI workflows to comply with the latest GitHub CLI behavior.