### PR TITLE
feat(ai): multi-file model support + honest llama.cpp/ONNX status

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ai/local/LocalModelCatalog.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ai/local/LocalModelCatalog.kt
@@ -7,6 +7,9 @@ package com.hereliesaz.ideaz.ai.local
  * before the download will succeed. URLs are direct download links; the download
  * manager is URL-generic, so this catalog can grow without code changes.
  */
+/** One extra file that belongs to a multi-file model (e.g. an ONNX model dir). */
+data class LocalModelFile(val url: String, val fileName: String)
+
 data class LocalModel(
     val id: String,
     val name: String,
@@ -17,6 +20,13 @@ data class LocalModel(
     val requiresAuth: Boolean = false,
     /** True for runtimes that manage their own model (e.g. AICore): no file download. */
     val systemManaged: Boolean = false,
+    /**
+     * Extra files for multi-file models. ONNX GenAI ships a *directory* (model +
+     * genai_config.json + tokenizer files); all files download into the model's
+     * own directory, which the runtime is pointed at. Empty for single-file
+     * models (MediaPipe `.task`, llama.cpp `.gguf`).
+     */
+    val additionalFiles: List<LocalModelFile> = emptyList(),
     val notes: String = "",
 )
 
@@ -56,15 +66,26 @@ object LocalModelCatalog {
             fileName = "gemma-2-2b-it.Q4_K_M.gguf",
             notes = "Stronger; wants ~3 GB free RAM.",
         ),
-        LocalModel(
-            id = "phi3_5-mini-onnx",
-            name = "Phi-3.5 Mini Instruct (ONNX GenAI)",
-            runtimeId = "onnx",
-            url = "https://huggingface.co/microsoft/Phi-3.5-mini-instruct-onnx/resolve/main/cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4/model.onnx.data",
-            approxSizeBytes = 2_200_000_000,
-            fileName = "phi3.5-mini.onnx.data",
-            notes = "ONNX Runtime GenAI; CPU int4.",
-        ),
+        run {
+            val base = "https://huggingface.co/microsoft/Phi-3.5-mini-instruct-onnx/resolve/main/" +
+                "cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4/"
+            LocalModel(
+                id = "phi3_5-mini-onnx",
+                name = "Phi-3.5 Mini Instruct (ONNX GenAI · CPU int4)",
+                runtimeId = "onnx",
+                url = base + "model.onnx",
+                approxSizeBytes = 2_200_000_000,
+                fileName = "model.onnx",
+                additionalFiles = listOf(
+                    LocalModelFile(base + "model.onnx.data", "model.onnx.data"),
+                    LocalModelFile(base + "genai_config.json", "genai_config.json"),
+                    LocalModelFile(base + "tokenizer.json", "tokenizer.json"),
+                    LocalModelFile(base + "tokenizer_config.json", "tokenizer_config.json"),
+                    LocalModelFile(base + "special_tokens_map.json", "special_tokens_map.json"),
+                ),
+                notes = "ONNX Runtime GenAI; multi-file model directory. Verify file list before use.",
+            )
+        },
         LocalModel(
             id = "gemma2-2b-it-mediapipe",
             name = "Gemma 2 2B Instruct (MediaPipe .task)",

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ai/local/LocalModelRuntime.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ai/local/LocalModelRuntime.kt
@@ -57,7 +57,12 @@ object MediaPipeRuntime : LocalModelRuntime {
         }
 }
 
-/** llama.cpp — any GGUF model. Wired in a follow-up. */
+/**
+ * llama.cpp — any GGUF model. Pending its native backend: llama.cpp has no
+ * published Android Maven artifact, so enabling it means adding an NDK module
+ * (CMake build of libllama + the `android.llama.cpp.LLamaAndroid` JNI class).
+ * Until that's present [isAvailable] is false and [generate] reports it.
+ */
 object LlamaCppRuntime : LocalModelRuntime {
     override val id = "llamacpp"
     override val displayName = "llama.cpp (GGUF)"
@@ -67,7 +72,13 @@ object LlamaCppRuntime : LocalModelRuntime {
         throw LocalRuntimeUnavailableException(displayName)
 }
 
-/** ONNX Runtime GenAI — Phi-3/3.5, Qwen. Wired in a follow-up. */
+/**
+ * ONNX Runtime GenAI — Phi-3/3.5, Qwen (multi-file model directory). Pending its
+ * backend: add the `com.microsoft.onnxruntime:onnxruntime-genai-android` AAR
+ * (confirm the published version/coordinates), then drive `ai.onnxruntime.genai`
+ * (SimpleGenAI/Model) over the downloaded model directory ([modelFile]'s parent).
+ * Until the dependency is present [isAvailable] is false and [generate] reports it.
+ */
 object OnnxGenAiRuntime : LocalModelRuntime {
     override val id = "onnx"
     override val displayName = "ONNX Runtime GenAI"

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ai/local/ModelDownloadManager.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ai/local/ModelDownloadManager.kt
@@ -11,9 +11,11 @@ import java.io.IOException
 import java.util.concurrent.TimeUnit
 
 /**
- * Downloads on-device model files into `<filesDir>/local-models/`, with progress
- * reporting, HTTP-Range resume of a partial download, and an optional bearer token
- * for gated models. URL-generic, so it works for any [LocalModel].
+ * Downloads on-device model files into a per-model directory
+ * `<filesDir>/local-models/<id>/`, with progress, HTTP-Range resume, and an
+ * optional bearer token for gated models. Handles both single-file models
+ * (MediaPipe `.task`, llama.cpp `.gguf`) and multi-file models (ONNX GenAI's
+ * model + config + tokenizer directory).
  */
 class ModelDownloadManager(
     context: Context,
@@ -22,42 +24,70 @@ class ModelDownloadManager(
         .readTimeout(60, TimeUnit.SECONDS)
         .build(),
 ) {
-    private val dir = File(context.filesDir, "local-models").apply { mkdirs() }
+    private val root = File(context.filesDir, "local-models").apply { mkdirs() }
 
-    fun fileFor(model: LocalModel): File = File(dir, model.fileName)
-    fun isDownloaded(model: LocalModel): Boolean =
-        model.systemManaged || fileFor(model).let { it.isFile && it.length() > 0 }
-    fun delete(model: LocalModel): Boolean = !model.systemManaged && fileFor(model).delete()
+    /** The directory all of [model]'s files live in. */
+    fun modelDir(model: LocalModel): File = File(root, model.id)
+
+    /** The model's primary file (runtimes that need a directory use its parent). */
+    fun fileFor(model: LocalModel): File = File(modelDir(model), model.fileName)
+
+    private fun filesOf(model: LocalModel): List<LocalModelFile> =
+        listOf(LocalModelFile(model.url, model.fileName)) + model.additionalFiles
+
+    fun isDownloaded(model: LocalModel): Boolean = model.systemManaged ||
+        filesOf(model).all { File(modelDir(model), it.fileName).let { f -> f.isFile && f.length() > 0 } }
+
+    fun delete(model: LocalModel): Boolean = !model.systemManaged && modelDir(model).deleteRecursively()
 
     /**
-     * Download [model], resuming a `.part` file if one exists. [onProgress] gets
-     * (bytesDownloaded, totalBytes); total is -1 when the server doesn't report it.
-     * Returns the finalized model file.
+     * Download every file of [model] into its directory, resuming partial files.
+     * [onProgress] reports cumulative bytes and the catalog's size estimate
+     * (`approxSizeBytes`, or -1 if unknown) for an overall progress bar.
+     * Returns the model's primary file.
      */
     suspend fun download(
         model: LocalModel,
         authToken: String? = null,
         onProgress: (downloaded: Long, total: Long) -> Unit = { _, _ -> },
     ): File = withContext(Dispatchers.IO) {
-        val target = fileFor(model)
-        if (target.isFile && target.length() > 0) return@withContext target
+        val mdir = modelDir(model).apply { mkdirs() }
+        val approxTotal = if (model.approxSizeBytes > 0) model.approxSizeBytes else -1L
+        var cumulative = 0L
 
-        val part = File(dir, model.fileName + ".part")
+        for (f in filesOf(model)) {
+            val target = File(mdir, f.fileName)
+            if (target.isFile && target.length() > 0) {
+                cumulative += target.length()
+                onProgress(cumulative, approxTotal)
+                continue
+            }
+            val base = cumulative
+            downloadOne(f, mdir, authToken) { soFar -> onProgress(base + soFar, approxTotal) }
+            cumulative += target.length()
+        }
+        fileFor(model)
+    }
+
+    private fun downloadOne(
+        f: LocalModelFile,
+        mdir: File,
+        authToken: String?,
+        onBytes: (Long) -> Unit,
+    ) {
+        val target = File(mdir, f.fileName)
+        val part = File(mdir, f.fileName + ".part")
         val existing = if (part.isFile) part.length() else 0L
 
-        val request = Request.Builder().url(model.url).apply {
+        val request = Request.Builder().url(f.url).apply {
             if (existing > 0) header("Range", "bytes=$existing-")
             if (!authToken.isNullOrBlank()) header("Authorization", "Bearer $authToken")
         }.build()
 
         client.newCall(request).execute().use { resp ->
-            if (!resp.isSuccessful) throw IOException("Download failed: HTTP ${resp.code}")
+            if (!resp.isSuccessful) throw IOException("Download failed for ${f.fileName}: HTTP ${resp.code}")
             val body = resp.body
             val resuming = resp.code == 206
-            val total = body.contentLength().let { len ->
-                if (len < 0) -1L else len + (if (resuming) existing else 0L)
-            }
-
             val append = resuming && existing > 0
             if (!append) part.delete()
             var downloaded = if (append) existing else 0L
@@ -70,7 +100,7 @@ class ModelDownloadManager(
                         if (n == -1) break
                         output.write(buf, 0, n)
                         downloaded += n
-                        onProgress(downloaded, total)
+                        onBytes(downloaded)
                     }
                     output.fd.sync()
                 }
@@ -78,7 +108,6 @@ class ModelDownloadManager(
         }
 
         if (target.exists()) target.delete()
-        if (!part.renameTo(target)) throw IOException("Could not finalize downloaded model")
-        target
+        if (!part.renameTo(target)) throw IOException("Could not finalize ${f.fileName}")
     }
 }

--- a/version.properties
+++ b/version.properties
@@ -2,4 +2,4 @@
 build=43
 major=1
 minor=12
-patch=10
+patch=11


### PR DESCRIPTION
Multi-file model download support (per-model dir; primary + additional files; per-file resume + aggregate progress) — what ONNX GenAI's directory models need. ONNX catalog entry rebuilt as a real multi-file Phi-3.5-mini directory (URLs need verification).

**Honest status on the two native backends** (couldn't be wired from this environment): llama.cpp has no Android Maven artifact (needs an NDK module); onnxruntime-genai-android's coordinates/version couldn't be confirmed so the dep wasn't added. Both stay registered runtimes that report "backend not in this build" — the picker degrades cleanly. Doc comments capture the exact integration steps.

Compile-verified. 🤖 Generated with [Claude Code](https://claude.com/claude-code)