### PR TITLE
Fix unresolved reference in GithubIssueReporter

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/ideaz/utils/GithubIssueReporter.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/utils/GithubIssueReporter.kt
@@ -89,7 +89,7 @@ object GithubIssueReporter {
 
             **Stack Trace:**
             ```
-            ${sanitizedPrimary.take(4000)}
+            ${sanitizeContent(stackTrace).take(4000)}
             ```
 
             Please debug this, Jules. Make sure you get both a correct code review and a passing build with tests before submitting your solution.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -15,3 +15,4 @@ When Phase 0 completes, this file will point to Phase 1's plan.
 - Fixed compilation error in `AiChatTab.kt` by updating it to pass `MainViewModel` to `ContextlessChatInput`.
 - Fixed CodeQL high priority "Zip Slip" vulnerability in `BackupManager.kt` and `RemoteBuildManager.kt`.
 - Improved crash reporting by allowing explicit stack trace strings in `GithubIssueReporter`, fixing an issue where fatal crashes had their stack traces truncated or lost.
+- Fixed a compilation error in `GithubIssueReporter.kt` caused by an unresolved reference `sanitizedPrimary`.

--- a/version.properties
+++ b/version.properties
@@ -1,5 +1,5 @@
-#Tue May 26 18:55:02 UTC 2026
-build=30
+#Thu May 28 15:48:30 UTC 2026
+build=33
 major=1
 minor=11
-patch=7
+patch=8


### PR DESCRIPTION
Resolved a build failure in the crash reporting utility by fixing an 'Unresolved reference' compilation error. The fix ensures that error reports sent to GitHub correctly include a sanitized stack trace. verified with a successful compilation of the app module.

Fixes #654

---
*PR created automatically by Jules for task [16127594467831916560](https://jules.google.com/task/16127594467831916560) started by @HereLiesAz*

## Summary by Sourcery

Fix crash reporting compilation error and update version metadata.

Bug Fixes:
- Resolve unresolved reference in GithubIssueReporter to restore successful builds.

Build:
- Increment app version patch and build numbers.

Documentation:
- Document the GithubIssueReporter compilation fix in the TODO changelog.