### PR TITLE
Highlight the active nav-rail item with a distinct accent color

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/IdeNavRail.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/IdeNavRail.kt
@@ -50,6 +50,9 @@ fun AzNavHostScope.ideNavRail(
     azTheme(
         defaultShape = AzButtonShape.RECTANGLE,
         headerIconShape = AzHeaderIconShape.NONE,
+        // The app palette is monochrome, so the selected/active rail item was
+        // indistinguishable from the rest. Give it a distinct accent.
+        activeColor = Color(0xFFFFC107),
         translucentBackground = Color.Black.copy(alpha = 0.5f),
     )
 


### PR DESCRIPTION
## Summary

The nav rail's selected/active item was indistinguishable from inactive items: the app palette is monochrome (white/black/grey) and `azTheme` had no `activeColor`, so the active item rendered the same as the rest.

Set `activeColor` to an amber accent (`#FFC107`) so the current screen's rail item stands out.

> The exact color is a one-liner in `IdeNavRail.kt` — easy to swap if you'd prefer a different accent (teal, the Material purple already in `colors.xml`, etc.).

## Test plan
- [ ] CI build.
- [ ] On-device: navigate between rail destinations (Project / Git / Files / Settings) and confirm the active one is amber while the others stay default.

https://claude.ai/code/session_013JezXQ5noQWxdYuxZNWWKv

---
_Generated by [Claude Code](https://claude.ai/code/session_013JezXQ5noQWxdYuxZNWWKv)_