### PR TITLE
Fix blank web/React preview (asset-loader prefix); Console log lines per detent

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/IdeBottomSheet.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/IdeBottomSheet.kt
@@ -44,7 +44,6 @@ fun IdeBottomSheet(
     onSendPrompt: (String) -> Unit
 ) {
     val detent by controller.detentFlow.collectAsState()
-    if (detent == AzSheetDetent.HIDDEN) return
 
     // Collect specific log streams directly to avoid filtering on every recomposition.
     val logMessages by viewModel.filteredLog.collectAsState(initial = emptyList()) // "All"
@@ -97,7 +96,10 @@ fun IdeBottomSheet(
                 .background(MaterialTheme.colorScheme.background)
         ) {
             when (detent) {
-                AzSheetDetent.PEEK -> PeekTicker(baseMessages)
+                // HIDDEN still shows the latest single line in its touch-target
+                // strip; PEEK shows the most recent handful.
+                AzSheetDetent.HIDDEN -> LogTicker(baseMessages, maxLines = 1)
+                AzSheetDetent.PEEK -> LogTicker(baseMessages, maxLines = 5)
                 AzSheetDetent.HALF, AzSheetDetent.FULL -> ExpandedContent(
                     selectedTab = selectedTab,
                     onSelectTab = { selectedTab = it },
@@ -110,25 +112,36 @@ fun IdeBottomSheet(
                     viewModel = viewModel,
                     screenHeight = screenHeight,
                 )
-                AzSheetDetent.HIDDEN -> Unit
             }
         }
     }
 }
 
+/**
+ * Bottom-anchored ticker showing the most recent [maxLines] log lines. Used for
+ * the collapsed sheet detents: 1 line at HIDDEN, a few at PEEK. Fills the strip
+ * and clips older lines if the detent is shorter than [maxLines].
+ */
 @Composable
