### PR TITLE
fix(ci): quote \$GITHUB_ENV and use printf for password write

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -78,14 +78,15 @@ jobs:
              echo "Verifying generated keystore..."
              keytool -list -keystore release.keystore -storepass "$KEYSTORE_PASSWORD" > /dev/null
 
-             echo "KEYSTORE_FILE=$(pwd)/release.keystore" >> $GITHUB_ENV
+             echo "KEYSTORE_FILE=$(pwd)/release.keystore" >> "$GITHUB_ENV"
              # Ensure Gradle uses the same password for the key as the store (OpenSSL default behavior)
-             # Using heredoc for safe environment variable export
+             # Using heredoc for safe environment variable export. printf avoids
+             # echo's handling of leading '-' or backslashes in the password.
              DELIM="DELIMITER_${{ github.run_id }}_${{ github.run_attempt }}"
              {
-               echo "KEY_PASSWORD<<${DELIM}"
-               echo "$KEYSTORE_PASSWORD"
-               echo "${DELIM}"
+               printf '%s\n' "KEY_PASSWORD<<${DELIM}"
+               printf '%s\n' "$KEYSTORE_PASSWORD"
+               printf '%s\n' "${DELIM}"
              } >> "$GITHUB_ENV"
           else
              echo "Warning: KEYSTORE_PRIVATE or KEYSTORE_CHAIN not set. Skipping release signing setup."
@@ -204,8 +205,8 @@ jobs:
           # Rename for release
           mv "$APK_ORIGINAL" "$TARGET_NAME"
           
-          echo "TAG_NAME=$TAG_NAME" >> $GITHUB_ENV
-          echo "APK_FILE=$TARGET_NAME" >> $GITHUB_ENV
+          echo "TAG_NAME=$TAG_NAME" >> "$GITHUB_ENV"
+          echo "APK_FILE=$TARGET_NAME" >> "$GITHUB_ENV"
 
       - name: Publish Release
         if: success() && github.event_name == 'push'


### PR DESCRIPTION
Address review feedback:
- Quote \$GITHUB_ENV consistently in all redirections so a (hypothetical) unset or whitespace-containing path can't break word splitting.
- Use printf '%s\n' for the KEY_PASSWORD value so a password starting with '-' or containing backslashes isn't reinterpreted by echo.

## Summary by Sourcery

Improve robustness and safety of GitHub Actions environment variable handling in the build-and-release workflow.

Bug Fixes:
- Prevent potential issues when writing to GITHUB_ENV by consistently quoting the environment file path in redirections.
- Avoid misinterpretation of keystore passwords starting with '-' or containing backslashes when exporting KEY_PASSWORD in the workflow.

CI:
- Harden the build-and-release GitHub Actions workflow by using printf for writing sensitive values and quoting GITHUB_ENV in all exports.