### PR TITLE
Configure Android Backup Rules

### DIFF
--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,13 +1,22 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-   Sample backup rules file; uncomment and customize as necessary.
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+   Backup rules for devices older than API 31.
+   Controls what is backed up via Auto Backup.
    See https://developer.android.com/guide/topics/data/autobackup
-   for details.
-   Note: This file is ignored for devices older than API 31
-   See https://developer.android.com/about/versions/12/backup-restore
 -->
 <full-backup-content>
-    <!--
-   <include domain="sharedpref" path="."/>
-   <exclude domain="sharedpref" path="device.xml"/>
--->
+    <!-- Include all shared preferences -->
+    <include domain="sharedpref" path="."/>
+
+    <!-- Include all files by default -->
+    <include domain="file" path="."/>
+
+    <!-- Exclude large, downloadable build tools -->
+    <exclude domain="file" path="local_build_tools"/>
+
+    <!-- Exclude temporary build caches -->
+    <exclude domain="file" path="cache"/>
+
+    <!-- Exclude build artifacts -->
+    <exclude domain="file" path="web_dist"/>
 </full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,19 +1,33 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-   Sample data extraction rules file; uncomment and customize as necessary.
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+   Data extraction rules for Android 12+ (API 31+).
+   Controls what is backed up to the cloud or transferred between devices.
    See https://developer.android.com/about/versions/12/backup-restore#xml-changes
-   for details.
 -->
 <data-extraction-rules>
     <cloud-backup>
-        <!-- TODO: Use <include> and <exclude> to control what is backed up.
-        <include .../>
-        <exclude .../>
-        -->
+        <!-- Include all shared preferences (settings, keys) -->
+        <include domain="sharedpref" path="."/>
+
+        <!-- Include all files by default (projects, user data) -->
+        <include domain="file" path="."/>
+
+        <!-- Exclude large, downloadable build tools -->
+        <exclude domain="file" path="local_build_tools"/>
+
+        <!-- Exclude temporary build caches -->
+        <exclude domain="file" path="cache"/>
+
+        <!-- Exclude build artifacts -->
+        <exclude domain="file" path="web_dist"/>
     </cloud-backup>
-    <!--
+
     <device-transfer>
-        <include .../>
-        <exclude .../>
+        <!-- Use the same rules for device-to-device transfer -->
+        <include domain="sharedpref" path="."/>
+        <include domain="file" path="."/>
+        <exclude domain="file" path="local_build_tools"/>
+        <exclude domain="file" path="cache"/>
+        <exclude domain="file" path="web_dist"/>
     </device-transfer>
-    -->
 </data-extraction-rules>


### PR DESCRIPTION
- Configured `app/src/main/res/xml/data_extraction_rules.xml` (API 31+) to include `sharedpref` and `file` domains while excluding `local_build_tools`, `cache`, and `web_dist`.
- Updated `app/src/main/res/xml/backup_rules.xml` (legacy) with matching rules for consistency.
- Ensures user projects (in `files/`) and settings are backed up, while regenerative build artifacts are not.