### PR TITLE
Fix redundant import in app/build.gradle.kts and bump version

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,8 +7,6 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
 }
 
-import java.io.FileInputStream
-
 val versionProps = Properties()
 val versionPropsFile = rootProject.file("version.properties")
 if (versionPropsFile.exists()) {

--- a/version.properties
+++ b/version.properties
@@ -1,3 +1,3 @@
 major=1
 minor=10
-patch=13
+patch=14


### PR DESCRIPTION
This PR fixes a build failure caused by a duplicate `import java.io.FileInputStream` in `app/build.gradle.kts`. The fix involves removing the redundant import statement. Additionally, the project's patch version has been incremented in `version.properties` from 13 to 14, following the project's versioning guidelines for bug fixes. Verified the fix by running `./gradlew :app:assembleDebug`, which succeeded. Also ran the test suite and confirmed that existing tests pass (with one known pre-existing Robolectric environment issue).

Fixes #591

---
*PR created automatically by Jules for task [8936026774136365004](https://jules.google.com/task/8936026774136365004) started by @HereLiesAz*

## Summary by Sourcery

Remove a redundant Gradle import and bump the patch version.

Build:
- Clean up an unused java.io.FileInputStream import from app/build.gradle.kts.

Chores:
- Increment the patch version in version.properties from 13 to 14.