### PR TITLE
feat(build): auto-fix manifest errors and update git screen ui

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/ideaz/buildlogic/ProcessManifest.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/buildlogic/ProcessManifest.kt
@@ -1,0 +1,128 @@
+package com.hereliesaz.ideaz.buildlogic
+
+import com.hereliesaz.ideaz.IBuildCallback
+import org.w3c.dom.Document
+import org.w3c.dom.Element
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+import javax.xml.transform.TransformerFactory
+import javax.xml.transform.dom.DOMSource
+import javax.xml.transform.stream.StreamResult
+
+class ProcessManifest(
+    private val inputManifestPath: String,
+    private val outputManifestPath: String,
+    private val packageName: String?,
+    private val minSdk: Int,
+    private val targetSdk: Int
+) : BuildStep {
+
+    override fun execute(callback: IBuildCallback?): BuildResult {
+        val inputFile = File(inputManifestPath)
+
+        // Handle missing manifest
+        if (!inputFile.exists()) {
+            if (packageName != null) {
+                callback?.onLog("ProcessManifest: Manifest missing. Generating stub.")
+                generateStubManifest(outputManifestPath, packageName)
+                return BuildResult(true, "Generated stub manifest")
+            }
+            return BuildResult(false, "Manifest not found at $inputManifestPath")
+        }
+
+        try {
+            val dbFactory = DocumentBuilderFactory.newInstance()
+            dbFactory.isNamespaceAware = true
+            val dBuilder = dbFactory.newDocumentBuilder()
+            val doc = dBuilder.parse(inputFile)
+
+            val root = doc.documentElement // <manifest>
+
+            // 1. Ensure Namespace
+            val androidNs = "http://schemas.android.com/apk/res/android"
+            if (!root.hasAttribute("xmlns:android")) {
+                root.setAttribute("xmlns:android", androidNs)
+            }
+
+            // 2. Inject Package
+            if (packageName != null && (!root.hasAttribute("package") || root.getAttribute("package").isBlank())) {
+                root.setAttribute("package", packageName)
+                callback?.onLog("ProcessManifest: Injected package='$packageName'")
+            }
+
+            // 3. Inject uses-sdk
+            val usesSdkList = root.getElementsByTagName("uses-sdk")
+            val usesSdk: Element = if (usesSdkList.length > 0) {
+                usesSdkList.item(0) as Element
+            } else {
+                val newUsesSdk = doc.createElement("uses-sdk")
+                // Insert at beginning (after permissions usually, but standard is early)
+                // Just append to root? XML order matters strictly? uses-sdk usually first or after perms.
+                // Appending to root is fine for most parsers.
+                root.insertBefore(newUsesSdk, root.firstChild)
+                newUsesSdk
+            }
+
+            // Ensure min/target SDK
+            if (!usesSdk.hasAttribute("android:minSdkVersion")) {
+                usesSdk.setAttribute("android:minSdkVersion", minSdk.toString())
+            }
+            if (!usesSdk.hasAttribute("android:targetSdkVersion")) {
+                usesSdk.setAttribute("android:targetSdkVersion", targetSdk.toString())
+            }
+
+            // 4. Inject Application Tag if missing
+            val appList = root.getElementsByTagName("application")
+            if (appList.length == 0) {
+                val newApp = doc.createElement("application")
+                root.appendChild(newApp)
+            }
+
+            // 5. Fix android:exported
+            val componentTags = listOf("activity", "service", "receiver", "provider", "activity-alias")
+            for (tagName in componentTags) {
+                val nodes = root.getElementsByTagName(tagName)
+                for (i in 0 until nodes.length) {
+                    val node = nodes.item(i) as Element
+
+                    if (!node.hasAttribute("android:exported")) {
+                        // Check for intent-filter
+                        val intentFilters = node.getElementsByTagName("intent-filter")
+                        if (intentFilters.length > 0) {
+                            node.setAttribute("android:exported", "true")
+                            callback?.onLog("ProcessManifest: Injected android:exported=true for $tagName")
+                        } else {
+                             // Default to false for safety/correctness on API 31+
+                            node.setAttribute("android:exported", "false")
+                        }
+                    }
+                }
+            }
+
+            // Write output
+            val transformerFactory = TransformerFactory.newInstance()
+            val transformer = transformerFactory.newTransformer()
+            val source = DOMSource(doc)
+            val result = StreamResult(File(outputManifestPath))
+            transformer.transform(source, result)
+
+            return BuildResult(true, "Manifest processed successfully")
+
+        } catch (e: Exception) {
+            e.printStackTrace()
+            return BuildResult(false, "ProcessManifest failed: ${e.message}")
+        }
+    }
+
+    private fun generateStubManifest(path: String, pkg: String) {
+        val content = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+                package="$pkg">
+                <uses-sdk android:minSdkVersion="$minSdk" android:targetSdkVersion="$targetSdk" />
+                <application android:label="StubApp" />
+            </manifest>
+        """.trimIndent()
+        File(path).writeText(content)
+    }
+}

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/services/BuildService.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/services/BuildService.kt
@@ -318,10 +318,13 @@ class BuildService : Service() {
 
             if (!isActive) return@launch
 
+            val processedManifestPath = File(buildDir, "processed_manifest.xml").absolutePath
+
             val buildOrchestrator = BuildOrchestrator(
                 listOf(
+                    ProcessManifest(File(projectDir, "app/src/main/AndroidManifest.xml").absolutePath, processedManifestPath, packageName, MIN_SDK, TARGET_SDK),
                     Aapt2Compile(aapt2Path, File(projectDir, "app/src/main/res").absolutePath, File(buildDir, "compiled_res").absolutePath, MIN_SDK, TARGET_SDK),
-                    Aapt2Link(aapt2Path, File(buildDir, "compiled_res").absolutePath, androidJarPath!!, File(projectDir, "app/src/main/AndroidManifest.xml").absolutePath, File(buildDir, "app.apk").absolutePath, File(buildDir, "gen").absolutePath, MIN_SDK, TARGET_SDK, processAars.compiledAars, packageName),
+                    Aapt2Link(aapt2Path, File(buildDir, "compiled_res").absolutePath, androidJarPath!!, processedManifestPath, File(buildDir, "app.apk").absolutePath, File(buildDir, "gen").absolutePath, MIN_SDK, TARGET_SDK, processAars.compiledAars, packageName),
                     KotlincCompile(kotlincJarPath!!, androidJarPath, File(projectDir, "app/src/main/java").absolutePath, File(buildDir, "classes"), fullClasspath, javaBinaryPath!!),
                     D8Compile(d8Path!!, javaBinaryPath, androidJarPath, File(buildDir, "classes").absolutePath, File(buildDir, "classes").absolutePath, fullClasspath),
                     ApkBuild(File(buildDir, "app-signed.apk").absolutePath, File(buildDir, "app.apk").absolutePath, File(buildDir, "classes").absolutePath),

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/GitScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/GitScreen.kt
@@ -35,20 +35,20 @@ fun GitScreen(
         AzButton(
             onClick = { viewModel.forceUpdateInitFiles() },
             text = "Force Update Init Files",
-            shape = AzButtonShape.RECTANGLE
+            shape = AzButtonShape.NONE
         )
 
         Spacer(modifier = Modifier.height(16.dp))
 
         // Git Commands
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            Button(onClick = { viewModel.gitFetch() }) { Text("Fetch") }
-            Button(onClick = { viewModel.gitPull() }) { Text("Pull") }
-            Button(onClick = { viewModel.gitPush() }) { Text("Push") }
+            AzButton(onClick = { viewModel.gitFetch() }, text = "Fetch", shape = AzButtonShape.NONE)
+            AzButton(onClick = { viewModel.gitPull() }, text = "Pull", shape = AzButtonShape.NONE)
+            AzButton(onClick = { viewModel.gitPush() }, text = "Push", shape = AzButtonShape.NONE)
         }
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.padding(top = 8.dp)) {
-            Button(onClick = { viewModel.gitStash("Stash via UI") }) { Text("Stash") }
-            Button(onClick = { viewModel.gitUnstash() }) { Text("Unstash") }
+            AzButton(onClick = { viewModel.gitStash("Stash via UI") }, text = "Stash", shape = AzButtonShape.NONE)
+            AzButton(onClick = { viewModel.gitUnstash() }, text = "Unstash", shape = AzButtonShape.NONE)
         }
 
         Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/test/java/com/hereliesaz/ideaz/buildlogic/ProcessManifestTest.kt
+++ b/app/src/test/java/com/hereliesaz/ideaz/buildlogic/ProcessManifestTest.kt
@@ -1,0 +1,97 @@
+package com.hereliesaz.ideaz.buildlogic
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+
+class ProcessManifestTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    @Test
+    fun fixMissingPackageAndExported() {
+        val manifestFile = tempFolder.newFile("AndroidManifest.xml")
+        manifestFile.writeText("""
+            <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+                <application>
+                    <activity android:name=".MainActivity">
+                        <intent-filter>
+                            <action android:name="android.intent.action.MAIN" />
+                            <category android:name="android.intent.category.LAUNCHER" />
+                        </intent-filter>
+                    </activity>
+                    <activity android:name=".SecondActivity" />
+                </application>
+            </manifest>
+        """.trimIndent())
+
+        val outputFile = File(tempFolder.root, "processed_manifest.xml")
+        val outputPath = outputFile.absolutePath
+
+        val processor = ProcessManifest(
+            manifestFile.absolutePath,
+            outputPath,
+            packageName = "com.test.app",
+            minSdk = 26,
+            targetSdk = 36
+        )
+        val result = processor.execute(null)
+
+        assertTrue(result.success)
+        assertTrue(outputFile.exists())
+
+        val content = outputFile.readText()
+
+        // Check package injected
+        assertTrue(content.contains("package=\"com.test.app\""))
+
+        // Check uses-sdk injected
+        assertTrue(content.contains("android:minSdkVersion=\"26\""))
+        assertTrue(content.contains("android:targetSdkVersion=\"36\""))
+
+        // Check exported injected
+        // MainActivity has intent-filter -> exported=true
+        // SecondActivity has no intent-filter -> exported=false
+
+        // Since XML order/formatting might change, parsing to verify is safer, but string check works if unique.
+        // Or check existence.
+
+        // Let's rely on basic string checks for now, trusting DOM transformer produces valid XML.
+        // We need to match <activity android:name=".MainActivity" ... android:exported="true">
+        // The order of attributes is not guaranteed.
+        // But "android:exported" must be present.
+
+        // Check count of exported attributes
+        val exportedTrueCount = content.split("android:exported=\"true\"").size - 1
+        val exportedFalseCount = content.split("android:exported=\"false\"").size - 1
+
+        assertEquals(1, exportedTrueCount) // MainActivity
+        assertEquals(1, exportedFalseCount) // SecondActivity
+    }
+
+    @Test
+    fun generateStubIfMissing() {
+        val inputPath = File(tempFolder.root, "missing.xml").absolutePath
+        val outputFile = File(tempFolder.root, "stub.xml")
+
+        val processor = ProcessManifest(
+            inputPath,
+            outputFile.absolutePath,
+            packageName = "com.stub.app",
+            minSdk = 26,
+            targetSdk = 36
+        )
+
+        val result = processor.execute(null)
+        assertTrue(result.success)
+
+        val content = outputFile.readText()
+        assertTrue(content.contains("package=\"com.stub.app\""))
+        assertTrue(content.contains("<application android:label=\"StubApp\" />"))
+    }
+}

--- a/app/src/test/java/com/hereliesaz/ideaz/utils/ProjectAnalyzerTest.kt
+++ b/app/src/test/java/com/hereliesaz/ideaz/utils/ProjectAnalyzerTest.kt
@@ -76,4 +76,71 @@ class ProjectAnalyzerTest {
         val type = ProjectAnalyzer.detectProjectType(projectDir)
         assertEquals(ProjectType.OTHER, type)
     }
+
+    @Test
+    fun detectPackageName_fromManifest() {
+        val projectDir = tempFolder.newFolder("manifest_project")
+        val manifestDir = File(projectDir, "app/src/main").apply { mkdirs() }
+        File(manifestDir, "AndroidManifest.xml").writeText("""
+            <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+                package="com.example.manifest">
+            </manifest>
+        """.trimIndent())
+
+        val packageName = ProjectAnalyzer.detectPackageName(projectDir)
+        assertEquals("com.example.manifest", packageName)
+    }
+
+    @Test
+    fun detectPackageName_fromGradleApplicationId() {
+        val projectDir = tempFolder.newFolder("gradle_appid_project")
+        val appDir = File(projectDir, "app").apply { mkdirs() }
+        File(appDir, "build.gradle").writeText("""
+            android {
+                defaultConfig {
+                    applicationId "com.example.gradle.appid"
+                }
+            }
+        """.trimIndent())
+
+        val packageName = ProjectAnalyzer.detectPackageName(projectDir)
+        assertEquals("com.example.gradle.appid", packageName)
+    }
+
+    @Test
+    fun detectPackageName_fromGradleNamespace() {
+        val projectDir = tempFolder.newFolder("gradle_namespace_project")
+        val appDir = File(projectDir, "app").apply { mkdirs() }
+        File(appDir, "build.gradle.kts").writeText("""
+            android {
+                namespace = "com.example.gradle.namespace"
+            }
+        """.trimIndent())
+
+        val packageName = ProjectAnalyzer.detectPackageName(projectDir)
+        assertEquals("com.example.gradle.namespace", packageName)
+    }
+
+    @Test
+    fun detectPackageName_fallbackToSourceDir() {
+        val projectDir = tempFolder.newFolder("source_fallback_project")
+        // Create directory structure: app/src/main/java/com/example/source
+        val sourceDir = File(projectDir, "app/src/main/java/com/example/source").apply { mkdirs() }
+        File(sourceDir, "Main.kt").createNewFile()
+
+        val packageName = ProjectAnalyzer.detectPackageName(projectDir)
+        assertEquals("com.example.source", packageName)
+    }
+
+    @Test
+    fun detectPackageName_fallbackToFolderName() {
+        val projectDir = tempFolder.newFolder("My-Project_123")
+        // No manifest, no gradle, no source
+
+        val packageName = ProjectAnalyzer.detectPackageName(projectDir)
+
+        // Should sanitize "My-Project_123" to something valid.
+        // Assuming format: "com.ideaz.generated.myproject123"
+        assertEquals("com.ideaz.generated.myproject123", packageName)
+    }
 }


### PR DESCRIPTION
Introduced `ProcessManifest` build step to automatically resolve common `AndroidManifest.xml` errors that block builds:
- Injects missing `package` attribute.
- Injects missing `uses-sdk` with min/target SDK versions.
- Injects missing `android:exported` attributes for components with intent filters (defaulting to false otherwise), satisfying Android 12+ requirements.
- Generates a stub manifest if the file is completely missing.

Updated `BuildService` to integrate `ProcessManifest` before `Aapt2Link`.

Updated `GitScreen.kt` to use `AzButton` with `shape = AzButtonShape.NONE` for all buttons, as requested.

Verified with comprehensive unit tests in `ProcessManifestTest`.