### PR TITLE
feat(ai): every provider gets the repo and is told to study it

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ai/AiAdapterFactory.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ai/AiAdapterFactory.kt
@@ -6,6 +6,8 @@ import com.hereliesaz.ideaz.ai.bridge.GeminiAppBridgeAdapter
 import com.hereliesaz.ideaz.ui.AiModel
 import com.hereliesaz.ideaz.ui.AiModels
 import com.hereliesaz.ideaz.ui.SettingsViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 /**
  * Centralised factory that maps a registered [AiModel] to a concrete
@@ -20,7 +22,25 @@ import com.hereliesaz.ideaz.ui.SettingsViewModel
  */
 object AiAdapterFactory {
 
+    /**
+     * Build a [ConversationalAiClient] for [model], wrapped so that — regardless of
+     * provider — the AI is handed the project and told to study it before helping.
+     * Returns null only when the provider can't be built (missing key, or Jules,
+     * which the caller handles separately).
+     */
     fun create(
+        model: AiModel,
+        context: Context,
+        tools: IdeTools,
+        settings: SettingsViewModel,
+    ): ConversationalAiClient? {
+        val base = createRaw(model, context, tools, settings) ?: return null
+        val appName = settings.getAppName()?.takeIf { it.isNotBlank() } ?: "this project"
+        val projectType = settings.getProjectType()
+        return RepoAwareClient(base, tools, appName, projectType)
+    }
+
+    private fun createRaw(
         model: AiModel,
         context: Context,
         tools: IdeTools,
@@ -96,4 +116,62 @@ object AiAdapterFactory {
         if (key.isBlank()) return null
         return OpenAiCompatibleAdapter(baseUrl = baseUrl, apiKey = key, model = model, tools = tools)
     }
+}
+
+/**
+ * Wraps any [ConversationalAiClient] so the model is always given the project and
+ * told to study it before helping — independent of provider. The instruction and
+ * a compact file tree are merged into the first user message each request (no
+ * extra turn, so role alternation stays valid for every backend, including the
+ * tool-less on-device / app-bridge paths). Tool-capable backends additionally use
+ * read_file / list_files to dig in; tool-less ones at least see the structure.
+ */
+private class RepoAwareClient(
+    private val delegate: ConversationalAiClient,
+    private val tools: IdeTools,
+    private val appName: String,
+    private val projectType: String,
+) : ConversationalAiClient {
+    override suspend fun chat(messages: List<ChatMessage>): String {
+        val preamble = withContext(Dispatchers.IO) {
+            AiRepoContext.systemPreamble(appName, projectType, tools.repoMap())
+        }
+        val enriched = if (messages.isEmpty()) {
+            listOf(ChatMessage("user", preamble))
+        } else {
+            val firstUser = messages.indexOfFirst { it.role == "user" }
+            if (firstUser == -1) {
+                listOf(ChatMessage("user", preamble)) + messages
+            } else {
+                messages.mapIndexed { i, m ->
+                    if (i == firstUser) {
+                        ChatMessage(m.role, listOf(ChatPart.Text(preamble + "\n\n")) + m.parts)
+                    } else m
+                }
+            }
+        }
+        return delegate.chat(enriched)
+    }
+}
+
+/** Builds the provider-agnostic "study the project first" system preamble. */
+object AiRepoContext {
+    fun systemPreamble(appName: String, projectType: String, repoMap: String): String = """
+        You are an expert AI pair-programmer embedded in IDEaz, a mobile IDE. You are
+        helping the user build their project "$appName" (type: $projectType). The full
+        project source is available to you.
+
+        Before answering or changing anything, STUDY THE PROJECT so your help fits how
+        it is actually built:
+        - Read the relevant files — entry points, configuration, and whatever the
+          request touches — using the read_file and list_files tools. The project file
+          tree below is your starting map.
+        - Understand the language/framework, dependencies, structure, and existing
+          conventions, then follow them.
+        - Make focused, idiomatic changes that build on the existing code, and briefly
+          explain what you changed and why.
+
+        Project file tree:
+        $repoMap
+    """.trimIndent()
 }

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ai/IdeTools.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ai/IdeTools.kt
@@ -56,6 +56,38 @@ class IdeTools(private val projectDir: File) {
     }
 
     /**
+     * A compact recursive map of the project's files, for orienting the AI before
+     * it digs in with [readFile]/[listFiles]. Skips dependency/build/VCS noise and
+     * caps the entry count so the listing stays small enough to put in a prompt.
+     */
+    fun repoMap(maxEntries: Int = 300): String {
+        val base = projectDir.canonicalFile
+        if (!base.isDirectory) return "(no project files yet)"
+        val skip = setOf(
+            ".git", "node_modules", "build", ".gradle", ".idea",
+            "dist", ".next", "out", ".cache", "__ideaz__"
+        )
+        val sb = StringBuilder()
+        var count = 0
+        fun walk(dir: File, prefix: String) {
+            val children = dir.listFiles()
+                ?.sortedWith(compareBy({ it.isFile }, { it.name })) ?: return
+            for (c in children) {
+                if (count >= maxEntries) {
+                    sb.append(prefix).append("…(truncated)\n")
+                    return
+                }
+                if (c.isDirectory && c.name in skip) continue
+                count++
+                sb.append(prefix).append(c.name).append(if (c.isDirectory) "/" else "").append('\n')
+                if (c.isDirectory) walk(c, "$prefix  ")
+            }
+        }
+        walk(base, "")
+        return sb.toString().ifBlank { "(no project files yet)" }
+    }
+
+    /**
      * Apply a unified diff [patchText] to the working tree using JGit's ApplyCommand.
      * Initialises a temporary git repository in [projectDir] if one does not already
      * exist, so that JGit's ApplyCommand has a valid work-tree context.

--- a/version.properties
+++ b/version.properties
@@ -2,4 +2,4 @@
 build=43
 major=1
 minor=12
-patch=4
+patch=6


### PR DESCRIPTION
No matter which model is selected, the AI is now handed the project and told to study it before helping.

- `IdeTools.repoMap()` — compact, noise-filtered, capped file tree.
- `AiAdapterFactory` wraps **every** `ConversationalAiClient` (Gemini, OpenAI-compatible providers, Gemini Nano, app-bridge) in `RepoAwareClient`, which merges a "study the project first" preamble + the file tree into the first user message (merge, not a new turn, so role alternation stays valid for tool-less backends too).
- `AiRepoContext.systemPreamble` centralizes the instruction.

Tool-capable models dig in via `read_file`/`list_files`; tool-less ones at least see the structure. Compile-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)