### PR TITLE
Fix clone blocking UI, add loading status feedback, and improve Botto…

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/IdeBottomSheet.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/IdeBottomSheet.kt
@@ -30,10 +30,11 @@ fun IdeBottomSheet(
     viewModel: MainViewModel,
     peekDetent: SheetDetent,
     halfwayDetent: SheetDetent,
+    fullyExpandedDetent: SheetDetent,
     screenHeight: Dp,
     onSendPrompt: (String) -> Unit
 ) {
-    val isHalfwayExpanded = sheetState.currentDetent == halfwayDetent
+    val isHalfwayExpanded = sheetState.currentDetent == halfwayDetent || sheetState.currentDetent == fullyExpandedDetent
     val logMessages by viewModel.filteredLog.collectAsState(initial = emptyList())
     val clipboardManager = LocalClipboardManager.current
     val coroutineScope = rememberCoroutineScope()
@@ -86,6 +87,7 @@ fun IdeBottomSheet(
     }
 
     val contentHeight = when (sheetState.currentDetent) {
+        fullyExpandedDetent -> screenHeight * 0.8f
         halfwayDetent -> screenHeight * 0.5f
         peekDetent -> screenHeight * 0.25f
         else -> 0.dp

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/SheetDetents.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/SheetDetents.kt
@@ -6,3 +6,4 @@ import com.composables.core.SheetDetent
 val AlmostHidden = SheetDetent("almost_hidden") { containerHeight, _ -> containerHeight * 0.01f }
 val Peek = SheetDetent("peek") { containerHeight, _ -> containerHeight * 0.2f }
 val Halfway = SheetDetent("halfway") { containerHeight, _ -> containerHeight * 0.5f }
+val FullyExpanded = SheetDetent("fully_expanded") { containerHeight, _ -> containerHeight * 0.8f }


### PR DESCRIPTION
…mSheet behavior

- **Fix Hang:** Offloaded `GitManager.clone` operation to `Dispatchers.IO` in `RepoDelegate.kt` to prevent the UI from freezing during repository cloning.
- **Improved Feedback:** Updated `StateDelegate` to hold a `loadingStatus` message. Updated `RepoDelegate` and `MainViewModel` to pipe granular Git task descriptions ("Cloning...", "Receiving objects...") to the UI. Updated `ProjectScreen`'s progress dialog to display this status text, so the user knows exactly what is happening.
- **UI Improvement:** Added `FullyExpanded` detent (80% height) to `SheetDetents.kt`.
- **UI Interaction:** Implemented "tap outside to retract" logic in `MainScreen.kt` using `PointerEventPass.Initial`. This allows taps outside the bottom sheet to retract it by one detent (Full -> Half -> Peek -> Hidden) while still passing the touch event to underlying UI elements (like the Nav Rail).
- **Refactor:** Updated `IdeBottomSheet.kt` to support the new `FullyExpanded` detent height.