### PR TITLE
Claude/fix keystore env error gql ew

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,35 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
-    schedule: 
+  # Android / Kotlin dependencies declared in gradle/libs.versions.toml and
+  # app/build.gradle.kts.
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "gradle"
+    groups:
+      androidx:
+        patterns:
+          - "androidx.*"
+      compose:
+        patterns:
+          - "androidx.compose*"
+          - "androidx.activity:activity-compose"
+          - "androidx.navigation:navigation-compose"
+      kotlin:
+        patterns:
+          - "org.jetbrains.kotlin*"
+          - "org.jetbrains.kotlinx*"
+
+  # GitHub Actions versions referenced in .github/workflows/*.yml.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/delegates/AIDelegate.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/delegates/AIDelegate.kt
@@ -13,6 +13,8 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.updateAndGet
 import kotlinx.coroutines.launch
 
 /**
@@ -233,12 +235,18 @@ class AIDelegate(
         }
         val adapter = geminiAdapterFactory(apiKey, appName)
 
-        val withUser = _geminiHistory.value + ChatMessage("user", richPrompt)
-        _geminiHistory.value = withUser
+        // updateAndGet returns the post-update snapshot so we can hand the
+        // exact history we appended to into chat(). Using atomic update
+        // ops on both sides means a second prompt that lands while
+        // chat() is in flight can't overwrite the user turn we just
+        // recorded — its messages slot in around ours instead of replacing
+        // them. Conversation order across concurrent prompts is therefore
+        // non-deterministic, but no message is lost.
+        val historyForChat = _geminiHistory.updateAndGet { it + ChatMessage("user", richPrompt) }
 
-        val response = adapter.chat(withUser)
+        val response = adapter.chat(historyForChat)
 
-        _geminiHistory.value = withUser + ChatMessage("model", response)
+        _geminiHistory.update { it + ChatMessage("model", response) }
         onOverlayLog("Gemini: $response")
         onFilesChanged()
     }

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/delegates/AIDelegate.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/delegates/AIDelegate.kt
@@ -246,6 +246,30 @@ class AIDelegate(
     // --- Private Implementation ---
 
     /**
+     * Returns the repo's current default branch from GitHub, persisting the
+     * result so the UI catches up. Falls back to the stored value (which
+     * itself defaults to "main") if no token is set or the API call fails —
+     * we'd rather try a slightly stale branch than block the prompt
+     * entirely on a network hiccup.
+     */
+    private suspend fun resolveDefaultBranch(user: String, appName: String): String {
+        val stored = settingsViewModel.getBranchName()
+        val token = settingsViewModel.getGithubToken() ?: return stored
+        return try {
+            val remote = GitHubApiClient.createService(token)
+                .getRepo(user, appName)
+                .defaultBranch
+                ?: return stored
+            if (remote != stored) {
+                settingsViewModel.saveBranchName(remote)
+            }
+            remote
+        } catch (e: Exception) {
+            stored
+        }
+    }
+
+    /**
      * Handles the interaction with the Jules API.
      *
      * **Logic:**
@@ -256,7 +280,14 @@ class AIDelegate(
     private suspend fun runJulesTask(promptText: String) {
         val appName = settingsViewModel.getAppName() ?: "project"
         val user = settingsViewModel.getGithubUser() ?: "user"
-        val branch = settingsViewModel.getBranchName()
+
+        // Refresh the branch from GitHub before handing off to Jules. The
+        // stored value defaults to "main" but real repos may use "master"
+        // or anything else; if we send the wrong name Jules' clone fails
+        // with "Remote branch <X> not found in upstream origin" and the
+        // session never starts. Fall back to whatever we have locally on
+        // any API failure (offline, missing token, rate-limited).
+        val branch = resolveDefaultBranch(user, appName)
 
         // Construct SourceContext for the API
         val currentSourceContext = SourceContext(

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/project/SetupTab.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/project/SetupTab.kt
@@ -194,10 +194,16 @@ fun ProjectSetupTab(
 
             AzTextBox(
                 value = packageName,
-                onValueChange = { /* read-only; in Create mode the value is derived */ },
+                // Editable in Configure mode so an existing project can be
+                // corrected if the stored package drifted from the source
+                // (e.g. someone moved the manifest namespace by hand).
+                // In Create mode the field is driven by the derivedPackageName
+                // LaunchedEffect above, so user edits would just be
+                // immediately overwritten — keep it read-only there.
+                onValueChange = { if (!isCreateMode) packageName = it },
                 hint = if (isCreateMode) "Package Name (auto-generated)" else "Package Name",
                 onSubmit = {},
-                enabled = false,
+                enabled = !isCreateMode,
                 keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next)
             )
 

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/utils/BackupManager.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/utils/BackupManager.kt
@@ -50,13 +50,18 @@ object BackupManager {
         return withContext(Dispatchers.IO) {
             try {
                 val filesDir = context.filesDir
+                // Trailing separator closes the prefix-attack hole where an
+                // entry like ../files-evil/x would otherwise pass a bare
+                // startsWith(filesDir.canonicalPath) check.
+                val canonicalDestPrefix = filesDir.canonicalPath + File.separator
                 val `in` = context.contentResolver.openInputStream(uri) ?: return@withContext false
                 `in`.use { inputStream ->
                     ZipInputStream(inputStream).use { zipIn ->
                         var entry = zipIn.nextEntry
                         while (entry != null) {
                             val filePath = File(filesDir, entry.name)
-                            if (!filePath.canonicalPath.startsWith(filesDir.canonicalPath)) {
+                            val canonical = filePath.canonicalPath
+                            if (canonical != filesDir.canonicalPath && !canonical.startsWith(canonicalDestPrefix)) {
                                 throw IOException("Zip entry is outside of the target dir: ${entry.name}")
                             }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,9 +11,15 @@ pluginManagement {
         gradlePluginPortal()
     }
 }
-plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
-}
+// foojay-resolver-convention was removed: its transitive Netty/BouncyCastle/
+// Jackson/Commons-Lang/HttpClient surface accounted for all 16 build-time
+// dependency CVEs flagged on this project, and upstream is already at the
+// latest 1.0.0 release with no fixed-in version to bump to.
+//
+// Gradle still resolves the jvmToolchain(21) request in app/build.gradle.kts,
+// just from locally-installed JDKs (CI installs one via actions/setup-java).
+// If a fresh dev machine doesn't have JDK 21, the build now fails fast
+// instead of auto-downloading via Foojay — install Temurin 21 once.
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {


### PR DESCRIPTION
## Summary by Sourcery

Improve AI prompt handling, repository branch resolution, dependency management, and project safety/UX.

New Features:
- Allow editing the package name when configuring an existing project while keeping it auto-generated and read-only during project creation.

Bug Fixes:
- Prevent concurrent Gemini chat prompts from overwriting each other by atomically updating conversation history.
- Resolve the correct default GitHub branch before running Jules tasks to avoid clone failures when the stored branch name is stale or incorrect.
- Harden backup restoration against zip-slip style path traversal by ensuring extracted files remain within the app files directory.

Enhancements:
- Persist and reuse the resolved default GitHub branch name from GitHub to keep configuration in sync with the remote repository.
- Remove the foojay toolchain resolver plugin to eliminate build-time dependency CVEs while relying on locally installed JDKs.

Build:
- Configure Dependabot for Gradle dependencies and GitHub Actions with weekly update checks and grouped dependency rules.