### PR TITLE
Fix compilation error: unresolved reference 'sanitizedPrimary' in GithubIssueReporter

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/ideaz/utils/GithubIssueReporter.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/utils/GithubIssueReporter.kt
@@ -82,7 +82,7 @@ object GithubIssueReporter {
 
         // Truncate for safety (API limit ~65k chars, URL limit 2k-8k). Keep the
         // head — the exception and app frames live at the top of a stack trace.
-        val sanitizedPrimary = sanitizeContent(stackTrace)
+        val sanitizedPrimary = sanitizeContent(stackTrace.take(4000))
         val bodyContent = """
             **Context:** $contextMessage
             **Device:** ${Build.MANUFACTURER} ${Build.MODEL} (SDK ${Build.VERSION.SDK_INT})

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/utils/GithubIssueReporter.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/utils/GithubIssueReporter.kt
@@ -82,6 +82,7 @@ object GithubIssueReporter {
 
         // Truncate for safety (API limit ~65k chars, URL limit 2k-8k). Keep the
         // head — the exception and app frames live at the top of a stack trace.
+        val sanitizedPrimary = sanitizeContent(stackTrace)
         val bodyContent = """
             **Context:** $contextMessage
             **Device:** ${Build.MANUFACTURER} ${Build.MODEL} (SDK ${Build.VERSION.SDK_INT})

--- a/version.properties
+++ b/version.properties
@@ -1,5 +1,5 @@
-#Tue May 26 18:55:02 UTC 2026
-build=30
+#Thu May 28 16:08:13 UTC 2026
+build=36
 major=1
 minor=11
-patch=7
+patch=8


### PR DESCRIPTION
This PR fixes a Kotlin compilation error in `GithubIssueReporter.kt` where the variable `sanitizedPrimary` was used without being defined. I have added the definition by calling `sanitizeContent(stackTrace)` and also incremented the patch version in `version.properties` as per the project's guidelines.

The fix was verified by running `./gradlew :app:compileReleaseKotlin`, which now succeeds. Temporary build artifacts were removed before submission.

Fixes #655

---
*PR created automatically by Jules for task [10620144497464683280](https://jules.google.com/task/10620144497464683280) started by @HereLiesAz*

## Summary by Sourcery

Fix Github issue reporting stack trace handling and bump build version.

Bug Fixes:
- Define and use a sanitized stack trace snippet when constructing Github issue report bodies to resolve a compilation error.

Build:
- Increment the build number in version.properties.