### PR TITLE
Implement onShowPromptPopup logic

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/MainScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/MainScreen.kt
@@ -118,7 +118,10 @@ fun MainScreen(
                     navController = navController,
                     viewModel = viewModel,
                     context = context,
-                    onShowPromptPopup = { isPromptPopupVisible = true },
+                    onShowPromptPopup = {
+                        // Show the prompt input dialog
+                        isPromptPopupVisible = true
+                    },
                     handleActionClick = { it() },
                     isIdeVisible = isIdeVisible,
                     onLaunchOverlay = {


### PR DESCRIPTION
Verify and formalize the logic for displaying the prompt popup in MainScreen.kt. The implementation uses a local state variable `isPromptPopupVisible` to trigger the `PromptPopup` dialog. A comment has been added to the callback to clearly indicate its purpose.

Ref: Task - Implement Prompt Popup Action

## Summary by Sourcery

Enhancements:
- Document the onShowPromptPopup callback to explicitly state that it triggers the prompt input dialog display.