### PR TITLE
test: add missing unit tests for LogSanitizer.kt

### DIFF
--- a/app/src/test/java/com/hereliesaz/ideaz/utils/LogSanitizerTest.kt
+++ b/app/src/test/java/com/hereliesaz/ideaz/utils/LogSanitizerTest.kt
@@ -1,0 +1,82 @@
+package com.hereliesaz.ideaz.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LogSanitizerTest {
+
+    private val redacted = "***REDACTED***"
+
+    @Test
+    fun sanitize_redactsGitHubTokens() {
+        val input = "My token is ghp_12345abcde and another gho_xyz987"
+        val expected = "My token is $redacted and another $redacted"
+        assertEquals(expected, LogSanitizer.sanitize(input))
+    }
+
+    @Test
+    fun sanitize_redactsGoogleApiKeys() {
+        val key = "AIza" + "a".repeat(35)
+        val input = "API_KEY=$key"
+        val expected = "API_KEY=$redacted"
+        assertEquals(expected, LogSanitizer.sanitize(input))
+    }
+
+    @Test
+    fun sanitize_redactsBearerTokens() {
+        val input = "Authorization: Bearer abc123_xyz.789"
+        val expected = "Authorization: Bearer $redacted"
+        assertEquals(expected, LogSanitizer.sanitize(input))
+    }
+
+    @Test
+    fun sanitize_redactsGenericKeys() {
+        val testCases = listOf(
+            "key=secret_value" to "key=$redacted",
+            "password: \"my_pwd\"" to "password: \"$redacted\"",
+            "access_token = 'token123'" to "access_token = '$redacted'",
+            "api_key:val123" to "api_key:$redacted",
+            "pwd=password123&other=val" to "pwd=$redacted&other=val",
+            "secret: topSecret" to "secret: $redacted"
+        )
+
+        testCases.forEach { (input, expected) ->
+            assertEquals("Failed for input: $input", expected, LogSanitizer.sanitize(input))
+        }
+    }
+
+    @Test
+    fun sanitize_redactsUrlCredentials() {
+        val input = "Connecting to https://user:pass123@example.com/api"
+        val expected = "Connecting to https://$redacted@example.com/api"
+        assertEquals(expected, LogSanitizer.sanitize(input))
+
+        val ftp = "ftp://admin:secret@192.168.1.1"
+        val expectedFtp = "ftp://$redacted@192.168.1.1"
+        assertEquals(expectedFtp, LogSanitizer.sanitize(ftp))
+    }
+
+    @Test
+    fun sanitize_handlesMultipleSecrets() {
+        val input = "Error using ghp_token with AIza" + "b".repeat(35) + " at https://u:p@host.com"
+        val expected = "Error using $redacted with $redacted at https://$redacted@host.com"
+        assertEquals(expected, LogSanitizer.sanitize(input))
+    }
+
+    @Test
+    fun sanitize_doesNotRedactNormalText() {
+        val input = "This is a normal log message with no secrets. key and password are words here."
+        assertEquals(input, LogSanitizer.sanitize(input))
+    }
+
+    @Test
+    fun sanitize_redactsThrowableStackTrace() {
+        val secret = "ghp_secretToken"
+        val exception = RuntimeException("Error with token $secret")
+        val sanitized = LogSanitizer.sanitize(exception)
+
+        assertTrue("Stack trace should contain redacted marker", sanitized.contains(redacted))
+        assertTrue("Stack trace should not contain secret", !sanitized.contains(secret))
+    }
+}

--- a/docs/file_descriptions.md
+++ b/docs/file_descriptions.md
@@ -123,6 +123,7 @@
 *   `BackupManager.kt`: Project backup logic.
 *   `ErrorCollector.kt`: Non-fatal error collection.
 *   `LogcatReader.kt`: System logcat reader.
+*   `LogSanitizer.kt`: Utility for redacting sensitive information (API keys, tokens, passwords) from logs and error reports.
 
 ## docs/
 See the index in `AGENTS.md`. The current source-of-truth is `docs/plans/2026-05-01-ideaz-revival-design.md`.

--- a/version.properties
+++ b/version.properties
@@ -1,3 +1,3 @@
 major=1
 minor=10
-patch=13
+patch=14


### PR DESCRIPTION
- Implements comprehensive unit tests covering:
    - GitHub tokens (ghp_, gho_)
    - Google API keys (AIza...)
    - Bearer tokens
    - Generic key/value pairs (password, secret, api_key, etc.)
    - URL credentials (protocol://user:pass@host)
    - Multiple secrets in a single string
    - Throwable stack trace sanitization
    - Normal text (no false positives)
- Updates file_descriptions.md to include LogSanitizer.kt
- Increments version.properties patch version to 1.10.14

## Summary by Sourcery

Add unit test coverage for log sanitization and update related metadata.

Build:
- Increment patch version to 1.10.14 in version.properties.

Documentation:
- Document LogSanitizer in file_descriptions.md as a utility for redacting sensitive information from logs.

Tests:
- Add comprehensive unit tests for LogSanitizer covering various secret formats, URL credentials, multiple secrets, and throwable stack traces.