### PR TITLE
Audit remediation: resource leaks, error-handling, correctness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ If a doc and the design doc disagree, the design doc wins.
 ## Critical Known Issues / Discrepancies
 
 *   **`RepoDelegate.uploadProjectSecrets` is a no-op stub.** Lazysodium was removed in Phase 0; the sealed-box encryption needed to push GitHub Actions secrets has no replacement yet. Phase 2 must restore this before Actions-based workflows can consume device-side credentials. See `docs/plans/phase-0-followups.md`.
-*   **WebView `file://` URI exposure.** Phase 0 / Task 10 left `WebSettings.allowFileAccessFromFileURLs` and `allowUniversalAccessFromFileURLs` set with `@Suppress("DEPRECATION")`. They are real cross-origin file-read / universal-XSS hazards. Phase 1's `WebViewAssetLoader` migration (to `https://appassets.androidplatform.net`) must delete both flags. See `docs/plans/phase-0-followups.md`.
+*   **WebView `file://` URI exposure — RESOLVED (Phase 1).** The `WebViewAssetLoader` migration to `https://appassets.androidplatform.net` is complete. `WebProjectHost` now sets `allowFileAccess = false` / `allowContentAccess = false`, and the deprecated `allowFileAccessFromFileURLs` / `allowUniversalAccessFromFileURLs` flags have been removed (see `WebProjectHost.kt`). `SourceContextHelper` additionally enforces project-directory containment on the JS-bridge `__source:` tag.
 
 ## Documentation Index
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,9 +13,9 @@ if (versionPropsFile.exists()) {
     versionPropsFile.inputStream().use { versionProps.load(it) }
 }
 
