### PR TITLE
Implement robust deleteProject logic in MainViewModel

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/MainViewModel.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/MainViewModel.kt
@@ -452,6 +452,7 @@ class MainViewModel(
      * Deletes a local project by name.
      */
     fun deleteProject(n: String) {
+        if (n.isBlank()) return
         viewModelScope.launch(Dispatchers.IO) {
             try {
                 performLocalDeletion(n)
@@ -499,7 +500,11 @@ class MainViewModel(
     private suspend fun performLocalDeletion(n: String) {
         val projectDir = settingsViewModel.getProjectPath(n)
         if (projectDir.exists()) {
-            projectDir.deleteRecursively()
+            if (!projectDir.deleteRecursively()) {
+                if (projectDir.exists()) {
+                    throw java.io.IOException("Failed to delete project directory: ${projectDir.absolutePath}")
+                }
+            }
         }
         withContext(Dispatchers.Main) {
             settingsViewModel.removeProject(n)


### PR DESCRIPTION
## Summary by Sourcery

Harden project deletion in MainViewModel to avoid invalid input and surface failures when the project directory cannot be removed.

Bug Fixes:
- Ignore delete requests with blank project names in MainViewModel.
- Detect and throw an error if recursive deletion of a project directory fails while it still exists.