### PR TITLE
Fix build failure due to missing imports in app/build.gradle.kts

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,6 @@
+import java.util.Properties
+import java.io.FileInputStream
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.compose)

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -7,3 +7,6 @@ abandoned-and-now-revived project. It has been superseded.
 **Active phase plan:** [`plans/2026-05-01-phase-0-triage.md`](plans/2026-05-01-phase-0-triage.md)
 
 When Phase 0 completes, this file will point to Phase 1's plan.
+
+## Completed (Triage Phase)
+- Fixed build failure in `app/build.gradle.kts` caused by missing `java.util.Properties` and `java.io.FileInputStream` imports.

--- a/docs/file_descriptions.md
+++ b/docs/file_descriptions.md
@@ -15,7 +15,7 @@
 *   `.gitignore`: Git ignore rules.
 
 ## app/
-*   `build.gradle.kts`: App module build script (includes standard Java imports for versioning logic).
+*   `build.gradle.kts`: App module build script.
 *   `src/main/AndroidManifest.xml`: Application manifest (Permissions, Activities, Services).
 
 ### app/src/main/kotlin/com/hereliesaz/ideaz/

--- a/docs/file_descriptions.md
+++ b/docs/file_descriptions.md
@@ -15,7 +15,7 @@
 *   `.gitignore`: Git ignore rules.
 
 ## app/
-*   `build.gradle.kts`: App module build script.
+*   `build.gradle.kts`: App module build script (includes standard Java imports for versioning logic).
 *   `src/main/AndroidManifest.xml`: Application manifest (Permissions, Activities, Services).
 
 ### app/src/main/kotlin/com/hereliesaz/ideaz/

--- a/version.properties
+++ b/version.properties
@@ -1,3 +1,3 @@
 major=1
 minor=10
-patch=14
+patch=15


### PR DESCRIPTION
Fixed the Gradle build failure by adding the required Java standard library imports to the `app/build.gradle.kts` file. This resolves the 'Unresolved reference' errors for `Properties` and `FileInputStream`. Additionally, the patch version was incremented as per the project's versioning strategy, and the documentation was updated to reflect these changes. All tests and the build itself were verified to pass.

Fixes #598

---
*PR created automatically by Jules for task [1306289142659595669](https://jules.google.com/task/1306289142659595669) started by @HereLiesAz*

## Summary by Sourcery

Fix Gradle build failures by importing missing Java standard library classes and update project metadata accordingly.

Build:
- Add missing java.util.Properties and java.io.FileInputStream imports to app/build.gradle.kts to resolve unresolved reference errors.

Documentation:
- Document the completed triage-phase fix for the Gradle build failure in TODO.md.

Chores:
- Increment the patch version in version.properties from 1.10.14 to 1.10.15.