-val major = versionProps.getProperty("major").toInt()
-val minor = versionProps.getProperty("minor").toInt()
-val patch = versionProps.getProperty("patch").toInt()
+val major = versionProps.getProperty("major", "1").toInt()
+val minor = versionProps.getProperty("minor", "0").toInt()
+val patch = versionProps.getProperty("patch", "0").toInt()
 val buildNumber = versionProps.getProperty("build", "0").toInt() + 1
 
 extensions.configure<com.android.build.api.dsl.ApplicationExtension> {

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ai/OpenAiCompatibleAdapter.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ai/OpenAiCompatibleAdapter.kt
@@ -213,7 +213,9 @@ private fun AiToolSpec.toOpenAiTool(): JsonElement = buildJsonObject {
  */
 private fun parseToolArgs(raw: String): Map<String, String?> {
     if (raw.isBlank()) return emptyMap()
-    val element = runCatching { OpenAiCompatibleAdapter.JSON.parseToJsonElement(raw) }.getOrNull()
+    val element = runCatching { OpenAiCompatibleAdapter.JSON.parseToJsonElement(raw) }
+        .onFailure { android.util.Log.w("OpenAiCompatibleAdapter", "Malformed tool-call arguments JSON; dispatching with no args", it) }
+        .getOrNull()
         ?: return emptyMap()
     val obj = element as? JsonObject ?: return emptyMap()
     return obj.entries.associate { (k, v) ->

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/api/AuthInterceptor.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/api/AuthInterceptor.kt
@@ -12,7 +12,9 @@ object AuthInterceptor : Interceptor {
         val originalRequest = chain.request()
         val builder = originalRequest.newBuilder()
 
-        apiKey?.let {
+        // Only attach the header when we actually have a key. A blank key would
+        // produce "X-Goog-Api-Key: " and a confusing 400 instead of a clear 401.
+        apiKey?.takeIf { it.isNotBlank() }?.let {
             builder.header("X-Goog-Api-Key", it)
         }
 

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/api/GeminiApiClient.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/api/GeminiApiClient.kt
@@ -27,7 +27,6 @@ object GeminiApiClient {
     suspend fun generateContent(prompt: String, apiKey: String): String =
         withContext(Dispatchers.IO) {
             try {
-                val client = Client.builder().apiKey(apiKey).build()
                 val parts = mutableListOf<Part>()
 
                 if (prompt.contains(IMAGE_TAG)) {
@@ -57,8 +56,12 @@ object GeminiApiClient {
                 }
 
                 val content = Content.builder().role("user").parts(parts).build()
-                val response = client.models.generateContent(MODEL, listOf(content), null)
-                response.text() ?: "Error: Received an empty response from the API."
+                // Client is AutoCloseable and holds an HTTP client; close it after the
+                // one-shot call so repeated overlay calls don't leak connections/threads.
+                Client.builder().apiKey(apiKey).build().use { client ->
+                    val response = client.models.generateContent(MODEL, listOf(content), null)
+                    response.text() ?: "Error: Received an empty response from the API."
+                }
             } catch (e: Exception) {
                 Log.e(TAG, "Gemini API call failed", e)
                 "Error: ${e.message}"

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/api/RetryInterceptor.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/api/RetryInterceptor.kt
@@ -4,6 +4,8 @@ import android.util.Log
 import okhttp3.Interceptor
 import okhttp3.Response
 import java.io.IOException
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
 import java.util.concurrent.TimeUnit
 
 class RetryInterceptor(
@@ -28,8 +30,14 @@ class RetryInterceptor(
                     return response
                 }
 
-                Log.w(TAG, "Request failed with code ${response.code}. Closing and retrying...")
-                response.close() // Close previous response before retrying
+                // Retryable status. Only close (and discard) this response if we are
+                // going to retry. On the final attempt we must fall through and return
+                // it OPEN — closing it here would hand the caller a closed body that
+                // throws IllegalStateException when read.
+                if (attempt < maxRetries) {
+                    Log.w(TAG, "Request failed with code ${response.code}. Closing and retrying...")
+                    response.close()
+                }
 
             } catch (e: IOException) {
                 Log.w(TAG, "Request failed with exception: ${e.message}. Retrying...", e)
@@ -65,9 +73,17 @@ class RetryInterceptor(
             try {
                 // Try seconds
                 val seconds = retryAfter.toLong()
-                return seconds * 1000
+                return (seconds * 1000).coerceAtMost(maxDelayMs)
             } catch (e: NumberFormatException) {
-                // Ignore date format for now
+                // Not numeric seconds — try the RFC 7231 HTTP-date form
+                // (e.g. "Wed, 21 Oct 2025 07:28:00 GMT").
+                val untilMs = runCatching {
+                    ZonedDateTime.parse(retryAfter, DateTimeFormatter.RFC_1123_DATE_TIME)
+                        .toInstant().toEpochMilli() - System.currentTimeMillis()
+                }.getOrNull()
+                if (untilMs != null && untilMs > 0) {
+                    return untilMs.coerceAtMost(maxDelayMs)
+                }
             }
         }
 

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/buildlogic/RemoteBuildManager.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/buildlogic/RemoteBuildManager.kt
@@ -187,7 +187,11 @@ class RemoteBuildManager(
             val failed = jobs.find { it.conclusion == "failure" } ?: return
             val resp = api.getJobLogs(user, repo, failed.id)
             if (resp.isSuccessful) {
-                onLog("Remote Build Log:\n${resp.body()?.string().orEmpty()}\n")
+                // ResponseBody.string() consumes and closes the body; use{} makes the
+                // close explicit and also covers the error/empty paths.
+                resp.body()?.use { body ->
+                    onLog("Remote Build Log:\n${body.string()}\n")
+                }
             }
         } catch (e: Exception) {
             onLog("Could not retrieve remote logs: ${e.message}\n")

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/git/GitManager.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/git/GitManager.kt
@@ -259,29 +259,31 @@ class GitManager(private val projectDir: File) {
 
                 if (branchId == null || baseId == null) return@use false
 
-                val walk = org.eclipse.jgit.revwalk.RevWalk(repository)
-                val branchCommit = walk.parseCommit(branchId)
-                val baseCommit = walk.parseCommit(baseId)
+                org.eclipse.jgit.revwalk.RevWalk(repository).use { walk ->
+                    val branchCommit = walk.parseCommit(branchId)
+                    val baseCommit = walk.parseCommit(baseId)
 
-                // Check if branch has commits not in base
-                // count(base..branch) > 0
-                walk.setRevFilter(org.eclipse.jgit.revwalk.filter.RevFilter.MERGE_BASE)
-                walk.markStart(branchCommit)
-                walk.markStart(baseCommit)
-                val mergeBase = walk.next()
+                    // Check if branch has commits not in base
+                    // count(base..branch) > 0
+                    walk.setRevFilter(org.eclipse.jgit.revwalk.filter.RevFilter.MERGE_BASE)
+                    walk.markStart(branchCommit)
+                    walk.markStart(baseCommit)
+                    val mergeBase = walk.next()
 
-                // Reset walk for counting
-                walk.reset()
-                walk.setRevFilter(org.eclipse.jgit.revwalk.filter.RevFilter.ALL)
-                walk.markStart(branchCommit)
-                if (mergeBase != null) {
-                    walk.markUninteresting(mergeBase)
+                    // Reset walk for counting
+                    walk.reset()
+                    walk.setRevFilter(org.eclipse.jgit.revwalk.filter.RevFilter.ALL)
+                    walk.markStart(branchCommit)
+                    if (mergeBase != null) {
+                        walk.markUninteresting(mergeBase)
+                    }
+
+                    // Simple check: does the walk return anything?
+                    walk.iterator().hasNext()
                 }
-
-                // Simple check: does the walk return anything?
-                walk.iterator().hasNext()
             }
         } catch (e: Exception) {
+            android.util.Log.w("GitManager", "isAhead($branch, $base) failed", e)
             false
         }
     }

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/services/ScreenshotService.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/services/ScreenshotService.kt
@@ -161,6 +161,7 @@ class ScreenshotService : Service() {
                 // Crop and draw (Draw skipped as UIInspectionService handles highlight)
                 // val finalBitmap = processBitmap(bitmap, rect)
                 val base64String = bitmapToBase64(bitmap)
+                bitmap.recycle()
 
                 // Send broadcast back to MainViewModel
                 val resultIntent = Intent("com.hereliesaz.ideaz.SCREENSHOT_TAKEN").apply {

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/MainViewModel.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/MainViewModel.kt
@@ -323,7 +323,6 @@ class MainViewModel(
     val isLoadingJulesResponse = aiDelegate.isLoadingJulesResponse
     val julesError = aiDelegate.julesError
     val currentJulesSessionId = aiDelegate.currentJulesSessionId
-    val showCancelDialog = MutableStateFlow(false).asStateFlow()
 
     // --- Artifact Check State ---
 
@@ -1146,35 +1145,36 @@ class MainViewModel(
 
     private suspend fun downloadFile(urlStr: String, destination: File, onProgress: (Int) -> Unit): Boolean {
         return withContext(Dispatchers.IO) {
+            var connection: HttpURLConnection? = null
             try {
                 val url = URL(urlStr)
-                val connection = url.openConnection() as HttpURLConnection
-                connection.connect()
+                connection = (url.openConnection() as HttpURLConnection).also { it.connect() }
 
                 if (connection.responseCode != HttpURLConnection.HTTP_OK) {
                     return@withContext false
                 }
 
                 val fileLength = connection.contentLength
-                val input = connection.inputStream
-                val output = FileOutputStream(destination)
-
-                val data = ByteArray(4096)
-                var total: Long = 0
-                var count: Int
-                while (input.read(data).also { count = it } != -1) {
-                    total += count
-                    if (fileLength > 0) {
-                        onProgress((total * 100 / fileLength).toInt())
+                connection.inputStream.use { input ->
+                    FileOutputStream(destination).use { output ->
+                        val data = ByteArray(4096)
+                        var total: Long = 0
+                        var count: Int
+                        while (input.read(data).also { count = it } != -1) {
+                            total += count
+                            if (fileLength > 0) {
+                                onProgress((total * 100 / fileLength).toInt())
+                            }
+                            output.write(data, 0, count)
+                        }
                     }
-                    output.write(data, 0, count)
                 }
-                output.close()
-                input.close()
                 true
             } catch (e: Exception) {
                 android.util.Log.w("MainViewModel", "Operation failed", e)
                 false
+            } finally {
+                connection?.disconnect()
             }
         }
     }

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/delegates/AIDelegate.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/delegates/AIDelegate.kt
@@ -424,7 +424,10 @@ class AIDelegate(
             activities.forEach { activity ->
                 // Only process each activity once
                 if (activity.id !in processedActivityIds) {
-                    var activityProcessed = false
+                    // Mark processed up-front. An activity record is immutable, so
+                    // re-fetching it next poll and re-applying a patch that already
+                    // failed only spams the user and wastes work — attempt each once.
+                    processedActivityIds.add(activity.id)
 
                     activity.artifacts?.forEach { artifact ->
                         val patch = artifact.changeSet?.gitPatch?.unidiffPatch
@@ -436,14 +439,10 @@ class AIDelegate(
 
                             if (success) {
                                 onOverlayLog("Patch applied.")
-                                activityProcessed = true
                             } else {
                                 onOverlayLog("Patch failed to apply.")
                             }
                         }
-                    }
-                    if (activityProcessed) {
-                        processedActivityIds.add(activity.id)
                     }
                 }
             }

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/delegates/SystemEventDelegate.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/delegates/SystemEventDelegate.kt
@@ -132,7 +132,14 @@ class SystemEventDelegate(
      * Must be called when the ViewModel is cleared.
      */
     fun cleanup() {
-        try { application.unregisterReceiver(promptReceiver) } catch (e: Exception) {}
-        try { application.unregisterReceiver(visibilityReceiver) } catch (e: Exception) {}
+        // A receiver that was never registered (or already unregistered) throws
+        // IllegalArgumentException; that's expected here, so log at debug rather
+        // than swallowing silently.
+        try { application.unregisterReceiver(promptReceiver) } catch (e: Exception) {
+            android.util.Log.d("SystemEventDelegate", "promptReceiver not registered", e)
+        }
+        try { application.unregisterReceiver(visibilityReceiver) } catch (e: Exception) {
+            android.util.Log.d("SystemEventDelegate", "visibilityReceiver not registered", e)
+        }
     }
 }

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/delegates/UpdateDelegate.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/delegates/UpdateDelegate.kt
@@ -184,25 +184,27 @@ class UpdateDelegate(
      */
     private suspend fun downloadFile(urlStr: String, fileName: String): File? {
         return withContext(Dispatchers.IO) {
+            var connection: HttpURLConnection? = null
             try {
                 val url = URL(urlStr)
-                val connection = url.openConnection() as HttpURLConnection
-                connection.connect()
+                connection = (url.openConnection() as HttpURLConnection).also { it.connect() }
 
                 if (connection.responseCode != HttpURLConnection.HTTP_OK) {
                     return@withContext null
                 }
 
                 val file = File(application.filesDir, fileName)
-                val input = connection.inputStream
-                val output = FileOutputStream(file)
-                input.copyTo(output)
-                output.close()
-                input.close()
+                connection.inputStream.use { input ->
+                    FileOutputStream(file).use { output ->
+                        input.copyTo(output)
+                    }
+                }
                 file
             } catch (e: Exception) {
                 android.util.Log.w("UpdateDelegate", "Update operation failed", e)
                 null
+            } finally {
+                connection?.disconnect()
             }
         }
     }

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/web/WebProjectHost.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/web/WebProjectHost.kt
@@ -122,6 +122,11 @@ fun WebProjectHost(
                 safeBrowsingEnabled = true
             }
 
+            // Trust boundary: these interfaces are only safe because this WebView
+            // exclusively loads app-served content from the WebViewAssetLoader origin
+            // (https://appassets.androidplatform.net). Never load remote/untrusted URLs
+            // here. resourceId from onInspectResult is path-validated downstream in
+            // SourceContextHelper before any file access.
             addJavascriptInterface(IdeazJsInterface(context), "Ideaz")
             addJavascriptInterface(
                 WebViewBridge { json -> scope.launch { currentOnElementContext(json) } },

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/web/WebProjectPathHandler.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/web/WebProjectPathHandler.kt
@@ -84,6 +84,7 @@ class WebProjectPathHandler(
 
     private fun diagnosticIndexPage(projectDir: File): WebResourceResponse {
         fun esc(s: String) = s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+            .replace("\"", "&quot;").replace("'", "&#39;")
         val contents = projectDir.listFiles()?.joinToString(", ") { esc(it.name) }
             ?.ifEmpty { "(empty)" } ?: "(unreadable)"
         val html = """

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/utils/ApkInstaller.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/utils/ApkInstaller.kt
@@ -13,66 +13,48 @@ import android.net.Uri
 object ApkInstaller {
 
     fun installApk(context: Context, apkPath: String) {
+        val file = File(apkPath)
+        if (!file.exists()) return
+
         val packageInstaller = context.packageManager.packageInstaller
         val params = PackageInstaller.SessionParams(PackageInstaller.SessionParams.MODE_FULL_INSTALL)
         val sessionId = packageInstaller.createSession(params)
-        val session = packageInstaller.openSession(sessionId)
-
-        val file = File(apkPath)
-        if (!file.exists()) {
-            session.close()
-            return
+        packageInstaller.openSession(sessionId).use { session ->
+            file.inputStream().use { inputStream ->
+                session.openWrite("IDEazIDE", 0, file.length()).use { outputStream ->
+                    inputStream.copyTo(outputStream)
+                    session.fsync(outputStream)
+                }
+            }
+            session.commit(buildInstallIntentSender(context, sessionId))
         }
-
-        val inputStream = file.inputStream()
-        val outputStream = session.openWrite("IDEazIDE", 0, file.length())
-
-        inputStream.copyTo(outputStream)
-        session.fsync(outputStream)
-        outputStream.close()
-        inputStream.close()
-
-        val intent = Intent(context, MainActivity::class.java).apply {
-            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        }
-        
-        val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            PendingIntent.FLAG_MUTABLE
-        } else {
-            0
-        }
-
-        val pendingIntent = PendingIntent.getActivity(context, sessionId, intent, flags)
-        session.commit(pendingIntent.intentSender)
-        session.close()
     }
 
     fun installApk(context: Context, uri: android.net.Uri) {
         val packageInstaller = context.packageManager.packageInstaller
         val params = PackageInstaller.SessionParams(PackageInstaller.SessionParams.MODE_FULL_INSTALL)
         val sessionId = packageInstaller.createSession(params)
-        val session = packageInstaller.openSession(sessionId)
+        packageInstaller.openSession(sessionId).use { session ->
+            val input = context.contentResolver.openInputStream(uri) ?: return
+            input.use { inputStream ->
+                session.openWrite("IDEazIDE_uri", 0, -1).use { outputStream -> // size -1 if unknown
+                    inputStream.copyTo(outputStream)
+                    session.fsync(outputStream)
+                }
+            }
+            session.commit(buildInstallIntentSender(context, sessionId))
+        }
+    }
 
-        val inputStream = context.contentResolver.openInputStream(uri) ?: return
-        val outputStream = session.openWrite("IDEazIDE_uri", 0, -1) // size -1 if unknown
-
-        inputStream.copyTo(outputStream)
-        session.fsync(outputStream)
-        outputStream.close()
-        inputStream.close()
-
+    private fun buildInstallIntentSender(context: Context, sessionId: Int): android.content.IntentSender {
         val intent = Intent(context, MainActivity::class.java).apply {
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         }
-
         val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             PendingIntent.FLAG_MUTABLE
         } else {
             0
         }
-
-        val pendingIntent = PendingIntent.getActivity(context, sessionId, intent, flags)
-        session.commit(pendingIntent.intentSender)
-        session.close()
+        return PendingIntent.getActivity(context, sessionId, intent, flags).intentSender
     }
 }

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/utils/ErrorCollector.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/utils/ErrorCollector.kt
@@ -46,18 +46,19 @@ object ErrorCollector {
     }
 
     fun getAndClear(): String? {
-        if (pendingErrors.isEmpty()) return null
+        // Snapshot, then remove exactly the drained items rather than clear()ing the
+        // whole list. An error reported concurrently (after the snapshot) then survives
+        // to the next drain instead of being silently dropped.
+        val drained = pendingErrors.toList()
+        if (drained.isEmpty()) return null
+        pendingErrors.removeAll(drained)
 
-        val allErrors = StringBuilder()
-        // Drain the list
-        val iterator = pendingErrors.iterator()
-        while (iterator.hasNext()) {
-            allErrors.appendLine(iterator.next())
-            allErrors.appendLine("---")
+        return buildString {
+            drained.forEach {
+                appendLine(it)
+                appendLine("---")
+            }
         }
-        pendingErrors.clear()
-
-        return allErrors.toString()
     }
 
     private fun isIgnored(message: String): Boolean {

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/utils/ProcessExecutor.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/utils/ProcessExecutor.kt
@@ -7,8 +7,9 @@ data class ProcessResult(val exitCode: Int, val output: String)
 
 object ProcessExecutor {
     fun execute(command: List<String>): ProcessResult {
+        var process: Process? = null
         return try {
-            val process = ProcessBuilder(command)
+            process = ProcessBuilder(command)
                 .redirectErrorStream(true)
                 .start()
 
@@ -23,6 +24,8 @@ object ProcessExecutor {
         } catch (e: Exception) {
             android.util.Log.w("ProcessExecutor", "Process invocation failed", e)
             ProcessResult(-1, e.message ?: "Unknown error")
+        } finally {
+            process?.destroy()
         }
     }
 
@@ -31,8 +34,9 @@ object ProcessExecutor {
         onOutputLine: (String) -> Unit,
         onCompletion: (Int) -> Unit
     ) {
+        var process: Process? = null
         try {
-            val process = ProcessBuilder(command)
+            process = ProcessBuilder(command)
                 .redirectErrorStream(true)
                 .start()
 
@@ -45,6 +49,8 @@ object ProcessExecutor {
             android.util.Log.w("ProcessExecutor", "Process invocation failed", e)
             onOutputLine("Error: ${e.message ?: "Unknown error"}")
             onCompletion(-1)
+        } finally {
+            process?.destroy()
         }
     }
 
@@ -52,8 +58,9 @@ object ProcessExecutor {
         command: List<String>,
         onOutputLine: (String) -> Unit
     ): ProcessResult {
+        var process: Process? = null
         return try {
-            val process = ProcessBuilder(command)
+            process = ProcessBuilder(command)
                 .redirectErrorStream(true)
                 .start()
 
@@ -73,6 +80,8 @@ object ProcessExecutor {
             val msg = e.message ?: "Unknown error"
             onOutputLine("Error: $msg")
             ProcessResult(-1, msg)
+        } finally {
+            process?.destroy()
         }
     }
 }

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/utils/ProjectConfigManager.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/utils/ProjectConfigManager.kt
@@ -120,11 +120,11 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build Release APK
-      run: ./gradlew assembleDebug # Should be assembleRelease in real scenario
+      run: ./gradlew assembleRelease
     - name: Create Release
       uses: softprops/action-gh-release@v2
       with:
-        files: app/build/outputs/apk/debug/app-debug.apk
+        files: app/build/outputs/apk/release/*.apk
 """.trimIndent()
 
     private val WEB_CI_PAGES_YML = """
@@ -505,7 +505,7 @@ jobs:
 val versionProps = Properties()
 val versionPropsFile = rootProject.file("version.properties")
 if (versionPropsFile.exists()) {
-    versionProps.load(FileInputStream(versionPropsFile))
+    FileInputStream(versionPropsFile).use { versionProps.load(it) }
 }
 
 val major = versionProps.getProperty("major", "1").toInt()
@@ -560,7 +560,7 @@ val buildNumber = System.getenv("BUILD_NUMBER")?.toIntOrNull() ?: 1
 def versionProps = new Properties()
 def versionPropsFile = rootProject.file("version.properties")
 if (versionPropsFile.exists()) {
-    versionProps.load(new FileInputStream(versionPropsFile))
+    versionPropsFile.withInputStream { stream -> versionProps.load(stream) }
 }
 
 def major = versionProps.getProperty("major", "1").toInteger()

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/utils/ProjectInitializer.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/utils/ProjectInitializer.kt
@@ -55,9 +55,18 @@ object ProjectInitializer {
             val repoName = settingsViewModel.getAppName() ?: "Unknown"
             val source = "sources/github/$user/$repoName"
 
-            secretsContent = secretsContent.replace("const val API_KEY = \"\"", "const val API_KEY = \"$apiKey\"")
-            secretsContent = secretsContent.replace("const val GITHUB_USER = \"Unknown\"", "const val GITHUB_USER = \"$user\"")
-            secretsContent = secretsContent.replace("const val REPO_SOURCE = \"sources/github/Unknown/Unknown\"", "const val REPO_SOURCE = \"$source\"")
+            // Replace placeholders, warning loudly if the template text has drifted
+            // (a silent no-op would ship a project with empty/default secrets).
+            fun replaceOrWarn(content: String, target: String, replacement: String): String {
+                if (!content.contains(target)) {
+                    Log.w(TAG, "Secrets.kt template drift — placeholder not found: \"$target\"")
+                    return content
+                }
+                return content.replace(target, replacement)
+            }
+            secretsContent = replaceOrWarn(secretsContent, "const val API_KEY = \"\"", "const val API_KEY = \"$apiKey\"")
+            secretsContent = replaceOrWarn(secretsContent, "const val GITHUB_USER = \"Unknown\"", "const val GITHUB_USER = \"$user\"")
+            secretsContent = replaceOrWarn(secretsContent, "const val REPO_SOURCE = \"sources/github/Unknown/Unknown\"", "const val REPO_SOURCE = \"$source\"")
 
             val secretsFile = File(targetUtilsDir, "Secrets.kt")
             secretsFile.writeText(secretsContent)

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/utils/SourceContextHelper.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/utils/SourceContextHelper.kt
@@ -40,9 +40,16 @@ object SourceContextHelper {
             val lineStr = content.substring(lastColonIndex + 1)
             val lineNumber = lineStr.toIntOrNull() ?: 0
 
-            // Resolve relative path against projectDir
-            val filePath = File(projectDir, fileName).absolutePath
-            val file = File(filePath)
+            // Resolve relative path against projectDir, then enforce containment.
+            // The tag originates from the in-WebView inspect bridge, so a crafted
+            // value (e.g. "../../secret") must not be allowed to read outside the
+            // project directory.
+            val projectRoot = projectDir.canonicalFile
+            val file = File(projectDir, fileName).canonicalFile
+            if (!file.toPath().startsWith(projectRoot.toPath())) {
+                return ContextResult("", lineNumber, "", true, "Source path escapes project directory")
+            }
+            val filePath = file.absolutePath
             if (!file.exists()) {
                 return ContextResult(filePath, lineNumber, "", true, "Source file not found: $filePath")
             }

--- a/app/src/test/java/com/hereliesaz/ideaz/api/RetryInterceptorTest.kt
+++ b/app/src/test/java/com/hereliesaz/ideaz/api/RetryInterceptorTest.kt
@@ -1,0 +1,79 @@
+package com.hereliesaz.ideaz.api
+
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class RetryInterceptorTest {
+
+    private lateinit var server: MockWebServer
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    private fun client(maxRetries: Int) = OkHttpClient.Builder()
+        .addInterceptor(RetryInterceptor(maxRetries = maxRetries, initialDelayMs = 1, maxDelayMs = 5))
+        .build()
+
+    @Test
+    fun exhaustedRetries_returnReadableResponse() {
+        // maxRetries = 2 -> 3 attempts; every one is a retryable 503.
+        repeat(3) {
+            server.enqueue(MockResponse().setResponseCode(503).setBody("rate limited"))
+        }
+
+        val response = client(maxRetries = 2)
+            .newCall(Request.Builder().url(server.url("/")).build())
+            .execute()
+
+        // Regression: on exhausted retries the final response must still be OPEN.
+        // Previously it was close()d inside the loop before being returned, so
+        // reading the body threw IllegalStateException("closed").
+        assertEquals(503, response.code)
+        assertEquals("rate limited", response.body.string())
+        assertEquals(3, server.requestCount)
+        response.close()
+    }
+
+    @Test
+    fun retryableThenSuccess_returnsSuccess() {
+        server.enqueue(MockResponse().setResponseCode(503).setBody("try again"))
+        server.enqueue(MockResponse().setResponseCode(200).setBody("ok"))
+
+        val response = client(maxRetries = 3)
+            .newCall(Request.Builder().url(server.url("/")).build())
+            .execute()
+
+        assertEquals(200, response.code)
+        assertEquals("ok", response.body.string())
+        assertEquals(2, server.requestCount)
+        response.close()
+    }
+
+    @Test
+    fun nonRetryableStatus_returnedImmediately() {
+        server.enqueue(MockResponse().setResponseCode(404).setBody("nope"))
+
+        val response = client(maxRetries = 3)
+            .newCall(Request.Builder().url(server.url("/")).build())
+            .execute()
+
+        assertEquals(404, response.code)
+        assertEquals("nope", response.body.string())
+        assertEquals(1, server.requestCount)
+        response.close()
+    }
+}

--- a/app/src/test/java/com/hereliesaz/ideaz/utils/SourceContextHelperTest.kt
+++ b/app/src/test/java/com/hereliesaz/ideaz/utils/SourceContextHelperTest.kt
@@ -48,6 +48,23 @@ class SourceContextHelperTest {
     }
 
     @Test
+    fun resolveContext_pathTraversal_isRejected() {
+        // The __source: tag originates from the in-WebView inspect bridge, so a
+        // crafted "../" path must not be allowed to read outside the project dir.
+        val parent = tempFolder.newFolder("workspace")
+        val projectDir = File(parent, "project").apply { mkdirs() }
+        // A file that exists OUTSIDE the project (a sibling under the workspace).
+        File(parent, "secret.txt").writeText("top secret")
+
+        val resourceId = "__source:../secret.txt:1__"
+        val result = SourceContextHelper.resolveContext(resourceId, projectDir)
+
+        assertEquals(true, result.isError)
+        assertTrue(result.errorMessage?.contains("escapes project directory") == true)
+        assertEquals("", result.snippet)
+    }
+
+    @Test
     fun resolveContext_androidId_degradesGracefully() {
         // The on-device source-map generator was removed in Phase 0 (Task 6),
         // so any non-__source__ id (e.g., a plain Android resource id) now

--- a/docs/plans/phase-0-followups.md
+++ b/docs/plans/phase-0-followups.md
@@ -45,6 +45,14 @@ test repo's secret store, which a hand-pushed workflow successfully reads back.
 
 ## 2. Phase 1 — `WebViewAssetLoader` migration (security + deprecation)
 
+> **STATUS: RESOLVED.** The migration landed: `WebProjectHost` serves content via
+> `WebViewAssetLoader` at `https://appassets.androidplatform.net/`, sets
+> `allowFileAccess = false` / `allowContentAccess = false`, and no longer references
+> `allowFileAccessFromFileURLs` / `allowUniversalAccessFromFileURLs` (the
+> `@Suppress("DEPRECATION")` is gone). `SourceContextHelper` enforces project-directory
+> containment on the `__source:` JS-bridge tag. Item 6 below (source-map regeneration)
+> remains future work. The original write-up is kept for history.
+
 **Where:** `app/src/main/kotlin/com/hereliesaz/ideaz/ui/web/WebProjectHost.kt:55-63`,
 plus `IdeazAccessibilityService.kt:150-154`.
 

--- a/version.properties
+++ b/version.properties
@@ -1,5 +1,5 @@
-#Thu May 28 16:08:13 UTC 2026
-build=36
+#Fri Jun 05 06:02:41 CDT 2026
+build=39
 major=1
 minor=11
-patch=9
+patch=10


### PR DESCRIPTION
Full-codebase audit + remediation of 27 verified findings.

## Highlights
- **Resource leaks** (use{}/finally): downloadFile (MainViewModel, UpdateDelegate), GitManager.isAhead RevWalk, ProcessExecutor, ApkInstaller, GeminiApiClient, RemoteBuildManager.getJobLogs, ScreenshotService bitmap.
- **Correctness**: RetryInterceptor no longer returns a *closed* response on exhausted retries (+ honors HTTP-date Retry-After); AIDelegate stops re-applying failed patches every poll; dead `showCancelDialog` removed; SourceContextHelper enforces project-dir containment; release workflow builds `assembleRelease`.
- **Hardening**: blank-API-key guard, swallowed-exception logging, atomic ErrorCollector drain, template-drift warning, version-parse defaults, HTML quote-escaping.
- **Docs**: WebView `file://` exposure marked RESOLVED in AGENTS.md + phase-0-followups.

## Verified
`:app:assembleDebug` passes; relevant unit classes pass with 0 failures (RetryInterceptor [new], SourceContextHelper [+traversal test], AIDelegate, RemoteBuildManager, SettingsViewModel, SystemEventDelegate, CrashReportingService).

Two audit findings were confirmed **false positives** and intentionally left as-is (OpenAI body-read is correct on OkHttp 5; BouncyCastle toml already pins the patched 1.84).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Audit and remediate resource leaks, error-handling issues, and security/correctness problems across networking, Git, process execution, WebView, and build/versioning paths.

Bug Fixes:
- Ensure APK installation, HTTP downloads, process execution, and HTTP client usage close resources reliably to prevent leaks.
- Fix RetryInterceptor to return an open response after final retry and to honor both numeric and HTTP-date Retry-After headers within a bounded delay.
- Prevent SourceContextHelper from reading files outside the project directory and add a regression test for path traversal.
- Stop AIDelegate from re-processing failed activities on every poll by marking them processed after the first attempt.
- Make SystemEventDelegate cleanup log unexpected unregister errors instead of silently swallowing them.
- Guard AuthInterceptor against sending a blank API key header that would cause confusing API errors.
- Recycle screenshots' bitmaps after encoding to base64 to avoid memory leaks.
- Avoid dropping concurrently added errors by making ErrorCollector drains snapshot-based and atomic.
- Fix RemoteBuildManager job log retrieval to close response bodies correctly and avoid leaks.

Enhancements:
- Refine ApkInstaller to share intent-sender construction, validate file existence early, and use scoped streams and sessions.
- Improve GitManager.isAhead logging and resource safety by using try-with-resources RevWalk and warning on failures.
- Add logging when OpenAiCompatibleAdapter receives malformed tool-call JSON instead of silently ignoring parse failures.
- Harden ProjectInitializer secrets substitution by warning on template drift instead of failing silently.
- Clarify WebProjectHost WebView trust boundaries and SourceContextHelper’s path validation in code comments.
- Escape additional HTML characters in WebProjectPathHandler diagnostic output to reduce XSS risk.
- Default app version components when version.properties is missing and ensure Gradle scripts load properties via safe, closed streams.

Build:
- Update generated GitHub Actions release workflow template to build assembleRelease and publish release APK artifacts instead of debug builds.

Documentation:
- Mark the WebView file:// exposure issue as resolved in AGENTS.md and phase-0 followups, documenting the WebViewAssetLoader migration and strengthened source-path containment.

Tests:
- Add RetryInterceptor tests to cover exhausted retries, retryable-to-success flows, and non-retryable statuses.
- Extend SourceContextHelper tests to verify path traversal attempts are rejected with an error and no snippet.