### PR TITLE
Implement launchTargetApp logic in MainViewModel

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/MainViewModel.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/MainViewModel.kt
@@ -14,6 +14,7 @@ import com.hereliesaz.ideaz.models.ProjectType
 import com.hereliesaz.ideaz.services.CrashReportingService
 import com.hereliesaz.ideaz.ui.delegates.*
 import com.hereliesaz.ideaz.utils.ErrorCollector
+import com.hereliesaz.ideaz.R
 import com.hereliesaz.ideaz.utils.ProjectAnalyzer
 import com.hereliesaz.ideaz.utils.ToolManager
 import kotlinx.coroutines.Dispatchers
@@ -567,33 +568,54 @@ class MainViewModel(
             stateDelegate.setTargetAppVisible(true)
         } else {
             // Android, Flutter, React Native (assume APK)
-            var packageName = settingsViewModel.targetPackageName.value
-            if (packageName.isNullOrBlank()) {
-                 packageName = "com.example.helloworld" // fallback
-            }
+            val packageName = settingsViewModel.targetPackageName.value
 
             try {
-                val intent = c.packageManager.getLaunchIntentForPackage(packageName)
-                if (intent != null) {
-                    c.startActivity(intent)
-                } else {
-                    // Try to detect package name again as fallback
+                if (packageName.isNullOrBlank()) {
+                     // Try to detect package name if not set
+                    val projectDir = settingsViewModel.getProjectPath(appName)
+                    val detectedPackage = ProjectAnalyzer.detectPackageName(projectDir)
+
+                    if (!detectedPackage.isNullOrBlank()) {
+                        settingsViewModel.saveTargetPackageName(detectedPackage)
+                        launchPackage(c, detectedPackage)
+                    } else {
+                        Toast.makeText(c, c.getString(R.string.error_app_not_installed), Toast.LENGTH_SHORT).show()
+                    }
+                    return
+                }
+
+                if (!launchPackage(c, packageName)) {
+                    // Try to detect package name again as fallback in case it changed
                     val projectDir = settingsViewModel.getProjectPath(appName)
                     val detectedPackage = ProjectAnalyzer.detectPackageName(projectDir)
 
                     if (!detectedPackage.isNullOrBlank() && detectedPackage != packageName) {
                         settingsViewModel.saveTargetPackageName(detectedPackage)
-                        val newIntent = c.packageManager.getLaunchIntentForPackage(detectedPackage)
-                        if (newIntent != null) {
-                            c.startActivity(newIntent)
-                            return
+                        if (!launchPackage(c, detectedPackage)) {
+                             Toast.makeText(c, c.getString(R.string.error_app_not_installed), Toast.LENGTH_SHORT).show()
                         }
+                    } else {
+                        Toast.makeText(c, c.getString(R.string.error_app_not_installed), Toast.LENGTH_SHORT).show()
                     }
-                    Toast.makeText(c, "App not installed. Please build first.", Toast.LENGTH_SHORT).show()
                 }
             } catch (e: Exception) {
-                Toast.makeText(c, "Failed to launch app: ${e.message}", Toast.LENGTH_SHORT).show()
+                Toast.makeText(c, c.getString(R.string.error_launch_failed, e.message), Toast.LENGTH_SHORT).show()
             }
+        }
+    }
+
+    private fun launchPackage(c: Context, pkg: String): Boolean {
+        return try {
+            val intent = c.packageManager.getLaunchIntentForPackage(pkg)
+            if (intent != null) {
+                c.startActivity(intent)
+                true
+            } else {
+                false
+            }
+        } catch (e: Exception) {
+            false
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,4 +6,6 @@
     <string name="starting_task">Starting task...</string>
 <string name="accessibility_service_label">IDEaz Inspection Service</string>
 <string name="accessibility_service_description">Allows IDEaz to inspect the UI layout to provide contextual AI assistance.</string>
+    <string name="error_app_not_installed">App not installed. Please build first.</string>
+    <string name="error_launch_failed">Failed to launch app: %1$s</string>
 </resources>


### PR DESCRIPTION
Refactored `launchTargetApp` to robustly handle app launching for Android projects.
- Removed magic string "com.example.helloworld" fallback unless necessary.
- Added localized error messages in `strings.xml`.
- Implemented package name detection fallback if the stored package name is incorrect.
- Verified existence of dependent methods in `SettingsViewModel` and `ProjectAnalyzer`.