### PR TITLE
Fix package visibility and update artifact detection logic

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,18 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
 
+    <!--
+         Required for Android 11+ (API 30+) to detect installed apps.
+         We query for any app that has a launcher activity, so we can launch
+         the apps we build.
+    -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.MAIN" />
+            <category android:name="android.intent.category.LAUNCHER" />
+        </intent>
+    </queries>
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/MainViewModel.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/MainViewModel.kt
@@ -1376,6 +1376,10 @@ class MainViewModel(
         }
     }
 
+    private fun isValidSha(s: String): Boolean {
+        return s.matches(Regex("^[0-9a-fA-F]{40}$"))
+    }
+
     private suspend fun checkForArtifact(sha: String): RemoteArtifact? {
         val user = settingsViewModel.getGithubUser() ?: return null
         val appName = settingsViewModel.getAppName() ?: return null
@@ -1416,7 +1420,12 @@ class MainViewModel(
                         if (assets.length() > 0) {
                             val asset = assets.getJSONObject(0)
                             val downloadUrl = if (!token.isNullOrBlank()) asset.getString("url") else asset.getString("browser_download_url")
-                            val artifact = RemoteArtifact(downloadUrl, targetCommitish, tagName)
+
+                            // Fix: If target_commitish is a branch name (e.g. "main"), we can't use it as a version identifier
+                            // because it doesn't change when a new release is made from the same branch.
+                            // In that case, we use the Tag Name as the unique identifier.
+                            val identifier = if (isValidSha(targetCommitish)) targetCommitish else tagName
+                            val artifact = RemoteArtifact(downloadUrl, identifier, tagName)
 
                             if (latestRelease == null) {
                                 latestRelease = artifact // First one is latest

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+# A script to correctly set up a basic Android development environment.
+
+# Exit on error, print commands
+set -euo pipefail
+set -x
+
+# --- 1. Install Java Development Kit (JDK) 17 ---
+echo "➡️ Installing OpenJDK 17..."
+sudo apt-get update
+sudo apt-get install -y openjdk-17-jdk
+
+# Verify Java installation
+JAVA_17_HOME="/usr/lib/jvm/java-17-openjdk-amd64"
+if [ ! -d "$JAVA_17_HOME" ] || [ ! -f "$JAVA_17_HOME/bin/java" ]; then
+    echo "❌ ERROR: OpenJDK 17 installation failed or was not found at the expected path."
+    echo "Please check your system's package manager and Java installation."
+    exit 1
+fi
+echo "✅ OpenJDK 17 installed successfully."
+
+
+# --- 2. Install Android Command Line Tools ---
+echo "➡️ Setting up Android SDK..."
+
+# Define paths
+ANDROID_SDK_ROOT="$HOME/Android/sdk"
+echo "SDK Root will be: $ANDROID_SDK_ROOT"
+
+TOOLS_VERSION="11076708"
+TOOLS_URL="https://dl.google.com/android/repository/commandlinetools-linux-${TOOLS_VERSION}_latest.zip"
+TOOLS_ZIP="/tmp/android-tools.zip"
+
+# Create parent directory for cmdline-tools
+mkdir -p "$ANDROID_SDK_ROOT/cmdline-tools"
+if [ ! -d "$ANDROID_SDK_ROOT/cmdline-tools" ]; then
+    echo "❌ ERROR: Failed to create SDK directory at $ANDROID_SDK_ROOT/cmdline-tools."
+    exit 1
+fi
+
+# Download and place the tools in their final destination
+echo "Downloading tools from $TOOLS_URL..."
+wget -q "$TOOLS_URL" -O "$TOOLS_ZIP"
+if [ ! -f "$TOOLS_ZIP" ]; then
+    echo "❌ ERROR: Failed to download Android command line tools."
+    exit 1
+fi
+
+# Unzip and restructure the directory
+echo "Unzipping tools..."
+rm -rf "$ANDROID_SDK_ROOT/cmdline-tools/latest"
+unzip -oq "$TOOLS_ZIP" -d "$ANDROID_SDK_ROOT/cmdline-tools"
+mv "$ANDROID_SDK_ROOT/cmdline-tools/cmdline-tools" "$ANDROID_SDK_ROOT/cmdline-tools/latest"
+rm "$TOOLS_ZIP"
+
+# Verify tools installation
+SDKMANAGER="$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager"
+if [ ! -f "$SDKMANAGER" ]; then
+    echo "❌ ERROR: sdkmanager not found after installation."
+    exit 1
+fi
+echo "✅ Android command line tools installed successfully."
+
+
+# --- 3. Set Environment Variables Permanently ---
+echo "➡️ Configuring environment variables..."
+
+# Auto-detect the user's shell configuration file
+if [[ "$SHELL" == */bash ]]; then
+    RC_FILE="$HOME/.bashrc"
+elif [[ "$SHELL" == */zsh ]]; then
+    RC_FILE="$HOME/.zshrc"
+else
+    RC_FILE="$HOME/.profile"
+fi
+echo "Updating shell configuration at: $RC_FILE"
+
+# Use a function to avoid adding duplicate lines
+append_if_missing() {
+    CONTENT="$1"
+    FILE="$2"
+    case "$(cat "$FILE")" in
+        *"$CONTENT"*)
+            echo "Content already exists in $FILE: $CONTENT"
+            ;;
+        *)
+            echo "Appending to $FILE: $CONTENT"
+            echo "$CONTENT" >> "$FILE"
+            ;;
+    esac
+}
+
+# Add environment variables
+append_if_missing '' "$RC_FILE"
+append_if_missing '# Android & Java Environment' "$RC_FILE"
+append_if_missing "export JAVA_HOME=$JAVA_17_HOME" "$RC_FILE"
+append_if_missing 'export ANDROID_SDK_ROOT=$HOME/Android/sdk' "$RC_FILE"
+append_if_missing 'export ANDROID_HOME=$ANDROID_SDK_ROOT' "$RC_FILE"
+append_if_missing 'export PATH=$PATH:$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:$ANDROID_SDK_ROOT/platform-tools' "$RC_FILE"
+append_if_missing 'export PATH=$JAVA_HOME/bin:$PATH' "$RC_FILE"
+echo "✅ Environment variables configured."
+
+
+# --- 4. Install SDK Packages ---
+echo "➡️ Installing SDK packages (platform-tools, build-tools, platforms)..."
+# Export variables for the current session to use sdkmanager
+export JAVA_HOME=$JAVA_17_HOME
+export ANDROID_HOME=$ANDROID_SDK_ROOT
+export PATH=$PATH:$ANDROID_HOME/cmdline-tools/latest/bin
+
+# The `yes` command automatically accepts licenses.
+yes | "$SDKMANAGER" --licenses > /dev/null || true
+
+# Install essential packages
+echo "Installing platform-tools..."
+"$SDKMANAGER" "platform-tools" > /dev/null
+echo "Installing build-tools..."
+"$SDKMANAGER" "build-tools;34.0.0" > /dev/null
+echo "Installing Android 36 platform..."
+"$SDKMANAGER" "platforms;android-36" > /dev/null
+
+# Verify installation of platform-tools
+if [ ! -d "$ANDROID_SDK_ROOT/platform-tools" ]; then
+    echo "❌ ERROR: Failed to install platform-tools."
+    exit 1
+fi
+echo "✅ SDK packages installed."
+
+
+echo "✅🎉 Android development environment setup complete!"
+echo "Please run 'source $RC_FILE' or restart your terminal to apply the changes."
+set +x


### PR DESCRIPTION
1. Add `<queries>` to AndroidManifest.xml to allow the app to detect other installed packages on Android 11+ (API 30+). This fixes the issue where the app incorrectly reported "package not found" for installed apps.
2. Update MainViewModel.checkForArtifact to fallback to using the release tagName as the unique identifier if target_commitish is not a valid SHA-1 hash (e.g., "main"). This ensures updates are correctly detected and installed when releases target a branch name.
3. Include setup_env.sh for development environment setup.