### PR TITLE
Fix build failure and update version

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,8 +7,6 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
 }
 
-import java.io.FileInputStream
-
 val versionProps = Properties()
 val versionPropsFile = rootProject.file("version.properties")
 if (versionPropsFile.exists()) {

--- a/app/src/test/java/com/hereliesaz/ideaz/buildlogic/RemoteBuildManagerTest.kt
+++ b/app/src/test/java/com/hereliesaz/ideaz/buildlogic/RemoteBuildManagerTest.kt
@@ -13,6 +13,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 import retrofit2.Response
 import java.io.File
 import java.io.ByteArrayOutputStream
@@ -20,6 +21,7 @@ import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 
 @RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
 class RemoteBuildManagerTest {
 
     private val context = ApplicationProvider.getApplicationContext<Context>()

--- a/version.properties
+++ b/version.properties
@@ -1,3 +1,3 @@
 major=1
 minor=10
-patch=14
+patch=15


### PR DESCRIPTION
I fixed the build failure caused by duplicate imports in `app/build.gradle.kts`. While verifying the fix, I also encountered and resolved a Robolectric compatibility issue in the test suite that was preventing tests from passing on the current Android SDK 37 target. Finally, I updated the version in `version.properties` as per the project's mandatory workflow.

Fixes #595

---
*PR created automatically by Jules for task [15473522828329108626](https://jules.google.com/task/15473522828329108626) started by @HereLiesAz*

## Summary by Sourcery

Fix build failures and test compatibility issues while updating the patch version.

Bug Fixes:
- Remove a duplicate import from the Android app Gradle build script to resolve a build failure.
- Configure Robolectric tests to run with a compatible SDK level to restore test suite compatibility.

Build:
- Clean up imports in the app Gradle build script to prevent compilation conflicts.

Tests:
- Add Robolectric SDK configuration to RemoteBuildManagerTest to ensure tests run against a supported Android API level.

Chores:
- Bump the application patch version from 1.10.14 to 1.10.15 in version.properties.