### PR TITLE
Fix Protobuf Duplicate Class Build Failure

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -200,7 +200,9 @@ dependencies {
     // Used for libsodium-compatible crypto_box_seal (GithubSecretBox) to encrypt
     // GitHub Actions secrets. R8 strips the unused remainder of bcprov in release.
     implementation(libs.bouncycastle.bcprov)
-    implementation(libs.google.genai)
+    implementation(libs.google.genai) {
+        exclude(group = "com.google.protobuf", module = "protobuf-java")
+    }
     implementation(libs.google.ai.edge.aicore)
     implementation(libs.mediapipe.tasks.genai)
     implementation(libs.androidx.localbroadcastmanager)

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -15,3 +15,4 @@ When Phase 0 completes, this file will point to Phase 1's plan.
 - Fixed compilation error in `AiChatTab.kt` by updating it to pass `MainViewModel` to `ContextlessChatInput`.
 - Fixed CodeQL high priority "Zip Slip" vulnerability in `BackupManager.kt` and `RemoteBuildManager.kt`.
 - Improved crash reporting by allowing explicit stack trace strings in `GithubIssueReporter`, fixing an issue where fatal crashes had their stack traces truncated or lost.
+- Fixed build failure caused by duplicate classes in `protobuf-java` and `protobuf-javalite` by excluding `protobuf-java` from `google-genai`.

--- a/version.properties
+++ b/version.properties
@@ -1,5 +1,5 @@
-#IDEaz version
-build=43
+#Fri Jun 05 14:26:53 UTC 2026
+build=46
 major=1
 minor=12
-patch=10
+patch=11


### PR DESCRIPTION
Resolved a critical build failure caused by duplicate class definitions between the full Java and Lite versions of the Protobuf library. The conflict was traced to `google-genai` (pulling in `protobuf-java`) and `mediapipe-tasks-genai` (pulling in `protobuf-javalite`).

Changes:
- Modified `app/build.gradle.kts` to exclude `protobuf-java` from the `google-genai` dependency.
- Incremented the patch version in `version.properties`.
- Updated `docs/TODO.md` to reflect the fix.
- Verified the fix by running `./gradlew :app:assembleDebug`, which succeeded.
- Cleaned up diagnostic files used during research.

Fixes #685

---
*PR created automatically by Jules for task [3594355844472158220](https://jules.google.com/task/3594355844472158220) started by @HereLiesAz*