### PR TITLE
Fix NavRail Z-Order, startup logic, and add Quit button

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/ideaz/services/IdeazOverlayService.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/services/IdeazOverlayService.kt
@@ -65,11 +65,18 @@ class IdeazOverlayService : AzNavRailOverlayService(), ViewModelStoreOwner {
 
     override fun onCreate() {
         createNotificationChannel()
-        super.onCreate()
+        // Setup Console FIRST so it is added to WindowManager first (bottom Z-order)
         setupConsole()
+        // Super (AzNavRailOverlayService) adds the Rail Window SECOND (top Z-order)
+        super.onCreate()
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        if (intent?.action == ACTION_QUIT) {
+            stopSelf()
+            android.os.Process.killProcess(android.os.Process.myPid())
+            return START_NOT_STICKY
+        }
         super.onStartCommand(intent, flags, startId)
         return START_STICKY
     }
@@ -87,11 +94,19 @@ class IdeazOverlayService : AzNavRailOverlayService(), ViewModelStoreOwner {
     }
 
     override fun getNotification(): Notification {
+        val quitIntent = Intent(this, IdeazOverlayService::class.java).apply {
+            action = ACTION_QUIT
+        }
+        val quitPendingIntent = android.app.PendingIntent.getService(
+            this, 0, quitIntent, android.app.PendingIntent.FLAG_IMMUTABLE
+        )
+
         return NotificationCompat.Builder(this, CHANNEL_ID)
             .setContentTitle("IDEaz Overlay")
             .setContentText("Tap to open navigation")
             .setSmallIcon(R.mipmap.ic_launcher)
             .setPriority(NotificationCompat.PRIORITY_LOW)
+            .addAction(android.R.drawable.ic_menu_close_clear_cancel, "Quit", quitPendingIntent)
             .build()
     }
 
@@ -181,9 +196,11 @@ class IdeazOverlayService : AzNavRailOverlayService(), ViewModelStoreOwner {
                     isLocalBuildEnabled = false,
                     onNavigateToMainApp = { route ->
                         val intent = context.packageManager.getLaunchIntentForPackage(context.packageName)
-                        intent?.putExtra("route", route)
-                        intent?.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                        context.startActivity(intent)
+                        if (intent != null) {
+                            intent.putExtra("route", route)
+                            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                            context.startActivity(intent)
+                        }
                     }
                 )
             }
@@ -216,21 +233,6 @@ class IdeazOverlayService : AzNavRailOverlayService(), ViewModelStoreOwner {
             val activeSelectionRect by viewModel.activeSelectionRect.collectAsState()
             val targetPackage by settingsViewModel.targetPackageName.collectAsState()
             val context = LocalContext.current
-
-            // --- AUTO-LAUNCH LOGIC ---
-            LaunchedEffect(Unit) {
-                if (!targetPackage.isNullOrBlank() && targetPackage != context.packageName) {
-                    try {
-                        val launchIntent = context.packageManager.getLaunchIntentForPackage(targetPackage!!)
-                        if (launchIntent != null) {
-                            launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                            context.startActivity(launchIntent)
-                        }
-                    } catch (e: Exception) {
-                        Toast.makeText(context, "Error launching project", Toast.LENGTH_SHORT).show()
-                    }
-                }
-            }
 
             // --- WINDOW SIZING LOGIC ---
             val currentDetent = sheetState.currentDetent
@@ -278,5 +280,6 @@ class IdeazOverlayService : AzNavRailOverlayService(), ViewModelStoreOwner {
 
     companion object {
         private const val CHANNEL_ID = "ideaz_overlay_channel"
+        private const val ACTION_QUIT = "com.hereliesaz.ideaz.ACTION_QUIT"
     }
 }

--- a/app/src/test/java/com/hereliesaz/ideaz/buildlogic/SimpleJsBundlerTest.kt
+++ b/app/src/test/java/com/hereliesaz/ideaz/buildlogic/SimpleJsBundlerTest.kt
@@ -1,6 +1,7 @@
 package com.hereliesaz.ideaz.buildlogic
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder

--- a/docs/UI_UX.md
+++ b/docs/UI_UX.md
@@ -14,7 +14,7 @@ The interaction model revolves around the **Live App** and the **IDE Overlay**.
 
 ### 1. Interaction Mode (Docked / FAB)
 *   **Purpose:** Allow the user to use their app normally.
-*   **State:** `IdeazOverlayService` window (for the Rail) is **dynamic** (managed by `AzNavRail`). It shrinks to wrap the content (Rail/FAB) when stationary to unblock the underlying app, and expands to full screen during drag operations to ensure smooth movement.
+*   **State:** `IdeazOverlayService` window (for the Rail) is **dynamic** (managed by `AzNavRail` v5.2+). It shrinks to wrap the content (Rail/FAB) when stationary to unblock the underlying app, and expands to full screen during drag operations to ensure smooth movement.
 *   **Visuals:** The user sees their app cleanly with the Rail docked.
     *   **FAB Mode:** Long-press the rail header to collapse it into a Floating Action Button (FAB). The FAB can be dragged around the screen.
 *   **Trigger:** User taps "Interact" or toggles the mode. Long-press header for FAB.
@@ -36,6 +36,7 @@ The interaction model revolves around the **Live App** and the **IDE Overlay**.
 
 ### 1. The Unified Overlay
 *   **Concept:** The IDE runs entirely within a System Alert Window.
+*   **Compliance:** The overlay service extends `AzNavRailOverlayService`, leveraging the library's built-in `WindowManager` handling for dynamic sizing and drag support.
 *   **Transparency Rules:**
     *   **Interact/Select Mode:** The background MUST be transparent.
     *   **Settings/Setup:** The background MUST be **Opaque** (Solid).


### PR DESCRIPTION
- Reordered `IdeazOverlayService.onCreate` to add the Console window before the Rail window, ensuring the Rail is Z-ordered on top and clickable.
- Removed auto-launch logic in `IdeazOverlayService` to ensure the IDE starts on the Project screen by default.
- Added a "Quit" action to the `IdeazOverlayService` notification that stops the service and kills the process.
- Updated documentation (UI_UX.md, architecture.md) to reflect the new dynamic overlay architecture.
- Fixed a test compilation error in `SimpleJsBundlerTest`.