### PR TITLE
Implement downloadDependencies in MainViewModel and BuildService

### DIFF
--- a/app/src/main/aidl/com/hereliesaz/ideaz/IBuildService.aidl
+++ b/app/src/main/aidl/com/hereliesaz/ideaz/IBuildService.aidl
@@ -5,6 +5,7 @@ import com.hereliesaz.ideaz.IBuildCallback;
 
 interface IBuildService {
     oneway void startBuild(String projectPath, IBuildCallback callback);
+    oneway void downloadDependencies(String projectPath, IBuildCallback callback);
     void updateNotification(String message);
     void cancelBuild();
 }

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/MainViewModel.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/MainViewModel.kt
@@ -202,7 +202,7 @@ class MainViewModel(
     // MISC
     fun clearLog() = stateDelegate.clearLog()
     fun launchTargetApp(c: Context) { /* TODO */ }
-    fun downloadDependencies() { /* TODO */ }
+    fun downloadDependencies() = buildDelegate.downloadDependencies()
 
     fun checkRequiredKeys(): List<String> {
         val missing = mutableListOf<String>()

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/delegates/BuildDelegate.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/delegates/BuildDelegate.kt
@@ -133,4 +133,15 @@ class BuildDelegate(
             }
         }
     }
+
+    fun downloadDependencies(projectDir: File? = null) {
+        scope.launch {
+            if (isBuildServiceBound) {
+                val dir = projectDir ?: settingsViewModel.getProjectPath(settingsViewModel.getAppName() ?: "")
+                buildService?.downloadDependencies(dir.absolutePath, buildCallback)
+            } else {
+                onLog("Error: Build Service not bound.\n")
+            }
+        }
+    }
 }


### PR DESCRIPTION
- Exposed `downloadDependencies` in `MainViewModel`, `BuildDelegate`, and `IBuildService.aidl`.
- Implemented dependency download logic in `BuildService.kt`:
  - Uses `HttpDependencyResolver` for Android projects.
  - Logs a message for Web projects (as npm/yarn are not supported on-device).
  - Handles background execution and UI notifications.
- Updated `MainViewModel` to call the delegate method.

## Summary by Sourcery

Add support for triggering dependency downloads from the UI through the bound build service.

New Features:
- Expose a downloadDependencies operation on the IBuildService AIDL interface and service binder.
- Allow MainViewModel and BuildDelegate to initiate dependency downloads for the current project.

Enhancements:
- Implement dependency download handling in BuildService, including Android-specific resolution via HttpDependencyResolver, informational handling for Web projects, and user-facing notifications.