### PR TITLE
Force secure versions on JGit's vulnerable transitive deps (close 5 Dependabot alerts)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -132,6 +132,25 @@ configurations.all {
 }
 
 dependencies {
+    // Force secure versions on JGit's vulnerable transitive deps (Dependabot
+    // alerts #26/#27/#29 Bouncy Castle, #30 Apache HttpClient, #31 commons-lang3).
+    // Constraints set the version without adding the dep; Gradle applies them
+    // only when the transitive resolution actually pulls the artifact.
+    constraints {
+        implementation(libs.bouncycastle.bcprov) {
+            because("CVE timing channel + LDAP injection (Dependabot #29, #27)")
+        }
+        implementation(libs.bouncycastle.bcpkix) {
+            because("Broken/risky cryptographic algorithm (Dependabot #26)")
+        }
+        implementation(libs.commons.lang3) {
+            because("Uncontrolled recursion CVE (Dependabot #31)")
+        }
+        implementation(libs.apache.httpclient) {
+            because("XSS in Apache HttpClient (Dependabot #30)")
+        }
+    }
+
     implementation(libs.sora.editor)
     implementation(libs.sora.language.textmate)
     implementation(libs.org.eclipse.jgit)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,12 @@ appcompat = "1.7.1"
 webkit = "1.16.0"
 aicore = "0.0.1-exp02"
 
+# Security-bumped versions for JGit's vulnerable transitive deps (Dependabot #26,
+# #27, #29 Bouncy Castle; #30 Apache HttpClient XSS; #31 commons-lang3 recursion).
+bouncycastle = "1.80"
+commonsLang3 = "3.18.0"
+apacheHttpclient = "4.5.14"
+
 [libraries]
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
 androidx-webkit = { group = "androidx.webkit", name = "webkit", version.ref = "webkit" }
@@ -81,6 +87,12 @@ haze = { module = "dev.chrisbanes.haze:haze", version.ref = "haze" }
 okhttp-logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "loggingInterceptor" }
 mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "mockitoKotlin" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
+
+# Security constraints (see version refs above for CVE context).
+bouncycastle-bcprov = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncycastle" }
+bouncycastle-bcpkix = { module = "org.bouncycastle:bcpkix-jdk18on", version.ref = "bouncycastle" }
+commons-lang3 = { module = "org.apache.commons:commons-lang3", version.ref = "commonsLang3" }
+apache-httpclient = { module = "org.apache.httpcomponents:httpclient", version.ref = "apacheHttpclient" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary

Closes five Dependabot alerts — all caused by JGit 7.6's transitive deps. Adds Gradle **constraints** so the transitive resolution picks safe versions without touching the direct deps (constraints are a no-op if the artifact later drops out of the tree).

| Alert | Lib | Bumped to |
| --- | --- | --- |
| #29 (High — Covert Timing Channel) | `org.bouncycastle:bcprov-jdk18on` | 1.80 |
| #27 (Mod — LDAP injection) | `org.bouncycastle:bcprov-jdk18on` | 1.80 |
| #26 (Mod — Broken crypto algorithm) | `org.bouncycastle:bcpkix-jdk18on` | 1.80 |
| #30 (Mod — XSS in Apache HttpClient) | `org.apache.httpcomponents:httpclient` | 4.5.14 |
| #31 (Mod — Uncontrolled recursion) | `org.apache.commons:commons-lang3` | 3.18.0 |

All four POMs verified present on Maven Central.

## Test plan
- [ ] CI build resolves the constrained versions and the app still builds.
- [ ] Dependabot rescan closes #26, #27, #29, #30, #31.

https://claude.ai/code/session_013JezXQ5noQWxdYuxZNWWKv

---
_Generated by [Claude Code](https://claude.ai/code/session_013JezXQ5noQWxdYuxZNWWKv)_