### PR TITLE
fix(flow): Load shows the project; a11y status; build aborts on push failure

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/MainViewModel.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/MainViewModel.kt
@@ -845,7 +845,7 @@ class MainViewModel(
         }
     }
 
-    fun loadProject(name: String, onSuccess: () -> Unit) {
+    fun loadProject(name: String, context: Context, onSuccess: () -> Unit) {
         viewModelScope.launch {
             aiDelegate.clearSession()
             settingsViewModel.setAppName(name)
@@ -856,8 +856,28 @@ class MainViewModel(
             gitDelegate.getCurrentBranch()?.let { actualBranch ->
                 settingsViewModel.saveBranchName(actualBranch)
             }
+
+            // Project type & target package are GLOBAL settings, so re-derive them
+            // from the project on disk. Without this, a loaded project inherits the
+            // previously-open project's type and gets routed down the wrong
+            // build/preview path (and a loaded web project never shows a preview).
+            val projectDir = settingsViewModel.getProjectPath(name)
+            val detectedType = withContext(Dispatchers.IO) {
+                ProjectAnalyzer.detectProjectType(projectDir)
+            }
+            settingsViewModel.setProjectType(detectedType.name)
+            if (!detectedType.isWebLike()) {
+                withContext(Dispatchers.IO) { ProjectAnalyzer.detectPackageName(projectDir) }
+                    ?.let { settingsViewModel.saveTargetPackageName(it) }
+            }
+
             val user = settingsViewModel.getGithubUser()
             if (!user.isNullOrBlank()) repoDelegate.uploadProjectSecrets(user, name)
+
+            // Re-mount: clear any prior preview so launchTargetApp mounts THIS
+            // project, then actually show it (web → live preview, Android → host).
+            stateDelegate.setCurrentWebUrl(null)
+            launchTargetApp(context)
             onSuccess()
         }
     }

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/ProjectScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/ProjectScreen.kt
@@ -356,12 +356,10 @@ fun ProjectScreen(
                 )
                 "Load" -> ProjectLoadTab(viewModel, settingsViewModel, context) {
                     if(checkLoadRequirements()) {
-                        // Reset web state when loading a project (it might be Android)
-                        viewModel.stateDelegate.setCurrentWebUrl(null)
-                        viewModel.stateDelegate.setTargetAppVisible(false)
-                        viewModel.loadProject(it) {
+                        // loadProject re-derives the type, re-mounts the preview, and
+                        // shows the project (web → live preview, Android → host).
+                        viewModel.loadProject(it, context) {
                             isCreateMode = false
-                            tabIndex = tabs.indexOf("Setup")
                         }
                     }
                 }

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/SettingsScreen.kt
@@ -546,7 +546,7 @@ fun SettingsScreen(
                 }
                 val hasScreenshot by remember(viewModel.hasScreenCapturePermission()) { mutableStateOf(viewModel.hasScreenCapturePermission()) }
                 val hasAccessibility by remember(refreshTrigger) {
-                    mutableStateOf(isAccessibilityServiceEnabled(context, ".services.UIInspectionService"))
+                    mutableStateOf(isAccessibilityServiceEnabled(context, ".services.IdeazAccessibilityService"))
                 }
                 val hasStorage by remember(refreshTrigger) {
                     mutableStateOf(

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/delegates/BuildDelegate.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/delegates/BuildDelegate.kt
@@ -217,7 +217,11 @@ class BuildDelegate(
         }
 
         onLog("[IDE] Pushing to remote...\n")
-        gitDelegate.push()
+        if (!gitDelegate.push()) {
+            onLog("Error: Push failed. Aborting remote build.\n")
+            handleFailure("Push failed. Aborting remote build.")
+            return
+        }
 
         val headSha = gitDelegate.getHeadSha()
         if (headSha == null) {

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/delegates/GitDelegate.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/delegates/GitDelegate.kt
@@ -164,20 +164,22 @@ class GitDelegate(
     /**
      * Pushes local changes to the remote repository.
      */
-    suspend fun push() = withContext(Dispatchers.IO) {
+    suspend fun push(): Boolean = withContext(Dispatchers.IO) {
         try {
-            val git = getGitManager() ?: return@withContext
+            val git = getGitManager() ?: return@withContext false
             val token = settingsViewModel.getGithubToken()
             val user = settingsViewModel.getGithubUser()
-            if (token != null) {
-                git.push(user, token) { p, t -> reportProgress(p, t) }
-                onLog("[GIT] Push successful.\n")
-            } else {
+            if (token == null) {
                 onLog("[GIT] Error: Missing Auth.\n")
+                return@withContext false
             }
+            git.push(user, token) { p, t -> reportProgress(p, t) }
+            onLog("[GIT] Push successful.\n")
             refreshGitData()
+            true
         } catch (e: Exception) {
             onLog("[GIT] Push Error: ${e.message}\n")
+            false
         }
     }
 

--- a/version.properties
+++ b/version.properties
@@ -2,4 +2,4 @@
 build=43
 major=1
 minor=12
-patch=3
+patch=4


### PR DESCRIPTION
Three confirmed user-flow blockers from the trace:

1. **Load → preview (Critical).** Project type/package are *global* settings; `loadProject` never re-derived them or triggered a preview, so loading a project just returned you to the Setup form (and a loaded web project could be routed to the Android build path). Now it re-derives the type via `ProjectAnalyzer.detectProjectType` (+ package for Android), clears the prior web URL, and calls `launchTargetApp`. `ProjectScreen` Load handler passes `context` and no longer forces the Setup tab.
2. **Accessibility status (High).** `SettingsScreen` checked the nonexistent `.services.UIInspectionService` → always "Not Granted". Fixed to `.services.IdeazAccessibilityService`.
3. **Push-failure abort (High).** `GitDelegate.push` now returns success; `startRemoteBuild` aborts with a clear message instead of polling a CI run that never comes.

Compile-verified. (Next pass: fork dead-end, Create-flow race, Gemini `function`/`tool` role.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)