### PR TITLE
security: pin patched versions of Dependabot-flagged transitive deps

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,39 @@
+name: Dependency Submission
+
+# Submits the FULLY RESOLVED Gradle dependency graph (all configurations, incl. the
+# test/lint-tooling classpaths) to GitHub so Dependabot evaluates the versions we
+# actually resolve. Without this, GitHub keeps re-using a stale, one-off snapshot and
+# never sees the patched versions pinned in app/build.gradle.kts — which is why the
+# Netty/BouncyCastle/Jackson/Commons-Lang alerts stayed open after the fixes landed.
+#
+# On push to the default branch, GitHub auto-dismisses alerts whose vulnerable version
+# is no longer present in the submitted graph.
+
+on:
+  push:
+    branches: [ "master" ]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: dependency-submission-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-submission:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # foojay-resolver was removed, so the jvmToolchain(21) request must be satisfied
+      # by an installed JDK rather than auto-downloaded.
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Generate and submit dependency graph
+        uses: gradle/actions/dependency-submission@v6

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -128,6 +128,40 @@ configurations.all {
     resolutionStrategy {
         force("androidx.concurrent:concurrent-futures:1.3.0")
         force("androidx.concurrent:concurrent-futures-ktx:1.3.0")
+
+        // Security: pin transitive libraries flagged by Dependabot to patched versions.
+        // Only Jackson actually ships in the APK (pulled by google-genai into
+        // releaseRuntimeClasspath); the rest live solely in test / lint-tooling
+        // classpaths — BouncyCastle via Robolectric, commons-lang3 (and BouncyCastle)
+        // via AGP's androidLintTool, Netty via grpc-netty on the unit-test classpath.
+        // They never reach a device, but they stay in the dependency graph, so pin
+        // them everywhere to clear the alerts. (The earlier foojay-resolver removal in
+        // settings.gradle.kts did NOT address these — that plugin was misattributed as
+        // the source; these come from real app dependencies.)
+        force(
+            "org.bouncycastle:bcprov-jdk18on:1.84",
+            "org.bouncycastle:bcpkix-jdk18on:1.84",
+            "org.bouncycastle:bcutil-jdk18on:1.84",
+            "org.apache.commons:commons-lang3:3.18.0",
+        )
+        eachDependency {
+            when {
+                // Jackson arrives as core/databind/annotations + datatype modules and a
+                // BOM; pin the whole family to a patched 2.18.x. Use 2.18.7 — the java8
+                // datatype modules (jackson-datatype-jdk8/jsr310) stop there, while
+                // core/databind go to 2.18.8, so 2.18.7 is the latest version every
+                // module publishes (and still > the 2.18.6 fix).
+                requested.group.startsWith("com.fasterxml.jackson") ->
+                    useVersion("2.18.7")
+                // Netty arrives as ~11 modules via grpc-netty (unit-test only). Pin the
+                // io.netty group to the latest patched 4.1.x — staying off 4.2.x, which
+                // grpc-netty does not support. (netty-tcnative tracks a separate scheme.)
+                requested.group == "io.netty" &&
+                    requested.name.startsWith("netty-") &&
+                    !requested.name.startsWith("netty-tcnative") ->
+                    useVersion("4.1.134.Final")
+            }
+        }
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,10 +11,13 @@ pluginManagement {
         gradlePluginPortal()
     }
 }
-// foojay-resolver-convention was removed: its transitive Netty/BouncyCastle/
-// Jackson/Commons-Lang/HttpClient surface accounted for all 16 build-time
-// dependency CVEs flagged on this project, and upstream is already at the
-// latest 1.0.0 release with no fixed-in version to bump to.
+// foojay-resolver-convention was removed. (An earlier changelog claimed this cleared
+// the Netty/BouncyCastle/Jackson/Commons-Lang/HttpClient dependency CVEs — that was a
+// misdiagnosis. Those libraries are NOT transitive deps of this settings-classpath
+// plugin; they come from real app dependencies — google-genai (Jackson at runtime;
+// Netty via grpc-netty on the unit-test classpath), Robolectric (BouncyCastle), and
+// AGP's androidLintTool (commons-lang3 + BouncyCastle) — and are now pinned to patched
+// versions via resolutionStrategy in app/build.gradle.kts.)
 //
 // Gradle still resolves the jvmToolchain(21) request in app/build.gradle.kts,
 // just from locally-installed JDKs (CI installs one via actions/setup-java).

--- a/version.properties
+++ b/version.properties
@@ -2,4 +2,4 @@
 build=36
 major=1
 minor=11
-patch=8
+patch=9


### PR DESCRIPTION
## What

Pins the transitive libraries behind the 17 open Dependabot alerts to patched versions via `resolutionStrategy` in `app/build.gradle.kts`, and adds a dependency-graph submission workflow so GitHub actually re-evaluates the resolved graph.

| Library | Forced to | Where it lives |
|---|---|---|
| Jackson family | **2.18.7** | `releaseRuntimeClasspath` (ships in APK, via `google-genai`) |
| `io.netty:netty-*` | **4.1.134.Final** | `testRuntimeOnly` (via `grpc-netty`, unit tests only) |
| `bcprov`/`bcpkix`/`bcutil-jdk18on` | **1.84** | test (Robolectric) + `androidLintTool` |
| `org.apache.commons:commons-lang3` | **3.18.0** | `androidLintTool` (AGP lint) |

The `force` even overrides Robolectric's strict `bcprov 1.81` constraint. Of the 17, only Jackson actually ships in the APK; the rest are confined to test/lint-tooling classpaths and never reach a device.

## Why the alerts never closed before

The earlier "remove foojay-resolver to clear the CVEs" change was a **misdiagnosis** — foojay is a settings-classpath plugin and its libraries never appear in `:app:dependencies`. The flagged modules come from real app dependencies (`google-genai`, Robolectric, AGP lint). The alerts persisted because GitHub's dependency graph is a **stale one-off snapshot** with no workflow refreshing it. `.github/workflows/dependency-submission.yml` fixes that: on merge to `master` it submits the patched resolved graph and GitHub auto-dismisses the alerts. This PR also corrects the misleading comment in `settings.gradle.kts`.

## Verification

- `./gradlew build` → **BUILD SUCCESSFUL** (compile + unit tests + lint + assemble) with all four forces applied
- `:app:dependencies` across all configs → **0 vulnerable resolved versions remain**
- `:app:assembleRelease` → **BUILD SUCCESSFUL**, release APK produced (Jackson 2.18.7 shipping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Pin vulnerable transitive dependencies to patched versions and ensure GitHub Dependabot evaluates the updated resolved dependency graph.

Bug Fixes:
- Force patched versions of Jackson, Netty, BouncyCastle, and commons-lang3 across all Gradle configurations to address Dependabot-reported vulnerabilities.

Enhancements:
- Clarify settings.gradle.kts comments about the removal of foojay-resolver and correct the earlier misattribution of CVE sources.
- Bump the application patch version in version.properties.

CI:
- Add a dependency submission GitHub Actions workflow to publish the fully resolved Gradle dependency graph on pushes to master.