### PR TITLE
Fix Build Failure: Missing Imports in app/build.gradle.kts

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,6 @@
+import java.util.Properties
+import java.io.FileInputStream
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.compose)

--- a/version.properties
+++ b/version.properties
@@ -1,3 +1,3 @@
 major=1
 minor=10
-patch=14
+patch=15


### PR DESCRIPTION
The build was failing because `Properties` and `FileInputStream` were used in `app/build.gradle.kts` without being imported. I added the necessary imports at the top of the file. I also incremented the patch version in `version.properties` as per the project's versioning strategy and verified the fix by running a full build and the test suite.

Fixes #599

---
*PR created automatically by Jules for task [16622466504869732841](https://jules.google.com/task/16622466504869732841) started by @HereLiesAz*

## Summary by Sourcery

Fix Gradle build failure by adding missing Java imports and incrementing the application patch version.

Build:
- Add missing Java imports in app/build.gradle.kts to resolve build failures.

Chores:
- Increment patch version in version.properties to 15 following project versioning strategy.