### PR TITLE
Fix invalid version reference for hermes-android

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -61,7 +61,7 @@ appcompat = "1.7.1"
 
 [libraries]
 react-android = { module = "com.facebook.react:react-android", version.ref = "reactNative" }
-hermes-android = { module = "com.facebook.react:hermes-android", version.ref = "hermes" }
+hermes-android = { module = "com.facebook.react:hermes-android", version.ref = "reactNative" }
 soloader = { module = "com.facebook.soloader:soloader", version.ref = "soloader" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
 org-json = { module = "org.json:json", version.ref = "json" }


### PR DESCRIPTION
Updated `gradle/libs.versions.toml` to change the version reference for `com.facebook.react:hermes-android` from `hermes` (non-existent) to `reactNative`. This resolves the Gradle build failure reported in the logs.

Fixes #582

---
*PR created automatically by Jules for task [17613829380592462459](https://jules.google.com/task/17613829380592462459) started by @HereLiesAz*

## Summary by Sourcery

Bug Fixes:
- Correct the version reference for com.facebook.react:hermes-android to use the existing reactNative version entry, restoring a successful Gradle build.