### PR TITLE
Fix: Grant write permissions and robustify dispatch logic

### DIFF
--- a/.github/workflows/gemini-dispatch.yml
+++ b/.github/workflows/gemini-dispatch.yml
@@ -10,6 +10,8 @@ on:
   pull_request:
     types:
       - 'opened'
+      - 'synchronize'
+      - 'reopened'
   issues:
     types:
       - 'opened'
@@ -46,18 +48,16 @@ jobs:
     # For PRs: only if not from a fork
     # For issues: only on open/reopen
     # For comments: only if user types @gemini-cli and is OWNER/MEMBER/COLLABORATOR
-    if: |-
-      (
-        github.event_name == 'pull_request' &&
-        github.event.pull_request.head.repo.fork == false
-      ) || (
-        github.event_name == 'issues' &&
-        contains(fromJSON('["opened", "reopened"]'), github.event.action)
-      ) || (
-        github.event.sender.type == 'User' &&
-        startsWith(github.event.comment.body || github.event.review.body || github.event.issue.body, '@gemini-cli') &&
-        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association || github.event.review.author_association || github.event.issue.author_association)
-      )
+    if: >-
+      ${{
+        (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) ||
+        (github.event_name == 'issues' && contains(fromJSON('["opened", "reopened"]'), github.event.action)) ||
+        (
+          github.event.sender.type == 'User' &&
+          startsWith(github.event.comment.body || github.event.review.body || github.event.issue.body, '@gemini-cli') &&
+          contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association || github.event.review.author_association || github.event.issue.author_association)
+        )
+      }}
     runs-on: 'ubuntu-latest'
     permissions:
       contents: 'read'
@@ -108,7 +108,7 @@ jobs:
               core.setOutput('additional_context', 'Assess this pull request. If it looks good, merge it into the target branch. If there are conflicts blocking the merge, resolve them by pushing fixes to the PR branch, and then merge it.');
             } else if (['issues.opened', 'issues.reopened'].includes(eventType)) {
               core.setOutput('command', 'invoke');
-              core.setOutput('additional_context', 'Please address this issue. Analyze the request and take appropriate action using your tools.');
+              core.setOutput('additional_context', 'Please address this issue. Analyze the request and take appropriate action using your tools. Commit your solution directly to the master branch.');
             } else {
               core.setOutput('command', 'fallthrough');
             }
@@ -148,7 +148,7 @@ jobs:
       ${{ needs.dispatch.outputs.command == 'invoke' }}
     uses: './.github/workflows/gemini-invoke.yml'
     permissions:
-      contents: 'read'
+      contents: 'write'
       id-token: 'write'
       issues: 'write'
       pull-requests: 'write'


### PR DESCRIPTION
This change addresses multiple issues with the `gemini-dispatch` workflow:
1. Grants `contents: write` permission to the `invoke` job, which is required by the called reusable workflow.
2. Updates the `dispatch` job's `if` condition to be more robust against expression evaluation issues, preventing the workflow from being incorrectly skipped on Issue events.
3. Explicitly instructs the AI agent to commit solutions to the `master` branch when triggered by new issues.
4. Adds `synchronize` and `reopened` triggers for Pull Requests to ensure continuous coverage.

## Summary by Sourcery

Update the gemini-dispatch GitHub workflow to broaden trigger coverage, harden dispatch conditions, and ensure invoked jobs have the permissions and guidance needed to act on new issues.

Build:
- Extend pull_request triggers to include synchronize and reopened events in the gemini-dispatch workflow.
- Adjust the dispatch job condition to a more robust GitHub Actions expression syntax to avoid unintended skips on issue events.
- Grant contents: write permissions to the reusable invoke job so it can modify repository content when handling automation tasks.

Documentation:
- Clarify the AI agent instructions for issue events so that solutions are committed directly to the master branch.