-private fun PeekTicker(messages: List<String>) {
-    val latest = messages.lastOrNull().orEmpty()
-    Text(
-        text = latest,
-        style = MaterialTheme.typography.bodySmall,
-        color = MaterialTheme.colorScheme.onSurface,
-        maxLines = 1,
-        overflow = TextOverflow.Ellipsis,
+private fun LogTicker(messages: List<String>, maxLines: Int) {
+    val recent = messages.takeLast(maxLines)
+    Column(
         modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 12.dp)
-    )
+            .fillMaxSize()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.Bottom
+    ) {
+        recent.forEach { line ->
+            Text(
+                text = line,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+    }
 }
 
 @Composable

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/web/WebProjectHost.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/web/WebProjectHost.kt
@@ -155,6 +155,22 @@ fun WebProjectHost(
                     bridgeJs?.let { js -> view?.evaluateJavascript(js, null) }
                 }
 
+                // Surface HTTP errors (e.g. 404 for a missing asset/module served
+                // by WebProjectPathHandler). These don't trigger onReceivedError,
+                // so without this a missing file fails silently.
+                override fun onReceivedHttpError(
+                    view: WebView?,
+                    request: WebResourceRequest?,
+                    errorResponse: WebResourceResponse?
+                ) {
+                    val msg = "[WEB] HTTP ${errorResponse?.statusCode} for ${request?.url}"
+                    val intent = Intent(ACTION_AI_LOG).apply {
+                        putExtra(EXTRA_MESSAGE, msg)
+                        setPackage(context.packageName)
+                    }
+                    context.sendBroadcast(intent)
+                }
+
                 override fun onReceivedError(
                     view: WebView?,
                     request: WebResourceRequest?,

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/web/WebProjectPathHandler.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/web/WebProjectPathHandler.kt
@@ -40,12 +40,16 @@ class WebProjectPathHandler(
 ) : WebViewAssetLoader.PathHandler {
 
     override fun handle(path: String): WebResourceResponse? {
-        if (path.startsWith(RUNTIME_PREFIX)) {
-            return serveRuntimeAsset(path.removePrefix(RUNTIME_PREFIX))
+        // WebViewAssetLoader strips the registered "/" prefix before calling us,
+        // so paths arrive WITHOUT a leading slash ("index.html", "src/main.jsx",
+        // "__ideaz__/babel.min.js"). Tolerate an optional leading slash too.
+        val rel = path.removePrefix("/")
+        if (rel.startsWith(RUNTIME_DIR)) {
+            return serveRuntimeAsset(rel.removePrefix(RUNTIME_DIR))
         }
 
         val projectDir = projectDirProvider() ?: return null
-        val relative = path.trimStart('/').ifEmpty { "index.html" }
+        val relative = rel.ifEmpty { "index.html" }
 
         val root = projectDir.canonicalFile
         val target = File(root, relative).canonicalFile
@@ -54,7 +58,11 @@ class WebProjectPathHandler(
         }
 
         val file = if (target.isDirectory) File(target, "index.html") else target
-        if (!file.isFile) return notFound()
+        if (!file.isFile) {
+            // A missing entry document otherwise renders as a blank white page
+            // with no explanation; serve a diagnostic instead.
+            return if (relative == "index.html") diagnosticIndexPage(projectDir) else notFound()
+        }
 
         val ext = file.extension.lowercase()
         if (ext == "html" || ext == "htm") {
@@ -72,6 +80,24 @@ class WebProjectPathHandler(
         val html = file.readText()
         val body = if (needsRuntime(html)) injectRuntime(html) else html
         return response("text/html", ByteArrayInputStream(body.toByteArray(Charsets.UTF_8)))
+    }
+
+    private fun diagnosticIndexPage(projectDir: File): WebResourceResponse {
+        fun esc(s: String) = s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+        val contents = projectDir.listFiles()?.joinToString(", ") { esc(it.name) }
+            ?.ifEmpty { "(empty)" } ?: "(unreadable)"
+        val html = """
+            <!doctype html><html><head><meta charset="utf-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1">
+            <style>body{font-family:system-ui,sans-serif;padding:1.25rem;line-height:1.5;color:#222}code{background:#0001;padding:.1em .3em;border-radius:3px}</style>
+            </head><body>
+            <h2>No <code>index.html</code> in this project</h2>
+            <p>IDEaz served <code>${esc(projectDir.name)}</code> but found no <code>index.html</code> at its root, so there is nothing to display.</p>
+            <p>If this project was generated from a template repository, that repo may be empty or not yet populated (or not marked as a template).</p>
+            <p><strong>Project root contains:</strong> $contents</p>
+            </body></html>
+        """.trimIndent()
+        return response("text/html", ByteArrayInputStream(html.toByteArray(Charsets.UTF_8)))
     }
 
     private fun serveRuntimeAsset(name: String): WebResourceResponse {
@@ -97,7 +123,10 @@ class WebProjectPathHandler(
     )
 
     companion object {
+        /** URL prefix for runtime assets (used in injected HTML). */
         const val RUNTIME_PREFIX = "/__ideaz__/"
+        /** Same prefix as seen by [handle] after WebViewAssetLoader strips "/". */
+        private const val RUNTIME_DIR = "__ideaz__/"
         private const val RUNTIME_ASSET_DIR = "ideaz-runtime"
 
         /**


### PR DESCRIPTION
## Summary

Fixes the blank web/React preview and improves the Console log display.

### Blank preview (root cause)
`WebViewAssetLoader` strips the registered `/` prefix before calling `PathHandler.handle()`, so paths arrived **without** a leading slash (`__ideaz__/babel.min.js`, not `/__ideaz__/…`). The runtime check used the leading-slash form, so every `/__ideaz__/*` request (Babel, React UMD, the loader, the shims) 404'd — React then rendered into an empty `#root`, i.e. a blank white page. Now matched against the slash-stripped form.

### Diagnostics (so "blank" is never silent)
- When a project has no `index.html` at its root (e.g. an empty generated-from-template repo), serve a small explanatory page instead of a blank 404.
- Override `onReceivedHttpError` so 404s for missing assets/modules show up in the `[WEB]` console logs.

### Console bottom sheet
- **HIDDEN** detent → shows the latest **1** log line (previously nothing).
- **PEEK** detent → shows the last **5** log lines (previously a single ticker line).

## Test plan
- [ ] **CI build** (no Android SDK in this session).
- [ ] **On-device:** open a React project → confirm it renders (no blank page) and `/__ideaz__/*` no longer 404s; open a project with no `index.html` → confirm the diagnostic page; drag the Console sheet → 1 line at HIDDEN, ~5 at PEEK.

https://claude.ai/code/session_013JezXQ5noQWxdYuxZNWWKv

---
_Generated by [Claude Code](https://claude.ai/code/session_013JezXQ5noQWxdYuxZNWWKv)_