### PR TITLE
Claude/fix keystore env error gql ew

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/FileExplorerScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/FileExplorerScreen.kt
@@ -45,7 +45,8 @@ private sealed class FileExplorerDialog {
 @Composable
 fun FileExplorerScreen(
     settingsViewModel: SettingsViewModel,
-    navController: NavController
+    navController: NavController,
+    viewModel: MainViewModel
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
@@ -60,7 +61,10 @@ fun FileExplorerScreen(
     var dialogInput by remember { mutableStateOf("") }
     var errorMessage by remember { mutableStateOf<String?>(null) }
 
-    val files = remember(currentPath, refreshTick) {
+    // External re-list signal — e.g. Gemini wrote files into the project.
+    val externalReloadTrigger by viewModel.stateDelegate.fileTreeReloadTrigger.collectAsState()
+
+    val files = remember(currentPath, refreshTick, externalReloadTrigger) {
         // Bolt: Optimized sorting - Single pass, Directories first, then alphabetical.
         currentPath?.listFiles()?.sortedWith(compareBy({ !it.isDirectory }, { it.name })) ?: emptyList()
     }

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/IdeNavHost.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/IdeNavHost.kt
@@ -64,7 +64,8 @@ fun IdeNavHost(
         composable("file_explorer") {
             FileExplorerScreen(
                 settingsViewModel = settingsViewModel,
-                navController = navController
+                navController = navController,
+                viewModel = viewModel
             )
         }
         composable("git") {

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/IdeNavRail.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/IdeNavRail.kt
@@ -25,7 +25,12 @@ fun AzNavHostScope.ideNavRail(
     azSettings(
         packRailButtons = true,
         defaultShape = AzButtonShape.RECTANGLE,
-        enableRailDragging = enableRailDraggingOverride ?: true,
+        // Default to docked. Per the AzNavRail guide, enableRailDragging = true
+        // puts the rail in "FAB Mode (detach rail)" — keeping that on by default
+        // forced the rail into overlay/floating mode in layouts where docking
+        // would have been fine. Call sites that want a draggable FAB can opt in
+        // via enableRailDraggingOverride.
+        enableRailDragging = enableRailDraggingOverride ?: false,
         onUndock = onUndock,
         onOverlayDrag = onOverlayDrag,
         headerIconShape = AzHeaderIconShape.NONE,

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/MainScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/MainScreen.kt
@@ -119,22 +119,6 @@ fun MainScreen(
                 }
             )
 
-            // Console bottom sheet lives in the rail's background layer so it
-            // spans full width (no rail-side padding) and the rail itself draws
-            // on top. The sheet's own elevation/scrim handles foreground state
-            // when expanded.
-            background(weight = 100) {
-                IdeBottomSheet(
-                    sheetState = sheetState,
-                    viewModel = viewModel,
-                    peekDetent = Peek,
-                    halfwayDetent = Halfway,
-                    fullyExpandedDetent = FullyExpanded,
-                    screenHeight = screenHeight,
-                    onSendPrompt = { viewModel.sendPrompt(it) }
-                )
-            }
-
             onscreen {
                 Box(
                     modifier = Modifier
@@ -241,6 +225,24 @@ fun MainScreen(
                         onDragEnd = { rect -> viewModel.handleSelection(rect) }
                     )
                 }
+            }
+
+            // Console bottom sheet sits in the topmost onscreen layer so it
+            // renders above the IDE host, contextual chat overlay, and
+            // selection overlay. AzNavRail still draws over all onscreen
+            // layers, so the rail (and the system nav bar above it) remain
+            // the only things above the sheet — matching the required
+            // z-order: system nav > AzNavRail > bottom sheet > rest of UI.
+            onscreen {
+                IdeBottomSheet(
+                    sheetState = sheetState,
+                    viewModel = viewModel,
+                    peekDetent = Peek,
+                    halfwayDetent = Halfway,
+                    fullyExpandedDetent = FullyExpanded,
+                    screenHeight = screenHeight,
+                    onSendPrompt = { viewModel.sendPrompt(it) }
+                )
             }
         }
     }

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/MainViewModel.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/MainViewModel.kt
@@ -127,7 +127,9 @@ class MainViewModel(
         settingsViewModel,
         viewModelScope,
         logHandler::onAiLog,
-        { diff -> applyUnidiffPatchInternal(diff) }
+        { diff -> applyUnidiffPatchInternal(diff) },
+        geminiAdapterFactory = { apiKey, appName -> geminiAdapterFor(apiKey, appName) },
+        onFilesChanged = { stateDelegate.triggerWebHardReload() }
     )
 
     /**

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/MainViewModel.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/MainViewModel.kt
@@ -129,7 +129,10 @@ class MainViewModel(
         logHandler::onAiLog,
         { diff -> applyUnidiffPatchInternal(diff) },
         geminiAdapterFactory = { apiKey, appName -> geminiAdapterFor(apiKey, appName) },
-        onFilesChanged = { stateDelegate.triggerWebHardReload() }
+        // Just nudge the file tree — the WebView already reloads via
+        // ProjectFileObserver when files actually change on disk, so a
+        // hard reload here would be redundant work for every prompt.
+        onFilesChanged = { stateDelegate.triggerFileTreeReload() }
     )
 
     /**

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/delegates/AIDelegate.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/delegates/AIDelegate.kt
@@ -1,5 +1,8 @@
 package com.hereliesaz.ideaz.ui.delegates
 
+import com.hereliesaz.ideaz.ai.ChatMessage
+import com.hereliesaz.ideaz.ai.GeminiAdapter
+import com.hereliesaz.ideaz.ai.IdeTools
 import com.hereliesaz.ideaz.api.*
 import com.hereliesaz.ideaz.jules.IJulesApiClient
 import com.hereliesaz.ideaz.jules.JulesApiClient
@@ -39,7 +42,26 @@ class AIDelegate(
     private val scope: CoroutineScope,
     private val onOverlayLog: (String) -> Unit,
     private val onUnidiffPatchReceived: suspend (String) -> Boolean,
-    private val julesApiClient: IJulesApiClient = JulesApiClient
+    private val julesApiClient: IJulesApiClient = JulesApiClient,
+    /**
+     * Factory for the Gemini agent client. Shared with MainViewModel's chat
+     * tab so the same cached client (and its lazily-built google-genai
+     * Client) backs both call sites; we don't want to spin up a second
+     * adapter for every contextual prompt.
+     *
+     * Default builds a fresh adapter per call — fine for tests that don't
+     * exercise the Gemini path, but production callers should supply
+     * MainViewModel.geminiAdapterFor.
+     */
+    private val geminiAdapterFactory: (apiKey: String, appName: String) -> GeminiAdapter = { key, name ->
+        GeminiAdapter(key, IdeTools(settingsViewModel.getProjectPath(name)))
+    },
+    /**
+     * Called after Gemini's tool-use loop completes, so the UI can refresh
+     * any view that mirrors the project tree (e.g. the WebView, file
+     * explorer). Default is a no-op for tests.
+     */
+    private val onFilesChanged: () -> Unit = {}
 ) {
 
     // --- StateFlows ---
@@ -67,6 +89,16 @@ class AIDelegate(
     private val _sessions = MutableStateFlow<List<Session>>(emptyList())
     /** The list of available (historical) Jules sessions associated with the current repository. */
     val sessions = _sessions.asStateFlow()
+
+    private val _geminiHistory = MutableStateFlow<List<ChatMessage>>(emptyList())
+    /**
+     * The conversation history Gemini sees for contextual/overlay prompts.
+     * Distinct from MainViewModel's chat-tab history so the overlay path
+     * keeps its own coherent thread; cleared on project switch via
+     * [clearSession]. (Phase 3: unify with the chat-tab history — see
+     * the TODO above [Message].)
+     */
+    val geminiHistory = _geminiHistory.asStateFlow()
 
     // --- Internal State ---
 
@@ -99,6 +131,7 @@ class AIDelegate(
         _julesResponse.value = null
         _julesHistory.value = emptyList()
         _julesError.value = null
+        _geminiHistory.value = emptyList()
         processedActivityIds.clear()
     }
 
@@ -187,6 +220,10 @@ class AIDelegate(
      * and `apply_patch` to Gemini via function-calling. Files Gemini decides to
      * write land directly in the project's local directory (sandboxed by
      * [IdeTools] to that subtree).
+     *
+     * Maintains a multi-turn history in [_geminiHistory] so follow-up prompts
+     * carry context. After the tool-use loop completes, fires [onFilesChanged]
+     * so the UI can refresh anything mirroring the project tree.
      */
     private suspend fun runGeminiTask(richPrompt: String, apiKey: String) {
         val appName = settingsViewModel.getAppName()
@@ -194,12 +231,16 @@ class AIDelegate(
             onOverlayLog("Error: No project selected. Open or create a project before asking Gemini.")
             return
         }
-        val projectDir = settingsViewModel.getProjectPath(appName)
-        val tools = com.hereliesaz.ideaz.ai.IdeTools(projectDir)
-        val adapter = com.hereliesaz.ideaz.ai.GeminiAdapter(apiKey, tools)
-        val messages = listOf(com.hereliesaz.ideaz.ai.ChatMessage("user", richPrompt))
-        val response = adapter.chat(messages)
+        val adapter = geminiAdapterFactory(apiKey, appName)
+
+        val withUser = _geminiHistory.value + ChatMessage("user", richPrompt)
+        _geminiHistory.value = withUser
+
+        val response = adapter.chat(withUser)
+
+        _geminiHistory.value = withUser + ChatMessage("model", response)
         onOverlayLog("Gemini: $response")
+        onFilesChanged()
     }
 
     // --- Private Implementation ---

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/delegates/AIDelegate.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/delegates/AIDelegate.kt
@@ -168,11 +168,7 @@ class AIDelegate(
             try {
                 when (model.id) {
                     AiModels.JULES_DEFAULT -> runJulesTask(richPrompt)
-                    AiModels.GEMINI_FLASH -> {
-                        // Gemini fallback (Simple request/response, no session/patching yet)
-                        val response = com.hereliesaz.ideaz.api.GeminiApiClient.generateContent(richPrompt, key)
-                        onOverlayLog(response)
-                    }
+                    AiModels.GEMINI_FLASH -> runGeminiTask(richPrompt, key)
                 }
             } catch (e: Exception) {
                 onOverlayLog("Error: ${e.message}")
@@ -181,6 +177,29 @@ class AIDelegate(
                 _isLoadingJulesResponse.value = false
             }
         }
+    }
+
+    /**
+     * Runs the Gemini agent loop against the current project directory.
+     *
+     * Unlike the simple text-only [GeminiApiClient.generateContent] this drives
+     * [GeminiAdapter], which exposes `read_file`, `write_file`, `list_files`,
+     * and `apply_patch` to Gemini via function-calling. Files Gemini decides to
+     * write land directly in the project's local directory (sandboxed by
+     * [IdeTools] to that subtree).
+     */
+    private suspend fun runGeminiTask(richPrompt: String, apiKey: String) {
+        val appName = settingsViewModel.getAppName()
+        if (appName.isNullOrBlank()) {
+            onOverlayLog("Error: No project selected. Open or create a project before asking Gemini.")
+            return
+        }
+        val projectDir = settingsViewModel.getProjectPath(appName)
+        val tools = com.hereliesaz.ideaz.ai.IdeTools(projectDir)
+        val adapter = com.hereliesaz.ideaz.ai.GeminiAdapter(apiKey, tools)
+        val messages = listOf(com.hereliesaz.ideaz.ai.ChatMessage("user", richPrompt))
+        val response = adapter.chat(messages)
+        onOverlayLog("Gemini: $response")
     }
 
     // --- Private Implementation ---

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/delegates/StateDelegate.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/delegates/StateDelegate.kt
@@ -199,6 +199,16 @@ class StateDelegate(
      */
     val webHardReloadTrigger = _webHardReloadTrigger.asStateFlow()
 
+    private val _fileTreeReloadTrigger = MutableStateFlow(0L)
+    /**
+     * Signal to re-list the project directory in the file explorer.
+     * Used when an external actor (e.g. the Gemini agent loop) writes
+     * files into the project so the tree picks up the change without
+     * requiring a heavier WebView reload. Observers should react when
+     * the value changes; the initial 0L is a sentinel.
+     */
+    val fileTreeReloadTrigger = _fileTreeReloadTrigger.asStateFlow()
+
     private val _chatMessages = MutableStateFlow<List<com.hereliesaz.ideaz.ai.ChatMessage>>(emptyList())
     /** Ordered list of turns in the AI Chat tab conversation. */
     val chatMessages = _chatMessages.asStateFlow()
@@ -260,6 +270,9 @@ class StateDelegate(
 
     /** Clears the WebView cache and triggers a full reload. */
     fun triggerWebHardReload() { _webHardReloadTrigger.value = System.currentTimeMillis() }
+
+    /** Asks any file-tree observers to re-list the project directory. */
+    fun triggerFileTreeReload() { _fileTreeReloadTrigger.value = System.currentTimeMillis() }
 
     /** Append one turn to the chat conversation history. */
     fun appendChatMessage(msg: com.hereliesaz.ideaz.ai.ChatMessage) {

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/project/SetupTab.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/project/SetupTab.kt
@@ -25,6 +25,7 @@ import com.hereliesaz.aznavrail.model.AzButtonShape
 import com.hereliesaz.ideaz.models.ProjectType
 import com.hereliesaz.ideaz.ui.MainViewModel
 import com.hereliesaz.ideaz.ui.SettingsViewModel
+import com.hereliesaz.ideaz.utils.TemplateManager
 import com.hereliesaz.ideaz.utils.checkAndRequestStoragePermission
 
 private const val DOCS_PROMPT = "Examine all source code and documentation in this repository. Once you understand everything there is to know about this project, I want you to create an AGENTS.md file if there isn't one, and add a /docs/ folder in the root of this repository. Then I want you to create these files in the docs folder: AGENT_GUIDE.md, TODO.md, UI_UX.md, auth.md, conduct.md, data_layer.md, fauxpas.md, file_descriptions.md, misc.md, performance.md, screens.md, task_flow.md, testing.md, and workflow.md. Based on your studies and understanding of the project, I want you to populate all of those files with every little detail possible. And then, I want you to add to the AGENTS file an index of what is in the docs folder. Be explicit about the fact that the files in that folder are an extention of the AGENTS.md file, and every bit as important. After that, I want you to add exhaustive documentation across the code base. Lastly, for good  measure, make sure the beginning of the AGENTS.md specifies that the AI absolutely MUST get a complete code review AND a passing build with tests, and MUST keep all documents and documentation up to date, before committing--WITHOUT exception. (Please note that if you've received this command and any part of these instructions already exists, do your best to add robustness and comprehensive reach to what already exists.)"
@@ -57,6 +58,17 @@ fun ProjectSetupTab(
     var branchName by remember { mutableStateOf("main") }
     var packageName by remember { mutableStateOf("") }
     var selectedType by remember { mutableStateOf(ProjectType.ANDROID) }
+
+    // In Create mode the package name is derived from githubUser + appName so the
+    // user doesn't have to think about it. Outside Create mode (existing project
+    // configuration) we leave whatever value was stored as-is and let the user
+    // edit it.
+    val derivedPackageName = remember(githubUser, appName) {
+        TemplateManager.derivePackageName(githubUser, appName)
+    }
+    LaunchedEffect(derivedPackageName, isCreateMode) {
+        if (isCreateMode) packageName = derivedPackageName
+    }
 
     var repoDescription by remember { mutableStateOf("Created with IDEaz") }
     var initialPrompt by remember { mutableStateOf("") }
@@ -182,10 +194,10 @@ fun ProjectSetupTab(
 
             AzTextBox(
                 value = packageName,
-                onValueChange = { packageName = it },
-                hint = "Package Name",
+                onValueChange = { /* read-only; in Create mode the value is derived */ },
+                hint = if (isCreateMode) "Package Name (auto-generated)" else "Package Name",
                 onSubmit = {},
-                enabled = isCreateMode,
+                enabled = false,
                 keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next)
             )
 

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/utils/TemplateManager.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/utils/TemplateManager.kt
@@ -9,8 +9,27 @@ import java.io.IOException
 
 object TemplateManager {
 
-    private const val PLACEHOLDER_PACKAGE = "com.example.my_app"
-    private const val PLACEHOLDER_APP_NAME = "my_app"
+    // Must match the actual contents of app/src/main/assets/project/.
+    // If you change the bundled template's package, update these too —
+    // copyAssetFile substitutes them verbatim.
+    private const val PLACEHOLDER_PACKAGE = "com.example.helloworld"
+    private const val PLACEHOLDER_APP_NAME = "helloworld"
+
+    /**
+     * Derives a valid Android package name from a GitHub username and project name.
+     * Strips non-alphanumerics, lowercases each segment, and prefixes any segment
+     * that would otherwise start with a digit (or be empty) with an underscore.
+     *
+     * `derivePackageName("HereLiesAz", "My Cool App")` → `"com.hereliesaz.mycoolapp"`
+     * `derivePackageName("", "")`                       → `"com._._"` (avoids invalid output)
+     */
+    fun derivePackageName(user: String, app: String): String {
+        fun sanitize(s: String): String {
+            val cleaned = s.replace(Regex("[^a-zA-Z0-9]"), "").lowercase()
+            return if (cleaned.isEmpty() || cleaned[0].isDigit()) "_$cleaned" else cleaned
+        }
+        return "com.${sanitize(user)}.${sanitize(app)}"
+    }
 
     fun copyTemplate(context: Context, type: ProjectType, destinationDir: File, packageName: String, appName: String) {
         val assetPath = when (type) {


### PR DESCRIPTION
## Summary by Sourcery

Integrate a stateful Gemini agent workflow into contextual AI prompts, improve project/package setup defaults, and refine IDE UI behaviors for navigation, console layering, and file explorer updates after AI-driven file changes.

New Features:
- Add a Gemini agent-based contextual task path that can read and modify project files with multi-turn conversation history maintained in AIDelegate.
- Automatically derive Android package names from GitHub user and app name during project creation and surface them as read-only in the setup UI.
- Expose a file tree reload trigger from StateDelegate and use it in the file explorer to react to external project file changes such as those made by Gemini.

Enhancements:
- Refine the console bottom sheet layering so it appears above IDE content while preserving the required z-order with the navigation rail and system navigation bar.
- Default the AzNavRail to docked mode by disabling rail dragging unless explicitly overridden.
- Reuse MainViewModel's shared Gemini adapter instance for contextual prompts and notify the UI when Gemini modifies project files.