### PR TITLE
Implement onShowPromptPopup logic in MainScreen.kt

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/MainScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/MainScreen.kt
@@ -61,6 +61,8 @@ fun MainScreen(
     val isContextualChatVisible by viewModel.isContextualChatVisible.collectAsState()
     val activeSelectionRect by viewModel.activeSelectionRect.collectAsState()
 
+    var isPromptPopupVisible by remember { mutableStateOf(false) }
+
     // Startup Logic
     LaunchedEffect(Unit) {
         navController.navigate("project_settings")
@@ -116,7 +118,7 @@ fun MainScreen(
                     navController = navController,
                     viewModel = viewModel,
                     context = context,
-                    onShowPromptPopup = { /*TODO*/ },
+                    onShowPromptPopup = { isPromptPopupVisible = true },
                     handleActionClick = { it() },
                     isIdeVisible = isIdeVisible,
                     onLaunchOverlay = {
@@ -166,6 +168,16 @@ fun MainScreen(
                     halfwayDetent = Halfway,
                     screenHeight = screenHeight,
                     onSendPrompt = { viewModel.sendPrompt(it) }
+                )
+            }
+
+            if (isPromptPopupVisible) {
+                PromptPopup(
+                    onDismiss = { isPromptPopupVisible = false },
+                    onSubmit = { prompt ->
+                        viewModel.sendPrompt(prompt)
+                        isPromptPopupVisible = false
+                    }
                 )
             }
         }


### PR DESCRIPTION
This commit implements the prompt popup display logic in `MainScreen.kt` by:
1. Adding a `isPromptPopupVisible` state variable.
2. Hooking the `onShowPromptPopup` callback to update this state.
3. Rendering the `PromptPopup` composable when the state is active.
4. Connecting the popup's submission to `MainViewModel.sendPrompt`.

## Summary by Sourcery

New Features:
- Add a prompt popup to MainScreen that can be triggered via onShowPromptPopup and submits prompts through MainViewModel.