### PR TITLE
fix(flow): fork clones locally and lands in Setup (no dead-end)

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/ProjectScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/ProjectScreen.kt
@@ -346,6 +346,14 @@ fun ProjectScreen(
                             }
                         }
                     },
+                    onForkRepo = { url ->
+                        if (checkKeys()) {
+                            viewModel.forkRepository(url) {
+                                isCreateMode = false
+                                tabIndex = tabs.indexOf("Setup")
+                            }
+                        }
+                    },
                     onCreateNewSelected = {
                         if (checkKeys()) {
                             isCreateMode = true // Enable Create mode

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/ProjectScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/ProjectScreen.kt
@@ -347,7 +347,14 @@ fun ProjectScreen(
                         }
                     },
                     onForkRepo = { url ->
-                        if (checkKeys()) {
+                        val parts = url.removePrefix("https://github.com/")
+                            .removeSuffix(".git")
+                            .split("/")
+                            .filter { it.isNotBlank() }
+                        if (parts.size < 2) {
+                            android.widget.Toast.makeText(context, "Invalid repository format. Use 'owner/repo'.", android.widget.Toast.LENGTH_SHORT).show()
+                        } else if (checkKeys()) {
+                            android.widget.Toast.makeText(context, "Forking...", android.widget.Toast.LENGTH_SHORT).show()
                             viewModel.forkRepository(url) {
                                 isCreateMode = false
                                 tabIndex = tabs.indexOf("Setup")

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/delegates/RepoDelegate.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/delegates/RepoDelegate.kt
@@ -281,6 +281,15 @@ class RepoDelegate(
                 val generatedPackage = "com.$sanitizedUser.$sanitizedApp"
                 settingsViewModel.saveTargetPackageName(generatedPackage)
 
+                // Clone the fork locally so there is an on-device project to edit
+                // and preview. Without this the fork existed only on GitHub and the
+                // flow dead-ended (no local files, nothing to initialise/preview).
+                val projectDir = settingsViewModel.getProjectPath(response.name)
+                if (!GitManager(projectDir).isRepo()) {
+                    onOverlayLog("Cloning $newOwner/${response.name}...")
+                    cloneWithRetry(projectDir, newOwner, response.name, token)
+                }
+
                 onSuccess(newOwner, response.name, newBranch)
 
             } catch (e: Exception) {

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/delegates/RepoDelegate.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/delegates/RepoDelegate.kt
@@ -288,6 +288,9 @@ class RepoDelegate(
                 if (!GitManager(projectDir).isRepo()) {
                     onOverlayLog("Cloning $newOwner/${response.name}...")
                     cloneWithRetry(projectDir, newOwner, response.name, token)
+                    if (!GitManager(projectDir).isRepo()) {
+                        throw Exception("Failed to clone the forked repository locally.")
+                    }
                 }
 
                 onSuccess(newOwner, response.name, newBranch)

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/project/CloneTab.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/project/CloneTab.kt
@@ -31,6 +31,7 @@ fun ProjectCloneTab(
     settingsViewModel: SettingsViewModel,
     context: Context,
     onRepoSelected: (GitHubRepoResponse) -> Unit,
+    onForkRepo: (String) -> Unit,
     onCreateNewSelected: () -> Unit,
     onNavigateToSettings: () -> Unit
 ) {
@@ -54,7 +55,7 @@ fun ProjectCloneTab(
                 modifier = Modifier.fillMaxWidth(),
                 leadingIcon = { Icon(Icons.Default.Link, contentDescription = null) },
                 onSubmit = {
-                    viewModel.forkRepository(cloneUrl)
+                    onForkRepo(cloneUrl)
                     Toast.makeText(context, "Forking...", Toast.LENGTH_SHORT).show()
                 },
                 submitButtonContent = { Text("Fork") },

--- a/version.properties
+++ b/version.properties
@@ -2,4 +2,4 @@
 build=43
 major=1
 minor=12
-patch=4
+patch=5


### PR DESCRIPTION
The Clone tab's **Fork** field forked on GitHub and set config but **never cloned locally or navigated** — no on-device project, no preview; the user was stranded after a "Forking..." toast.

- `RepoDelegate.forkRepository` now clones the fork locally (`cloneWithRetry`, mirroring `selectRepositoryForSetup`) before its success callback.
- `CloneTab` takes an `onForkRepo` callback; `ProjectScreen` wires it (behind `checkKeys`) to fork → Setup tab (non-create), same landing as picking a repo from the list.

Compile-verified. (Remaining 2nd-pass items: Create-flow prompt race, Gemini `function`/`tool` role.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)