### PR TITLE
feat(ai): on-device model foundation (multi-runtime + AICore)

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ai/AiAdapterFactory.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ai/AiAdapterFactory.kt
@@ -97,6 +97,14 @@ object AiAdapterFactory {
                 tools = tools,
             )
 
+            // On-device model the user downloaded (or AICore, system-managed).
+            // The active model + its runtime are resolved at call time.
+            AiModels.LOCAL_MODEL -> com.hereliesaz.ideaz.ai.local.LocalLlmAdapter(
+                context = context.applicationContext,
+                store = com.hereliesaz.ideaz.ai.local.LocalModelStore(context),
+                downloads = com.hereliesaz.ideaz.ai.local.ModelDownloadManager(context),
+            )
+
             // Jules has its own session/poll lifecycle outside the
             // ConversationalAiClient contract; callers handle it directly.
             AiModels.JULES_DEFAULT -> null

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ai/local/LocalLlmAdapter.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ai/local/LocalLlmAdapter.kt
@@ -1,0 +1,50 @@
+package com.hereliesaz.ideaz.ai.local
+
+import android.content.Context
+import com.hereliesaz.ideaz.ai.ChatMessage
+import com.hereliesaz.ideaz.ai.ConversationalAiClient
+
+/**
+ * [ConversationalAiClient] backed by the user's selected on-device model. Flattens
+ * the conversation into a prompt, dispatches to the model's runtime, and returns
+ * its text.
+ *
+ * When it can't run, it returns a clear, actionable message rather than throwing —
+ * no model selected, the file isn't downloaded, or the runtime backend isn't in
+ * this build yet — so the UI shows guidance instead of a crash.
+ */
+class LocalLlmAdapter(
+    private val context: Context,
+    private val store: LocalModelStore,
+    private val downloads: ModelDownloadManager,
+) : ConversationalAiClient {
+
+    override suspend fun chat(messages: List<ChatMessage>): String {
+        val model = store.activeModel()
+            ?: return "Error: No on-device model selected. Pick one in Settings → On-device models."
+        if (!downloads.isDownloaded(model)) {
+            return "Error: \"${model.name}\" isn't downloaded yet. Download it in Settings → On-device models."
+        }
+        val runtime = LocalModelRuntimes.byId(model.runtimeId)
+            ?: return "Error: No runtime '${model.runtimeId}' is registered for ${model.name}."
+        if (!runtime.isAvailable(context)) {
+            return "Error: The ${runtime.displayName} backend isn't included in this build yet."
+        }
+
+        val prompt = buildString {
+            messages.forEach { m ->
+                val who = if (m.role == "user") "User" else "Assistant"
+                append(who).append(": ").append(m.content).append('\n')
+            }
+            append("Assistant:")
+        }
+
+        // System-managed runtimes (AICore) ignore the file; pass a harmless path.
+        val modelFile = if (model.systemManaged) context.filesDir else downloads.fileFor(model)
+        return try {
+            runtime.generate(context, modelFile, prompt)
+        } catch (e: Exception) {
+            "Error: On-device generation failed: ${e.message}"
+        }
+    }
+}

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ai/local/LocalModelCatalog.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ai/local/LocalModelCatalog.kt
@@ -1,0 +1,82 @@
+package com.hereliesaz.ideaz.ai.local
+
+/**
+ * A downloadable on-device model.
+ *
+ * [requiresAuth] models (e.g. gated Gemma) need a provider token the user supplies
+ * before the download will succeed. URLs are direct download links; the download
+ * manager is URL-generic, so this catalog can grow without code changes.
+ */
+data class LocalModel(
+    val id: String,
+    val name: String,
+    val runtimeId: String,
+    val url: String,
+    val approxSizeBytes: Long,
+    val fileName: String,
+    val requiresAuth: Boolean = false,
+    /** True for runtimes that manage their own model (e.g. AICore): no file download. */
+    val systemManaged: Boolean = false,
+    val notes: String = "",
+)
+
+/**
+ * Curated starter catalog spanning the supported runtimes. The exact URLs/filenames
+ * should be verified before each is offered for download (some upstreams rename
+ * quantizations); the architecture does not depend on any specific entry.
+ */
+object LocalModelCatalog {
+    val models: List<LocalModel> = listOf(
+        LocalModel(
+            id = "aicore-gemini-nano",
+            name = "Gemini Nano (AICore · system-managed)",
+            runtimeId = "aicore",
+            url = "",
+            approxSizeBytes = 0,
+            fileName = "",
+            systemManaged = true,
+            notes = "No download — provided and updated by the device's AICore service. " +
+                "Supported hardware only (Pixel 8+/select Samsung).",
+        ),
+        LocalModel(
+            id = "qwen2_5-0_5b-instruct-q4-gguf",
+            name = "Qwen2.5 0.5B Instruct · Q4 (GGUF)",
+            runtimeId = "llamacpp",
+            url = "https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/main/qwen2.5-0.5b-instruct-q4_k_m.gguf",
+            approxSizeBytes = 400_000_000,
+            fileName = "qwen2.5-0.5b-instruct-q4_k_m.gguf",
+            notes = "Tiny and fast; good for low-RAM devices.",
+        ),
+        LocalModel(
+            id = "gemma2-2b-it-q4-gguf",
+            name = "Gemma 2 2B Instruct · Q4 (GGUF)",
+            runtimeId = "llamacpp",
+            url = "https://huggingface.co/unsloth/gemma-2-2b-it-GGUF/resolve/main/gemma-2-2b-it.Q4_K_M.gguf",
+            approxSizeBytes = 1_700_000_000,
+            fileName = "gemma-2-2b-it.Q4_K_M.gguf",
+            notes = "Stronger; wants ~3 GB free RAM.",
+        ),
+        LocalModel(
+            id = "phi3_5-mini-onnx",
+            name = "Phi-3.5 Mini Instruct (ONNX GenAI)",
+            runtimeId = "onnx",
+            url = "https://huggingface.co/microsoft/Phi-3.5-mini-instruct-onnx/resolve/main/cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4/model.onnx.data",
+            approxSizeBytes = 2_200_000_000,
+            fileName = "phi3.5-mini.onnx.data",
+            notes = "ONNX Runtime GenAI; CPU int4.",
+        ),
+        LocalModel(
+            id = "gemma2-2b-it-mediapipe",
+            name = "Gemma 2 2B Instruct (MediaPipe .task)",
+            runtimeId = "mediapipe",
+            url = "https://huggingface.co/google/gemma-2-2b-it/resolve/main/gemma-2-2b-it.task",
+            approxSizeBytes = 1_300_000_000,
+            fileName = "gemma-2-2b-it.task",
+            requiresAuth = true,
+            notes = "Gated by Google — requires a Hugging Face token with access granted.",
+        ),
+    )
+
+    fun byId(id: String): LocalModel? = models.firstOrNull { it.id == id }
+    fun forRuntime(runtimeId: String): List<LocalModel> = models.filter { it.runtimeId == runtimeId }
+}

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ai/local/LocalModelRuntime.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ai/local/LocalModelRuntime.kt
@@ -1,0 +1,101 @@
+package com.hereliesaz.ideaz.ai.local
+
+import android.content.Context
+import com.google.ai.edge.aicore.GenerativeModel
+import com.google.ai.edge.aicore.generationConfig
+import java.io.File
+
+/** Thrown when a runtime's backend library isn't present in this build yet. */
+class LocalRuntimeUnavailableException(runtimeName: String) :
+    Exception("On-device runtime \"$runtimeName\" is not available in this build yet.")
+
+/**
+ * A pluggable on-device inference backend (MediaPipe LLM Inference, llama.cpp,
+ * ONNX Runtime GenAI, …).
+ *
+ * Concrete runtimes are detected by reflection so the app builds and runs without
+ * their (large, native) dependencies. A runtime becomes usable once its dependency
+ * is added to the build and its [generate] is implemented — done per-runtime in
+ * follow-up changes so each can be verified on a device independently.
+ */
+interface LocalModelRuntime {
+    val id: String
+    val displayName: String
+
+    /** True if this backend's library is present in the current build. */
+    fun isAvailable(context: Context): Boolean
+
+    /** One-shot generation for [prompt] using the model file at [modelFile]. */
+    suspend fun generate(context: Context, modelFile: File, prompt: String): String
+}
+
+internal fun classPresent(fqcn: String): Boolean =
+    runCatching { Class.forName(fqcn, false, LocalModelRuntime::class.java.classLoader) }.isSuccess
+
+/** MediaPipe LLM Inference — Gemma/Phi/Falcon `.task` models. Wired in a follow-up. */
+object MediaPipeRuntime : LocalModelRuntime {
+    override val id = "mediapipe"
+    override val displayName = "MediaPipe LLM Inference"
+    override fun isAvailable(context: Context) =
+        classPresent("com.google.mediapipe.tasks.genai.llminference.LlmInference")
+    override suspend fun generate(context: Context, modelFile: File, prompt: String): String =
+        throw LocalRuntimeUnavailableException(displayName)
+}
+
+/** llama.cpp — any GGUF model. Wired in a follow-up. */
+object LlamaCppRuntime : LocalModelRuntime {
+    override val id = "llamacpp"
+    override val displayName = "llama.cpp (GGUF)"
+    override fun isAvailable(context: Context) =
+        classPresent("android.llama.cpp.LLamaAndroid") || classPresent("de.kherud.llama.LlamaModel")
+    override suspend fun generate(context: Context, modelFile: File, prompt: String): String =
+        throw LocalRuntimeUnavailableException(displayName)
+}
+
+/** ONNX Runtime GenAI — Phi-3/3.5, Qwen. Wired in a follow-up. */
+object OnnxGenAiRuntime : LocalModelRuntime {
+    override val id = "onnx"
+    override val displayName = "ONNX Runtime GenAI"
+    override fun isAvailable(context: Context) =
+        classPresent("ai.onnxruntime.genai.Model")
+    override suspend fun generate(context: Context, modelFile: File, prompt: String): String =
+        throw LocalRuntimeUnavailableException(displayName)
+}
+
+/**
+ * AICore — the device's system-managed Gemini Nano service
+ * (`com.google.ai.edge.aicore`). Unlike the file-based runtimes, the model is
+ * provided and updated by the system (no app download). Available on supported
+ * hardware (Pixel 8+/select Samsung); [generate] surfaces a clear message on
+ * unsupported devices. This is the same engine the GEMINI_NANO provider uses,
+ * exposed here so it appears in the unified on-device picker.
+ */
+object AiCoreRuntime : LocalModelRuntime {
+    override val id = "aicore"
+    override val displayName = "AICore · Gemini Nano (system)"
+    override fun isAvailable(context: Context) =
+        classPresent("com.google.ai.edge.aicore.GenerativeModel")
+    override suspend fun generate(context: Context, modelFile: File, prompt: String): String {
+        val config = generationConfig {
+            this.context = context.applicationContext
+            temperature = 0.2f
+            topK = 16
+            candidateCount = 1
+            maxOutputTokens = 512
+        }
+        val model = GenerativeModel(generationConfig = config)
+        return try {
+            model.prepareInferenceEngine()
+            model.generateContent(prompt).text.orEmpty().ifBlank { "(no text)" }
+        } finally {
+            runCatching { model.close() }
+        }
+    }
+}
+
+/** Registry of known on-device runtimes. */
+object LocalModelRuntimes {
+    val all: List<LocalModelRuntime> =
+        listOf(AiCoreRuntime, MediaPipeRuntime, LlamaCppRuntime, OnnxGenAiRuntime)
+    fun byId(id: String): LocalModelRuntime? = all.firstOrNull { it.id == id }
+}

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ai/local/LocalModelStore.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ai/local/LocalModelStore.kt
@@ -1,0 +1,25 @@
+package com.hereliesaz.ideaz.ai.local
+
+import android.content.Context
+import androidx.preference.PreferenceManager
+
+/** Persists which catalog model the user has selected as their on-device model. */
+class LocalModelStore(context: Context) {
+    private val prefs = PreferenceManager.getDefaultSharedPreferences(context.applicationContext)
+
+    var activeModelId: String?
+        get() = prefs.getString(KEY_ACTIVE_MODEL, null)
+        set(value) { prefs.edit().putString(KEY_ACTIVE_MODEL, value).apply() }
+
+    /** Optional token for gated downloads (e.g. a Hugging Face token for Gemma). */
+    var downloadToken: String?
+        get() = prefs.getString(KEY_DOWNLOAD_TOKEN, null)
+        set(value) { prefs.edit().putString(KEY_DOWNLOAD_TOKEN, value).apply() }
+
+    fun activeModel(): LocalModel? = activeModelId?.let { LocalModelCatalog.byId(it) }
+
+    companion object {
+        private const val KEY_ACTIVE_MODEL = "local_model_active_id"
+        private const val KEY_DOWNLOAD_TOKEN = "local_model_download_token"
+    }
+}

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ai/local/ModelDownloadManager.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ai/local/ModelDownloadManager.kt
@@ -1,0 +1,84 @@
+package com.hereliesaz.ideaz.ai.local
+
+import android.content.Context
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+
+/**
+ * Downloads on-device model files into `<filesDir>/local-models/`, with progress
+ * reporting, HTTP-Range resume of a partial download, and an optional bearer token
+ * for gated models. URL-generic, so it works for any [LocalModel].
+ */
+class ModelDownloadManager(
+    context: Context,
+    private val client: OkHttpClient = OkHttpClient.Builder()
+        .connectTimeout(30, TimeUnit.SECONDS)
+        .readTimeout(60, TimeUnit.SECONDS)
+        .build(),
+) {
+    private val dir = File(context.filesDir, "local-models").apply { mkdirs() }
+
+    fun fileFor(model: LocalModel): File = File(dir, model.fileName)
+    fun isDownloaded(model: LocalModel): Boolean =
+        model.systemManaged || fileFor(model).let { it.isFile && it.length() > 0 }
+    fun delete(model: LocalModel): Boolean = !model.systemManaged && fileFor(model).delete()
+
+    /**
+     * Download [model], resuming a `.part` file if one exists. [onProgress] gets
+     * (bytesDownloaded, totalBytes); total is -1 when the server doesn't report it.
+     * Returns the finalized model file.
+     */
+    suspend fun download(
+        model: LocalModel,
+        authToken: String? = null,
+        onProgress: (downloaded: Long, total: Long) -> Unit = { _, _ -> },
+    ): File = withContext(Dispatchers.IO) {
+        val target = fileFor(model)
+        if (target.isFile && target.length() > 0) return@withContext target
+
+        val part = File(dir, model.fileName + ".part")
+        val existing = if (part.isFile) part.length() else 0L
+
+        val request = Request.Builder().url(model.url).apply {
+            if (existing > 0) header("Range", "bytes=$existing-")
+            if (!authToken.isNullOrBlank()) header("Authorization", "Bearer $authToken")
+        }.build()
+
+        client.newCall(request).execute().use { resp ->
+            if (!resp.isSuccessful) throw IOException("Download failed: HTTP ${resp.code}")
+            val body = resp.body
+            val resuming = resp.code == 206
+            val total = body.contentLength().let { len ->
+                if (len < 0) -1L else len + (if (resuming) existing else 0L)
+            }
+
+            val append = resuming && existing > 0
+            if (!append) part.delete()
+            var downloaded = if (append) existing else 0L
+
+            body.byteStream().use { input ->
+                FileOutputStream(part, append).use { output ->
+                    val buf = ByteArray(64 * 1024)
+                    while (true) {
+                        val n = input.read(buf)
+                        if (n == -1) break
+                        output.write(buf, 0, n)
+                        downloaded += n
+                        onProgress(downloaded, total)
+                    }
+                    output.fd.sync()
+                }
+            }
+        }
+
+        if (target.exists()) target.delete()
+        if (!part.renameTo(target)) throw IOException("Could not finalize downloaded model")
+        target
+    }
+}

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/SettingsViewModel.kt
@@ -51,6 +51,7 @@ object AiModels {
     const val CEREBRAS_LLAMA = "CEREBRAS_LLAMA"
     const val HF_INFERENCE = "HF_INFERENCE"
     const val MISTRAL_SMALL = "MISTRAL_SMALL"
+    const val LOCAL_MODEL = "LOCAL_MODEL"
 
     val JULES = AiModel(JULES_DEFAULT, "Jules", SettingsViewModel.KEY_API_KEY)
     // Display name tracks the actual model id used in GeminiAdapter (currently
@@ -77,7 +78,11 @@ object AiModels {
     val HF        = AiModel(HF_INFERENCE,    "Hugging Face Inference",     SettingsViewModel.KEY_HF_API_KEY)
     val MISTRAL   = AiModel(MISTRAL_SMALL,   "Mistral Small (free)",       SettingsViewModel.KEY_MISTRAL_API_KEY)
 
-    val availableModels = listOf(NANO, BRIDGE, GEMINI, GROQ, CEREBRAS, HF, MISTRAL, JULES, CLI)
+    // User-downloaded / system-managed on-device model. No API key; the active
+    // model + runtime are chosen under Settings → On-device models.
+    val LOCAL     = AiModel(LOCAL_MODEL,     "On-device model",            "")
+
+    val availableModels = listOf(NANO, BRIDGE, LOCAL, GEMINI, GROQ, CEREBRAS, HF, MISTRAL, JULES, CLI)
 
     fun findById(id: String?): AiModel? = availableModels.find { it.id == id }
 }

--- a/version.properties
+++ b/version.properties
@@ -2,4 +2,4 @@
 build=43
 major=1
 minor=12
-patch=6
+patch=7


### PR DESCRIPTION
Re-opened against master (original #677 auto-closed when its stacked base merged).

Runtime-agnostic foundation for **user-downloadable on-device models**: `LocalModelRuntime` interface + registry (AICore implemented; MediaPipe/llama.cpp/ONNX reflection-detected), `LocalModelCatalog`, `ModelDownloadManager` (progress/Range-resume/token/delete), `LocalModelStore`, `LocalLlmAdapter`, and `AiModels.LOCAL_MODEL` + factory wiring. Compiles; no native deps yet. Next: per-runtime backends + a Settings → On-device models UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)