### PR TITLE
fix(ui): restore active nav-rail item highlight

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/IdeNavRail.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/IdeNavRail.kt
@@ -50,6 +50,9 @@ fun AzNavHostScope.ideNavRail(
     azTheme(
         defaultShape = AzButtonShape.RECTANGLE,
         headerIconShape = AzHeaderIconShape.NONE,
+        // The app palette is monochrome, so the active rail item is otherwise
+        // indistinguishable; give it a distinct accent.
+        activeColor = Color(0xFFFFC107),
         translucentBackground = Color.Black.copy(alpha = 0.5f),
     )
 

--- a/version.properties
+++ b/version.properties
@@ -1,5 +1,5 @@
-#Fri Jun 05 06:40:54 CDT 2026
-build=42
+#Fri Jun 05 07:29:55 CDT 2026
+build=43
 major=1
 minor=12
-patch=1
+patch=2


### PR DESCRIPTION
Re-adds the amber `activeColor` accent that was removed earlier. The docked-vs-FAB default was the actual rail problem (fixed in #670); the active-item highlight is wanted back. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Restore a distinct accent color for the active navigation rail item and bump the app patch version.

Enhancements:
- Set a specific amber accent color for the active navigation rail item to make it visually distinguishable.

Build:
- Increment the application version from 1.12.1 (build 42) to 1.12.2 (build 43).