### PR TITLE
Potential fix for code scanning alert no. 2: Arbitrary file access du…

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/ideaz/utils/ToolManager.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/utils/ToolManager.kt
@@ -146,6 +146,14 @@ object ToolManager {
             var entry: ZipEntry? = zis.nextEntry
             while (entry != null) {
                 val file = File(targetDir, entry.name)
+                // --- Prevent Zip Slip: ensure destination is within targetDir ---
+                val destPath = file.toPath().normalize()
+                val basePath = targetDir.toPath().normalize()
+                if (!destPath.startsWith(basePath)) {
+                    Log.w(TAG, "Skipping potentially malicious zip entry: ${entry.name}")
+                    entry = zis.nextEntry
+                    continue
+                }
                 if (entry.isDirectory) {
                     file.mkdirs()
                 } else {


### PR DESCRIPTION
…ring archive extraction ("Zip Slip")

## Summary by Sourcery

Bug Fixes:
- Add path normalization and directory boundary checks when extracting ZIP entries to prevent arbitrary file write via Zip Slip.