### PR TITLE
fix(overlay): constrain drag-to-select to the target app's window

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/ideaz/services/IdeazAccessibilityService.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/services/IdeazAccessibilityService.kt
@@ -10,6 +10,8 @@ import android.os.Build
 import android.util.Log
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
+import android.view.accessibility.AccessibilityWindowInfo
+import androidx.preference.PreferenceManager
 
 /**
  * An Accessibility Service that inspects the view hierarchy.
@@ -22,12 +24,17 @@ class IdeazAccessibilityService : AccessibilityService() {
 
     private val tapReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {
-            if (intent?.action == "com.hereliesaz.ideaz.INTERNAL_TAP_DETECTED") {
-                val x = intent.getIntExtra("X", -1)
-                val y = intent.getIntExtra("Y", -1)
-                if (x != -1 && y != -1) {
-                    inspectAt(x, y)
+            when (intent?.action) {
+                "com.hereliesaz.ideaz.INTERNAL_TAP_DETECTED" -> {
+                    val x = intent.getIntExtra("X", -1)
+                    val y = intent.getIntExtra("Y", -1)
+                    if (x != -1 && y != -1) {
+                        inspectAt(x, y)
+                    }
                 }
+                // IdeazOverlayService is about to intercept touches and needs to
+                // know the worked-on app's window bounds so it can constrain itself.
+                "com.hereliesaz.ideaz.REQUEST_TARGET_BOUNDS" -> reportTargetWindowBounds()
             }
         }
     }
@@ -36,7 +43,10 @@ class IdeazAccessibilityService : AccessibilityService() {
         super.onServiceConnected()
         Log.d(TAG, "Accessibility Service Connected")
 
-        val filter = IntentFilter("com.hereliesaz.ideaz.INTERNAL_TAP_DETECTED")
+        val filter = IntentFilter().apply {
+            addAction("com.hereliesaz.ideaz.INTERNAL_TAP_DETECTED")
+            addAction("com.hereliesaz.ideaz.REQUEST_TARGET_BOUNDS")
+        }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             registerReceiver(tapReceiver, filter, Context.RECEIVER_NOT_EXPORTED)
         } else {
@@ -54,11 +64,54 @@ class IdeazAccessibilityService : AccessibilityService() {
     }
 
     override fun onAccessibilityEvent(event: AccessibilityEvent?) {
-        // We only care about explicit inspection via tap
+        // Inspection itself is driven by explicit taps. We do watch window changes
+        // so the overlay's interception region keeps tracking the target app as it
+        // opens, moves, or resizes.
+        when (event?.eventType) {
+            AccessibilityEvent.TYPE_WINDOWS_CHANGED,
+            AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED -> reportTargetWindowBounds()
+        }
     }
 
     override fun onInterrupt() {
         Log.d(TAG, "onInterrupt")
+    }
+
+    /** The package name of the app currently being worked on, if configured. */
+    private fun targetPackage(): String? =
+        PreferenceManager.getDefaultSharedPreferences(this)
+            .getString("target_package_name", null)
+            ?.takeIf { it.isNotBlank() }
+
+    /**
+     * Broadcasts the screen bounds of the target app's window (or no BOUNDS extra
+     * if it isn't on screen) so [IdeazOverlayService] can constrain its
+     * touch-intercepting overlay to exactly that region.
+     */
+    private fun reportTargetWindowBounds() {
+        val pkg = targetPackage()
+        val rect = if (pkg == null) null else findWindowBounds(pkg)
+        val intent = Intent("com.hereliesaz.ideaz.TARGET_WINDOW_BOUNDS").apply {
+            if (rect != null) putExtra("BOUNDS", rect)
+            setPackage(packageName)
+        }
+        sendBroadcast(intent)
+    }
+
+    private fun findWindowBounds(pkg: String): Rect? {
+        return try {
+            windows?.firstOrNull { w ->
+                w.type == AccessibilityWindowInfo.TYPE_APPLICATION &&
+                    w.root?.packageName?.toString() == pkg
+            }?.let { w ->
+                val r = Rect()
+                w.getBoundsInScreen(r)
+                r.takeIf { !it.isEmpty }
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "findWindowBounds failed", e)
+            null
+        }
     }
 
     private fun inspectAt(x: Int, y: Int) {

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/services/IdeazOverlayService.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/services/IdeazOverlayService.kt
@@ -17,6 +17,7 @@ import android.graphics.Rect
 import android.os.Build
 import android.os.IBinder
 import android.provider.Settings
+import android.view.Gravity
 import android.view.WindowManager
 import androidx.core.app.NotificationCompat
 import com.hereliesaz.ideaz.MainActivity
@@ -44,6 +45,19 @@ class IdeazOverlayService : Service() {
     private var overlayView: OverlayView? = null
     private var isOverlayAdded = false
 
+    /** Whether selection mode is currently active (touch interception requested). */
+    private var selectMode = false
+
+    /**
+     * Screen bounds of the app currently being worked on, as reported by
+     * [IdeazAccessibilityService]. When set, the touch-intercepting overlay is
+     * constrained to exactly this region so it never blocks IDEaz, other apps, or
+     * the system bars. Null means "no target window on screen" — the overlay then
+     * stays fully pass-through (e.g. web/PWA projects, whose selection is handled
+     * by the in-app SelectionOverlay).
+     */
+    private var targetBounds: Rect? = null
+
     /**
      * Receiver for commands from the main app process.
      */
@@ -54,6 +68,15 @@ class IdeazOverlayService : Service() {
                 "com.hereliesaz.ideaz.TOGGLE_SELECT_MODE" -> {
                     val enable = intent.getBooleanExtra("ENABLE", false)
                     handleSelectionMode(enable)
+                }
+                // Target-app window bounds, reported by IdeazAccessibilityService.
+                "com.hereliesaz.ideaz.TARGET_WINDOW_BOUNDS" -> {
+                    targetBounds = if (Build.VERSION.SDK_INT >= 33) {
+                        intent.getParcelableExtra("BOUNDS", Rect::class.java)
+                    } else {
+                        @Suppress("DEPRECATION") intent.getParcelableExtra("BOUNDS")
+                    }
+                    if (isOverlayAdded) applyOverlayGeometry()
                 }
                 // Command to draw a highlight rectangle (e.g., after selecting an element)
                 "com.hereliesaz.ideaz.HIGHLIGHT_RECT" -> {
@@ -128,6 +151,7 @@ class IdeazOverlayService : Service() {
             addAction("com.hereliesaz.ideaz.TOGGLE_SELECT_MODE")
             addAction("com.hereliesaz.ideaz.HIGHLIGHT_RECT")
             addAction("com.hereliesaz.ideaz.SHOW_UPDATE_POPUP")
+            addAction("com.hereliesaz.ideaz.TARGET_WINDOW_BOUNDS")
         }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             registerReceiver(receiver, filter, RECEIVER_NOT_EXPORTED)
@@ -153,11 +177,21 @@ class IdeazOverlayService : Service() {
     }
 
     private fun handleSelectionMode(enable: Boolean) {
+        selectMode = enable
         if (overlayView == null && Settings.canDrawOverlays(this)) {
             setupOverlay()
         }
         overlayView?.setSelectionMode(enable)
-        updateOverlayParams(enable)
+        if (enable) {
+            // Ask the accessibility service for the current target-app window
+            // bounds so we can constrain interception to it before the user drags.
+            sendBroadcast(
+                Intent("com.hereliesaz.ideaz.REQUEST_TARGET_BOUNDS").apply {
+                    setPackage(packageName)
+                }
+            )
+        }
+        applyOverlayGeometry()
     }
 
     /**
@@ -186,29 +220,44 @@ class IdeazOverlayService : Service() {
     }
 
     /**
-     * Updates the Window LayoutParams to toggle touch interception.
+     * Positions and sizes the overlay window, and toggles touch interception.
+     *
+     * The overlay only ever intercepts touches when **both** selection mode is on
+     * **and** a target-app window is known — and then only over that window's
+     * exact bounds. In every other case it is a full-screen, pass-through layer
+     * (visual highlights draw, but touches reach whatever is underneath). This is
+     * what keeps drag-to-select from blocking taps over IDEaz, other apps, or the
+     * system bars.
      */
-    private fun updateOverlayParams(isSelectMode: Boolean) {
+    private fun applyOverlayGeometry() {
         if (!isOverlayAdded || overlayView == null) {
-            if (isSelectMode && Settings.canDrawOverlays(this)) {
-                setupOverlay()
-            } else {
-                return
-            }
+            if (selectMode && Settings.canDrawOverlays(this)) setupOverlay() else return
         }
-
         val params = overlayView?.layoutParams as? WindowManager.LayoutParams ?: return
-        if (isSelectMode) {
-            // Remove NOT_TOUCHABLE -> Intercept touches
-            params.flags = params.flags and WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE.inv()
+        val bounds = targetBounds
+
+        params.gravity = Gravity.TOP or Gravity.START
+        if (selectMode && bounds != null && !bounds.isEmpty) {
+            // Constrain the touchable window to the target app's window only.
+            params.x = bounds.left
+            params.y = bounds.top
+            params.width = bounds.width()
+            params.height = bounds.height()
+            params.flags = params.flags and
+                WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE.inv() and
+                WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS.inv()
         } else {
-            // Add NOT_TOUCHABLE -> Pass touches through
+            // Full-screen but pass-through: never intercept globally.
+            params.x = 0
+            params.y = 0
+            params.width = WindowManager.LayoutParams.MATCH_PARENT
+            params.height = WindowManager.LayoutParams.MATCH_PARENT
             params.flags = params.flags or WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE
         }
         try {
             windowManager.updateViewLayout(overlayView, params)
         } catch (e: Exception) {
-            android.util.Log.w("IdeazOverlay", "Overlay service operation failed", e)
+            android.util.Log.w("IdeazOverlay", "Overlay geometry update failed", e)
         }
     }
 

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/inspection/OverlayView.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/inspection/OverlayView.kt
@@ -93,10 +93,19 @@ class OverlayView(context: Context) : View(context) {
             canvas.drawText("Updating, gimme a sec...", width / 2f, height / 2f, textPaint)
         }
 
-        // Visual cue that we are in "Select Mode" (dim the screen slightly)
+        // Visual cue that we are in "Select Mode" (dim the region slightly)
         if (isSelectionMode) {
             canvas.drawColor(Color.argb(30, 0, 0, 0))
         }
+
+        // highlightRect and the drag points are in screen coordinates (rawX/rawY).
+        // When the overlay window is constrained to the target app's bounds the
+        // view's origin is offset from the screen origin, so translate by the
+        // window's on-screen location before drawing them. (Full-screen → (0,0).)
+        val loc = IntArray(2)
+        getLocationOnScreen(loc)
+        canvas.save()
+        canvas.translate(-loc[0].toFloat(), -loc[1].toFloat())
 
         highlightRect?.let {
             canvas.drawRect(it, fillPaint)
@@ -110,6 +119,8 @@ class OverlayView(context: Context) : View(context) {
             val bottom = kotlin.math.max(startY, currentY)
             canvas.drawRect(left, top, right, bottom, selectionPaint)
         }
+
+        canvas.restore()
     }
 
     override fun onTouchEvent(event: MotionEvent): Boolean {

--- a/version.properties
+++ b/version.properties
@@ -2,4 +2,4 @@
 build=42
 major=1
 minor=12
-patch=0
+patch=1


### PR DESCRIPTION
**Bug:** in select mode, the system overlay (`IdeazOverlayService`, `TYPE_APPLICATION_OVERLAY`) was full-screen and touchable, so drag-to-select blocked **every** touch on the device — even outside IDEaz.

The overlay is kept (it's needed for Android-app development — selecting elements in a separately-running target app), but reined in so it **only intercepts over the app being worked on**:

- `IdeazAccessibilityService` reports the target app's window bounds (matched by `target_package_name` across interactive windows) on window changes and on demand → `TARGET_WINDOW_BOUNDS` broadcast.
- `IdeazOverlayService` sizes its window to those bounds and only clears `FLAG_NOT_TOUCHABLE` there. With **no** target window on screen (web/PWA projects, which use the in-app `SelectionOverlay`) it stays full-screen **pass-through** and never intercepts. Touches outside the target window fall through.
- `OverlayView` offsets its screen-coordinate drawing by the window location so highlights/drag-rect still render correctly once the window is constrained.

Compile-verified (`:app:compileDebugKotlin`). **Needs on-device verification** with a real Android target — I can't run that here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Constrain the touch-intercepting inspection overlay to only the target app’s window while keeping it pass-through elsewhere.

Bug Fixes:
- Prevent drag-to-select mode from blocking touches across the entire device by limiting interception to the target app window bounds.

Enhancements:
- Have the accessibility service track and broadcast the active target app window bounds and update them on window changes.
- Adjust the overlay view rendering to account for constrained window positioning so highlights and selection rectangles align with screen coordinates.

Build:
- Bump the application patch version to 1.12.1.