### PR TITLE
fix(ui): restore intended in-app FAB mode for the nav rail

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/IdeNavRail.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/IdeNavRail.kt
@@ -50,19 +50,15 @@ fun AzNavHostScope.ideNavRail(
     azTheme(
         defaultShape = AzButtonShape.RECTANGLE,
         headerIconShape = AzHeaderIconShape.NONE,
-        // The app palette is monochrome, so the selected/active rail item was
-        // indistinguishable from the rest. Give it a distinct accent.
-        activeColor = Color(0xFFFFC107),
         translucentBackground = Color.Black.copy(alpha = 0.5f),
     )
 
     azAdvanced(
-        // Default to docked. Per the AzNavRail guide, enableRailDragging = true
-        // puts the rail in "FAB Mode (detach rail)" — keeping that on by default
-        // forced the rail into overlay/floating mode in layouts where docking
-        // would have been fine. Call sites that want a draggable FAB can opt in
-        // via enableRailDraggingOverride.
-        enableRailDragging = enableRailDraggingOverride ?: false,
+        // In-app FAB mode is the intended default: with IdeazOverlayService gone,
+        // the rail itself is the floating in-app control that sits over the live
+        // preview and can be dragged out of the way — not a fixed docked strip.
+        // Callers can still force docking via enableRailDraggingOverride = false.
+        enableRailDragging = enableRailDraggingOverride ?: true,
         onUndock = onUndock,
         onOverlayDrag = onOverlayDrag,
         // Help overlay: azHelpRailItem (below) is the dedicated tap trigger.

--- a/version.properties
+++ b/version.properties
@@ -2,4 +2,4 @@
 build=39
 major=1
 minor=11
-patch=10
+patch=11


### PR DESCRIPTION
Reverts two of my earlier rail changes that fought the AzNavRail library's intended design (confirmed against `docs/AZNAVRAIL_COMPLETE_GUIDE.md` and the GitHub docs).

- **`enableRailDragging` → default `true`.** Commit *"Remove IdeazOverlayService and enable in-app FAB mode"* made the rail itself the floating in-app control that sits over the live preview and drags out of the way. My `15422ab5` defaulted it to `false` (a permanent docked strip), which is why every rail item sat on screen at once — the "confusing/redundant" feel.
- **Remove the amber `activeColor`** I added in `bd25abc4` — an unrequested visual change; theme restored to its prior state.

The rail's host/sub structure (the intended separation of destinations and actions) is **unchanged**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Restore the AzNavRail in-app FAB behavior as the default and revert an unintended visual customization to the active rail item color.

Bug Fixes:
- Re-enable rail dragging by default so the navigation rail behaves as the intended floating in-app FAB rather than a permanently docked strip.

Build:
- Bump patch version to 1.11.11 to reflect the restored nav rail behavior change.