### PR TITLE
feat(ai): wire MediaPipe LLM Inference on-device runtime

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -202,6 +202,7 @@ dependencies {
     implementation(libs.bouncycastle.bcprov)
     implementation(libs.google.genai)
     implementation(libs.google.ai.edge.aicore)
+    implementation(libs.mediapipe.tasks.genai)
     implementation(libs.androidx.localbroadcastmanager)
     implementation(libs.aznavrail)
     implementation(libs.androidx.navigation.compose)

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -50,6 +50,13 @@
 -dontwarn org.bouncycastle.**
 -dontwarn javax.naming.**
 
+# ---- MediaPipe LLM Inference (on-device runtime; JNI/native) ----------------
+# MediaPipe resolves Java classes from native code by name, so keep it whole.
+-keep class com.google.mediapipe.** { *; }
+-dontwarn com.google.mediapipe.**
+-keep class com.google.protobuf.** { *; }
+-dontwarn com.google.protobuf.**
+
 # ---- JGit -----------------------------------------------------------------
 -keep class org.eclipse.jgit.** { *; }
 -dontwarn org.eclipse.jgit.**

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ai/local/LocalModelRuntime.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ai/local/LocalModelRuntime.kt
@@ -3,6 +3,9 @@ package com.hereliesaz.ideaz.ai.local
 import android.content.Context
 import com.google.ai.edge.aicore.GenerativeModel
 import com.google.ai.edge.aicore.generationConfig
+import com.google.mediapipe.tasks.genai.llminference.LlmInference
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.io.File
 
 /** Thrown when a runtime's backend library isn't present in this build yet. */
@@ -32,14 +35,26 @@ interface LocalModelRuntime {
 internal fun classPresent(fqcn: String): Boolean =
     runCatching { Class.forName(fqcn, false, LocalModelRuntime::class.java.classLoader) }.isSuccess
 
-/** MediaPipe LLM Inference — Gemma/Phi/Falcon `.task` models. Wired in a follow-up. */
+/** MediaPipe LLM Inference — Gemma/Phi/Falcon `.task` models. */
 object MediaPipeRuntime : LocalModelRuntime {
     override val id = "mediapipe"
     override val displayName = "MediaPipe LLM Inference"
     override fun isAvailable(context: Context) =
         classPresent("com.google.mediapipe.tasks.genai.llminference.LlmInference")
+
     override suspend fun generate(context: Context, modelFile: File, prompt: String): String =
-        throw LocalRuntimeUnavailableException(displayName)
+        withContext(Dispatchers.IO) {
+            // Loads the model and runs a one-shot generation. (Per-call load is
+            // simple and correct; caching the engine across calls is a future
+            // optimization but needs careful native-resource lifecycle handling.)
+            val options = LlmInference.LlmInferenceOptions.builder()
+                .setModelPath(modelFile.absolutePath)
+                .setMaxTokens(1024)
+                .build()
+            LlmInference.createFromOptions(context.applicationContext, options).use { llm ->
+                llm.generateResponse(prompt)
+            }
+        }
 }
 
 /** llama.cpp — any GGUF model. Wired in a follow-up. */

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,6 +35,7 @@ json = "20260522"
 appcompat = "1.7.1"
 webkit = "1.16.0"
 aicore = "0.0.1-exp02"
+mediapipeGenai = "0.10.24"
 
 # Security-bumped versions for JGit's vulnerable transitive deps (Dependabot #26,
 # #27, #29 Bouncy Castle; #30 Apache HttpClient XSS; #31 commons-lang3 recursion).
@@ -60,6 +61,7 @@ androidx-navigation-compose = { module = "androidx.navigation:navigation-compose
 aznavrail = { module = "com.github.HereLiesAz:AzNavRail", version.ref = "aznavrail" }
 google-genai = { module = "com.google.genai:google-genai", version.ref = "googleGenai" }
 google-ai-edge-aicore = { module = "com.google.ai.edge.aicore:aicore", version.ref = "aicore" }
+mediapipe-tasks-genai = { module = "com.google.mediapipe:tasks-genai", version.ref = "mediapipeGenai" }
 mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "mockwebserver" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }

--- a/version.properties
+++ b/version.properties
@@ -2,4 +2,4 @@
 build=43
 major=1
 minor=12
-patch=9
+patch=10


### PR DESCRIPTION
Recreated against master (original #681 auto-closed when its stacked base merged). Adds com.google.mediapipe:tasks-genai:0.10.24; MediaPipeRuntime.generate() runs the downloaded .task model via LlmInference; R8 keep rules added. Compile-verified; inference + catalog URLs need device verification. 🤖 Generated with [Claude Code](https://claude.com/claude-code)