### PR TITLE
Fix MediaPipe build failure and update documentation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -202,6 +202,9 @@ dependencies {
     implementation(libs.bouncycastle.bcprov)
     implementation(libs.google.genai)
     implementation(libs.google.ai.edge.aicore)
+    implementation(libs.mediapipe.tasks.genai) {
+        exclude(group = "com.google.protobuf", module = "protobuf-javalite")
+    }
     implementation(libs.androidx.localbroadcastmanager)
     implementation(libs.aznavrail)
     implementation(libs.androidx.navigation.compose)

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -50,6 +50,13 @@
 -dontwarn org.bouncycastle.**
 -dontwarn javax.naming.**
 
+# ---- MediaPipe LLM Inference (on-device runtime; JNI/native) ----------------
+# MediaPipe resolves Java classes from native code by name, so keep it whole.
+-keep class com.google.mediapipe.** { *; }
+-dontwarn com.google.mediapipe.**
+-keep class com.google.protobuf.** { *; }
+-dontwarn com.google.protobuf.**
+
 # ---- JGit -----------------------------------------------------------------
 -keep class org.eclipse.jgit.** { *; }
 -dontwarn org.eclipse.jgit.**

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ai/local/LocalModelRuntime.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ai/local/LocalModelRuntime.kt
@@ -3,6 +3,9 @@ package com.hereliesaz.ideaz.ai.local
 import android.content.Context
 import com.google.ai.edge.aicore.GenerativeModel
 import com.google.ai.edge.aicore.generationConfig
+import com.google.mediapipe.tasks.genai.llminference.LlmInference
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.io.File
 
 /** Thrown when a runtime's backend library isn't present in this build yet. */
@@ -32,14 +35,26 @@ interface LocalModelRuntime {
 internal fun classPresent(fqcn: String): Boolean =
     runCatching { Class.forName(fqcn, false, LocalModelRuntime::class.java.classLoader) }.isSuccess
 
-/** MediaPipe LLM Inference — Gemma/Phi/Falcon `.task` models. Wired in a follow-up. */
+/** MediaPipe LLM Inference — Gemma/Phi/Falcon `.task` models. */
 object MediaPipeRuntime : LocalModelRuntime {
     override val id = "mediapipe"
     override val displayName = "MediaPipe LLM Inference"
     override fun isAvailable(context: Context) =
         classPresent("com.google.mediapipe.tasks.genai.llminference.LlmInference")
+
     override suspend fun generate(context: Context, modelFile: File, prompt: String): String =
-        throw LocalRuntimeUnavailableException(displayName)
+        withContext(Dispatchers.IO) {
+            // Loads the model and runs a one-shot generation. (Per-call load is
+            // simple and correct; caching the engine across calls is a future
+            // optimization but needs careful native-resource lifecycle handling.)
+            val options = LlmInference.LlmInferenceOptions.builder()
+                .setModelPath(modelFile.absolutePath)
+                .setMaxTokens(1024)
+                .build()
+            LlmInference.createFromOptions(context.applicationContext, options).use { llm ->
+                llm.generateResponse(prompt)
+            }
+        }
 }
 
 /** llama.cpp — any GGUF model. Wired in a follow-up. */

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/OnDeviceModelsSection.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/OnDeviceModelsSection.kt
@@ -1,0 +1,204 @@
+package com.hereliesaz.ideaz.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import com.hereliesaz.aznavrail.AzButton
+import com.hereliesaz.aznavrail.model.AzButtonShape
+import com.hereliesaz.ideaz.ai.local.LocalModelCatalog
+import com.hereliesaz.ideaz.ai.local.LocalModelRuntimes
+import com.hereliesaz.ideaz.ai.local.LocalModelStore
+import com.hereliesaz.ideaz.ai.local.ModelDownloadManager
+import kotlinx.coroutines.launch
+
+private fun humanSize(bytes: Long): String = when {
+    bytes <= 0L -> "—"
+    bytes >= 1_000_000_000L -> "%.1f GB".format(bytes / 1e9)
+    bytes >= 1_000_000L -> "%.0f MB".format(bytes / 1e6)
+    else -> "%.0f KB".format(bytes / 1e3)
+}
+
+/**
+ * Settings section that lets the user download an on-device model (per runtime)
+ * and select which one the "On-device model" AI provider uses. AICore is offered
+ * as a no-download, system-managed entry.
+ */
+@Composable
+fun OnDeviceModelsSection() {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val store = remember { LocalModelStore(context) }
+    val downloads = remember { ModelDownloadManager(context) }
+
+    var activeId by remember { mutableStateOf(store.activeModelId) }
+    var token by remember { mutableStateOf(store.downloadToken ?: "") }
+    val progress = remember { mutableStateMapOf<String, Float>() }   // 0..1, or -1 = indeterminate
+    val downloading = remember { mutableStateMapOf<String, Boolean>() }
+    val errors = remember { mutableStateMapOf<String, String>() }
+    var refresh by remember { mutableStateOf(0) }
+
+    Text(
+        "On-device Models",
+        color = MaterialTheme.colorScheme.onBackground,
+        style = MaterialTheme.typography.titleLarge,
+        modifier = Modifier.semantics { heading() },
+    )
+    Spacer(Modifier.height(8.dp))
+    Text(
+        "Run the AI fully on-device. Download a model (or use the system AICore model), " +
+            "select it below, then choose \"On-device model\" as an AI Assignment above.",
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        style = MaterialTheme.typography.bodySmall,
+    )
+    Spacer(Modifier.height(8.dp))
+
+    if (LocalModelCatalog.models.any { it.requiresAuth }) {
+        OutlinedTextField(
+            value = token,
+            onValueChange = {
+                token = it
+                store.downloadToken = it.ifBlank { null }
+            },
+            label = { Text("Hugging Face token (for gated models)") },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        Spacer(Modifier.height(8.dp))
+    }
+
+    LocalModelCatalog.models.forEach { model ->
+        val runtime = LocalModelRuntimes.byId(model.runtimeId)
+        val backendOk = runtime?.isAvailable(context) == true
+        @Suppress("UNUSED_EXPRESSION") refresh // re-read download state when bumped
+        val downloaded = downloads.isDownloaded(model)
+
+        Card(
+            modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surface,
+                contentColor = MaterialTheme.colorScheme.onSurface,
+            ),
+        ) {
+            Column(Modifier.padding(12.dp)) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    RadioButton(
+                        selected = activeId == model.id,
+                        enabled = downloaded && backendOk,
+                        onClick = {
+                            activeId = model.id
+                            store.activeModelId = model.id
+                        },
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Column(Modifier.weight(1f)) {
+                        Text(model.name, style = MaterialTheme.typography.bodyLarge)
+                        Text(
+                            "${runtime?.displayName ?: model.runtimeId}" +
+                                (if (model.systemManaged) "" else " · ${humanSize(model.approxSizeBytes)}") +
+                                (if (model.requiresAuth) " · gated" else ""),
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            style = MaterialTheme.typography.bodySmall,
+                        )
+                        if (model.notes.isNotBlank()) {
+                            Text(
+                                model.notes,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                style = MaterialTheme.typography.bodySmall,
+                            )
+                        }
+                        if (!backendOk) {
+                            Text(
+                                if (model.systemManaged) "Not available on this device."
+                                else "Runtime backend not included in this build yet.",
+                                color = MaterialTheme.colorScheme.error,
+                                style = MaterialTheme.typography.bodySmall,
+                            )
+                        }
+                        errors[model.id]?.let {
+                            Text(it, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+                        }
+                    }
+                }
+
+                // Download / delete controls (system-managed entries need none).
+                if (!model.systemManaged) {
+                    Spacer(Modifier.height(8.dp))
+                    when {
+                        downloading[model.id] == true -> {
+                            val p = progress[model.id] ?: -1f
+                            if (p in 0f..1f) {
+                                LinearProgressIndicator(progress = { p }, modifier = Modifier.fillMaxWidth())
+                                Text("${(p * 100).toInt()}%", style = MaterialTheme.typography.bodySmall)
+                            } else {
+                                LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                            }
+                        }
+                        downloaded -> {
+                            AzButton(
+                                onClick = {
+                                    downloads.delete(model)
+                                    if (activeId == model.id) {
+                                        activeId = null
+                                        store.activeModelId = null
+                                    }
+                                    refresh++
+                                },
+                                text = "Delete",
+                                shape = AzButtonShape.RECTANGLE,
+                            )
+                        }
+                        else -> {
+                            AzButton(
+                                onClick = {
+                                    errors.remove(model.id)
+                                    downloading[model.id] = true
+                                    progress[model.id] = -1f
+                                    scope.launch {
+                                        try {
+                                            downloads.download(model, token.ifBlank { null }) { d, t ->
+                                                progress[model.id] = if (t > 0) d.toFloat() / t else -1f
+                                            }
+                                        } catch (e: Exception) {
+                                            errors[model.id] = "Download failed: ${e.message}"
+                                        } finally {
+                                            downloading[model.id] = false
+                                            refresh++
+                                        }
+                                    }
+                                },
+                                text = "Download",
+                                shape = AzButtonShape.RECTANGLE,
+                                enabled = !model.requiresAuth || token.isNotBlank(),
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Spacer(Modifier.height(24.dp))
+}

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/SettingsScreen.kt
@@ -532,6 +532,8 @@ fun SettingsScreen(
 
                 Spacer(modifier = Modifier.height(24.dp))
 
+                OnDeviceModelsSection()
+
                 Text("Permissions", color = MaterialTheme.colorScheme.onBackground, style = MaterialTheme.typography.titleLarge, modifier = Modifier.semantics { heading() })
                 Spacer(modifier = Modifier.height(16.dp))
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -15,3 +15,6 @@ When Phase 0 completes, this file will point to Phase 1's plan.
 - Fixed compilation error in `AiChatTab.kt` by updating it to pass `MainViewModel` to `ContextlessChatInput`.
 - Fixed CodeQL high priority "Zip Slip" vulnerability in `BackupManager.kt` and `RemoteBuildManager.kt`.
 - Improved crash reporting by allowing explicit stack trace strings in `GithubIssueReporter`, fixing an issue where fatal crashes had their stack traces truncated or lost.
+- Fixed MediaPipe LLM Inference build failure: resolved duplicate Protobuf classes by excluding `protobuf-javalite` from the MediaPipe dependency.
+- Implemented full MediaPipe LLM Inference on-device runtime, including model loading and one-shot generation.
+- Added "On-device Models" settings section for browsing, downloading, and selecting local LLMs (Gemma, Phi, Qwen).

--- a/docs/file_descriptions.md
+++ b/docs/file_descriptions.md
@@ -57,6 +57,12 @@
 *   `CrashReportingService.kt`: Service for fatal error reporting in `:crash_reporter`.
 *   `ScreenshotService.kt`: `MediaProjection` virtual display for region screenshots.
 
+#### ai/local/
+*   `LocalModelRuntime.kt`: Interface and implementations for on-device backends (MediaPipe, AICore, etc.).
+*   `LocalModelCatalog.kt`: Curated list of downloadable on-device models.
+*   `LocalModelStore.kt`: Manages locally stored model files and metadata.
+*   `ModelDownloadManager.kt`: Handles background downloading of model files with auth support.
+
 #### ui/
 *   `MainViewModel.kt`: Coordinator. Logic delegated to `ui/delegates/`.
 *   `SettingsViewModel.kt`: Manages user preferences.
@@ -72,6 +78,7 @@
 *   `LibrariesScreen.kt`: Dependency management UI.
 *   `CodeEditor.kt`: Compose component for code display.
 *   `PromptPopup.kt`: Simple dialog for text input.
+*   `OnDeviceModelsSection.kt`: Settings UI for managing on-device LLMs.
 *   `SheetDetents.kt`: Bottom sheet expansion states.
 *   `ContextlessChatInput.kt`: Prompt input outside element-tap context.
 *   `DragIndication.kt`: Visual handle for draggable UI elements.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,6 +35,7 @@ json = "20260522"
 appcompat = "1.7.1"
 webkit = "1.16.0"
 aicore = "0.0.1-exp02"
+mediapipeGenai = "0.10.24"
 
 # Security-bumped versions for JGit's vulnerable transitive deps (Dependabot #26,
 # #27, #29 Bouncy Castle; #30 Apache HttpClient XSS; #31 commons-lang3 recursion).
@@ -60,6 +61,7 @@ androidx-navigation-compose = { module = "androidx.navigation:navigation-compose
 aznavrail = { module = "com.github.HereLiesAz:AzNavRail", version.ref = "aznavrail" }
 google-genai = { module = "com.google.genai:google-genai", version.ref = "googleGenai" }
 google-ai-edge-aicore = { module = "com.google.ai.edge.aicore:aicore", version.ref = "aicore" }
+mediapipe-tasks-genai = { module = "com.google.mediapipe:tasks-genai", version.ref = "mediapipeGenai" }
 mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "mockwebserver" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }

--- a/version.properties
+++ b/version.properties
@@ -1,5 +1,5 @@
-#IDEaz version
-build=43
+#Fri Jun 05 14:33:33 UTC 2026
+build=55
 major=1
 minor=12
-patch=8
+patch=10


### PR DESCRIPTION
This PR fixes the build failure on the `feat/mediapipe-runtime` branch.

### Changes:
1.  **Dependency Fix:** In `app/build.gradle.kts`, added an `exclude` rule to the MediaPipe GenAI dependency to remove `protobuf-javalite`. This resolves the "Duplicate class found" errors caused by the coexistence of `protobuf-java` (from Gemini) and `protobuf-javalite` (from MediaPipe).
2.  **Documentation:** Updated `docs/TODO.md` and `docs/file_descriptions.md` to include the newly implemented on-device AI features (MediaPipe runtime and model management UI).
3.  **Verification:** 
    *   Successfully ran `./gradlew :app:assembleDebug` after the fix.
    *   Verified that AI-related unit tests (`GeminiAdapterTest`, `ConversationalAiClientTest`, `IdeToolsTest`) pass.
    *   Confirmed the fix on the `feat/mediapipe-runtime` branch.


Fixes #682

---
*PR created automatically by Jules for task [10834376742880195072](https://jules.google.com/task/10834376742880195072) started by @HereLiesAz*