### PR TITLE
🔒 Fix potential cleartext traffic vulnerability

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,8 +7,6 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
 }
 
-import java.io.FileInputStream
-
 val versionProps = Properties()
 val versionPropsFile = rootProject.file("version.properties")
 if (versionPropsFile.exists()) {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,6 +33,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.IDEaz"
+        android:usesCleartextTraffic="false"
         tools:targetApi="31">
 
         <activity

--- a/app/src/test/java/com/hereliesaz/ideaz/buildlogic/RemoteBuildManagerTest.kt
+++ b/app/src/test/java/com/hereliesaz/ideaz/buildlogic/RemoteBuildManagerTest.kt
@@ -13,6 +13,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 import retrofit2.Response
 import java.io.File
 import java.io.ByteArrayOutputStream
@@ -20,6 +21,7 @@ import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 
 @RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
 class RemoteBuildManagerTest {
 
     private val context = ApplicationProvider.getApplicationContext<Context>()


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Disabled cleartext traffic in the Android application by adding `android:usesCleartextTraffic="false"` to the `<application>` element in `AndroidManifest.xml`.

⚠️ **Risk:** The potential impact if left unfixed
If left unfixed, the application could potentially communicate over unencrypted HTTP connections. This exposes sensitive data transmitted over the network to interception (Man-in-the-Middle attacks), allowing attackers to read or modify the data in transit.

🛡️ **Solution:** How the fix addresses the vulnerability
The `android:usesCleartextTraffic="false"` attribute instructs the Android network security configuration to refuse all cleartext (non-HTTPS) traffic. This enforces secure connections, guaranteeing that any network communication by the app is encrypted, and successfully addressing the vulnerability.

Additionally, to ensure tests run smoothly, resolved an unused import warning in `build.gradle.kts` and fixed an SDK 37 initialization issue in `RemoteBuildManagerTest.kt` by using `@Config(sdk = [34])` for Robolectric.

---
*PR created automatically by Jules for task [18167896034278545625](https://jules.google.com/task/18167896034278545625) started by @HereLiesAz*

## Summary by Sourcery

Disable cleartext network traffic in the Android app and address related test and build issues.

Bug Fixes:
- Prevent the app from initiating cleartext (non-HTTPS) network connections by updating the Android manifest.
- Resolve a Robolectric test failure on SDK 37 by pinning tests to SDK 34.
- Remove an unused import from the Gradle build script to eliminate warnings.