### PR TITLE
fix(ai): correct Gemini tool-response role; sequence Create's initial prompt

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ai/GeminiAdapter.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ai/GeminiAdapter.kt
@@ -4,7 +4,6 @@ import com.google.genai.Client
 import com.google.genai.types.Blob
 import com.google.genai.types.Content
 import com.google.genai.types.FunctionDeclaration
-import com.google.genai.types.FunctionResponse
 import com.google.genai.types.GenerateContentConfig
 import com.google.genai.types.Part
 import com.google.genai.types.Schema
@@ -49,18 +48,15 @@ class GeminiAdapter(
                 val name = call.name().orElse("")
                 val args = call.args().orElse(emptyMap())
                 val output = dispatchTool(name, args)
-                val funcResponse = FunctionResponse.builder()
-                    .name(name)
-                    .response(mapOf("output" to output))
-                    .build()
-                // Role for function-response content in the google-genai SDK.
-                // The older generativeai SDK uses "function"; if the tool-use loop does not
-                // advance after providing results, try "tool" here instead.
+                // Build the function-response turn with the SDK's own helpers.
+                // Content.fromParts sets role "user" — which is what the google-genai
+                // SDK / Gemini API expect for function responses. The previous manual
+                // role("function") was wrong and stalled the tool-use loop until it
+                // hit MAX_TOOL_ROUNDS.
                 contents.add(
-                    Content.builder()
-                        .role("function")
-                        .parts(listOf(Part.builder().functionResponse(funcResponse).build()))
-                        .build()
+                    Content.fromParts(
+                        Part.fromFunctionResponse(name, mapOf<String, Any>("output" to output))
+                    )
                 )
             }
             rounds++

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/MainViewModel.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/MainViewModel.kt
@@ -627,14 +627,16 @@ class MainViewModel(
     fun uploadProjectSecrets(o: String, r: String) = repoDelegate.uploadProjectSecrets(o, r)
 
     /** Creates a new repo and initializes the project. */
-    fun createGitHubRepository(name: String, desc: String, priv: Boolean, type: ProjectType, pkg: String, ctx: Context, onSuccess: () -> Unit) {
+    fun createGitHubRepository(name: String, desc: String, priv: Boolean, type: ProjectType, pkg: String, ctx: Context, initialPrompt: String? = null, onSuccess: () -> Unit) {
         repoDelegate.createGitHubRepository(name, desc, priv, type, pkg, ctx) { owner, branch ->
             // Local content is either cloned from the template repo (generate
             // flow, handled in RepoDelegate) or scaffolded from the bundled
             // template by saveAndInitialize's ensureTemplate when the directory
             // is still empty (fallback). Either way ensureTemplate is a no-op
-            // once files are present, so we don't copy here.
-            saveAndInitialize(name, owner, branch, pkg, type, ctx)
+            // once files are present, so we don't copy here. The initial prompt
+            // is dispatched by saveAndInitialize AFTER scaffolding, so the AI
+            // never runs against an empty project.
+            saveAndInitialize(name, owner, branch, pkg, type, ctx, initialPrompt)
             onSuccess()
         }
     }
@@ -688,6 +690,13 @@ class MainViewModel(
             // Check for remote artifacts if it's an Android project
             if (type == ProjectType.ANDROID) {
                 startArtifactPolling(user, appName)
+            }
+
+            // Dispatch the initial prompt only now — the project is scaffolded and
+            // the build kicked off, so the AI runs against real files (fixes the
+            // race where the prompt fired before scaffolding finished).
+            if (!initialPrompt.isNullOrBlank()) {
+                sendPrompt(initialPrompt)
             }
         }
     }

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/project/SetupTab.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/project/SetupTab.kt
@@ -292,13 +292,11 @@ fun ProjectSetupTab(
                             showTokenRequiredDialog = true
                         } else if (onCheckRequirements()) {
                             viewModel.createGitHubRepository(
-                                appName, repoDescription, false, selectedType, packageName, context
+                                appName, repoDescription, false, selectedType, packageName, context,
+                                initialPrompt = initialPrompt.takeIf { it.isNotBlank() }
                             ) {
                                 viewModel.uploadProjectSecrets(githubUser, appName)
                                 onCreateModeChanged(false)
-                                if (initialPrompt.isNotBlank()) {
-                                    viewModel.sendPrompt(initialPrompt)
-                                }
                             }
                         }
                     },

--- a/version.properties
+++ b/version.properties
@@ -2,4 +2,4 @@
 build=43
 major=1
 minor=12
-patch=4
+patch=8


### PR DESCRIPTION
Completes the second-pass blockers.

- **Gemini tool-use role.** The function-response turn hardcoded `role("function")`, which the google-genai SDK/Gemini API reject — the loop never advanced and hit "Tool-use loop exceeded 10 rounds", so **every Gemini file edit silently failed**. Confirmed from the SDK bytecode that `Content.fromParts(...)` sets role `"user"`; rebuilt the response with the SDK's own helpers (`Content.fromParts(Part.fromFunctionResponse(...))`).
- **Create-flow prompt race.** "Create & Save" fired `sendPrompt` in parallel with `saveAndInitialize`'s coroutine, so the AI could run against an empty project. The prompt now threads through `createGitHubRepository → saveAndInitialize` and dispatches only after scaffolding + build kickoff.

Compile-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)