### PR TITLE
Make crash reports surface the real exception, not the synthetic placeholder

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/ideaz/utils/GithubIssueReporter.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/utils/GithubIssueReporter.kt
@@ -39,10 +39,17 @@ object GithubIssueReporter {
      * 2. Falls back to opening a browser with pre-filled data.
      */
     suspend fun reportError(context: Context, token: String?, error: Throwable, contextMessage: String, logContent: String? = null): String {
-        val stackTrace = error.stackTraceToString()
+        // The real crash/error is in logContent when provided (callers pass a
+        // synthetic Throwable plus the actual stack/log). Prefer it; the head of
+        // a stack trace (exception + app frames) is the useful part, so we never
+        // tail-truncate it below.
+        val sanitizedPrimary = sanitizeContent(logContent ?: error.stackTraceToString())
+        val firstLine = sanitizedPrimary.lineSequence()
+            .map { it.trim() }.firstOrNull { it.isNotBlank() } ?: "Unknown"
 
-        // Deduplication Logic
-        val errorSignature = "$contextMessage|${error::class.simpleName}|${error.message}"
+        // Deduplicate on the real error (not the synthetic Throwable, which would
+        // collapse every crash to one hash and suppress later, different crashes).
+        val errorSignature = "$contextMessage|$firstLine"
         val errorHash = errorSignature.hashCode()
         val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
         val timestampKey = "$KEY_PREFIX_TIMESTAMP$errorHash"
@@ -69,35 +76,23 @@ object GithubIssueReporter {
             return "Skipped (Duplicate report within 24h) [Hash: $errorHash, PID: $pid]"
         }
 
-        val sanitizedLogContent = logContent?.let { sanitizeContent(it) }
-        val sanitizedStackTrace = sanitizeContent(stackTrace)
-
-        val logSection = if (sanitizedLogContent != null) {
-            """
-
-            **Log Output:**
-            ```
-            ${sanitizedLogContent.takeLast(2000)}
-            ```
-            """.trimIndent()
-        } else ""
-
-        // Truncate for safety (API limit is roughly 65k chars, URL limit 2k-8k)
+        // Truncate for safety (API limit ~65k chars, URL limit 2k-8k). Keep the
+        // head — the exception and app frames live at the top of a stack trace.
         val bodyContent = """
             **Context:** $contextMessage
             **Device:** ${Build.MANUFACTURER} ${Build.MODEL} (SDK ${Build.VERSION.SDK_INT})
             **App Version:** 1.0 (Development)
-            
+
             **Stack Trace:**
             ```
-            ${sanitizedStackTrace.take(3000)}
+            ${sanitizedPrimary.take(4000)}
             ```
-            $logSection
 
-            Please debug this, Jules. Make sure you get both a correct code review and a passing build with tests before submitting your solution. 
+            Please debug this, Jules. Make sure you get both a correct code review and a passing build with tests before submitting your solution.
         """.trimIndent()
 
-        val titleContent = "IDE Error: ${error::class.simpleName} - ${error.message?.take(50) ?: "Unknown"}"
+        val label = error.message?.takeIf { it.isNotBlank() } ?: (error::class.simpleName ?: "Error")
+        val titleContent = "IDE Error: $label — ${firstLine.take(80)}"
 
         // 1. Try API Reporting
         if (!token.isNullOrBlank()) {


### PR DESCRIPTION
## Summary

The crash report I was sent showed `java.lang.Throwable: CRASH at CrashReportingService.kt:118` and a truncated, exception-less "Log Output" — because the reporter discards the real crash. Both callers (`CrashReportingService`, build-failure path in `MainViewModel`) pass a **synthetic** `Throwable` plus the actual stack/log in `logContent`. The reporter:

1. **`logContent.takeLast(2000)`** kept the *bottom* of the trace (framework input-loop frames) and dropped the *top*, where the exception type and app frames are.
2. Built the **title and "Stack Trace" section from the synthetic `Throwable`** → `Throwable - CRASH` / `CrashReportingService.kt:118`.
3. **Deduped on the synthetic `Throwable`**, so every fatal crash hashed identically and the 24h cooldown suppressed later, *different* crashes.

Now it prefers `logContent`, keeps the **head** of the trace, and derives the title + dedup key from the real first line. Crash reports (and build-failure reports) become actually diagnosable.

## Test plan
- [ ] CI build (no Android SDK in session).
- [ ] Trigger a crash → GitHub issue title is `IDE Error: <label> — <real exception line>` and the Stack Trace block starts with the exception + app frames; two different crashes within 24h both report.

https://claude.ai/code/session_013JezXQ5noQWxdYuxZNWWKv

---
_Generated by [Claude Code](https://claude.ai/code/session_013JezXQ5noQWxdYuxZNWWKv)_