### PR TITLE
Update Android backup rules to exclude local repo cache

### DIFF
--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -16,6 +16,7 @@
 
     <!-- Exclude temporary build caches -->
     <exclude domain="file" path="cache"/>
+    <exclude domain="file" path="local-repo"/>
 
     <!-- Exclude build artifacts -->
     <exclude domain="file" path="web_dist"/>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -17,6 +17,7 @@
 
         <!-- Exclude temporary build caches -->
         <exclude domain="file" path="cache"/>
+        <exclude domain="file" path="local-repo"/>
 
         <!-- Exclude build artifacts -->
         <exclude domain="file" path="web_dist"/>
@@ -28,6 +29,7 @@
         <include domain="file" path="."/>
         <exclude domain="file" path="local_build_tools"/>
         <exclude domain="file" path="cache"/>
+        <exclude domain="file" path="local-repo"/>
         <exclude domain="file" path="web_dist"/>
     </device-transfer>
 </data-extraction-rules>


### PR DESCRIPTION
Updated `data_extraction_rules.xml` and `backup_rules.xml` to explicitly exclude the `local-repo` directory from system backups. This directory is used for caching dependencies during builds and can be large and easily regenerated, making it unsuitable for backup.
- Added `<exclude domain="file" path="local-repo"/>` to `data_extraction_rules.xml`.
- Added `<exclude domain="file" path="local-repo"/>` to `backup_rules.xml`.

## Summary by Sourcery

Enhancements:
- Update Android data extraction and backup configuration to skip the local-repo directory alongside other temporary build caches and artifacts.