### PR TITLE
Revert AzNavRail to default implementation and disable auto-overlay

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/ideaz/MainActivity.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/MainActivity.kt
@@ -37,9 +37,6 @@ class MainActivity : ComponentActivity() {
             val intent = Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION, Uri.parse("package:$packageName"))
             startActivityForResult(intent, 1001)
         } else {
-            // Ensure Overlay Service is running (it might be redundant if already started, but safe)
-            launchOverlay()
-
             // Render the Main UI
             val app = application as MainApplication
             setContent {


### PR DESCRIPTION
- Modified `MainActivity.kt` to remove the automatic invocation of `launchOverlay()` on startup.
- Refactored `MainScreen.kt` to use a `Row` layout instead of a Z-layered `Box` layout, restoring the standard side-by-side behavior.
- Added missing import for `androidx.compose.foundation.layout.Row` to fix build errors.
- Updated `IdeNavRail.kt` to remove hardcoded custom parameters, restoring library defaults.