### PR TITLE
docs/scaffold: ONNX + llama.cpp on-device runtime integration

### DIFF
--- a/docs/on-device-runtimes.md
+++ b/docs/on-device-runtimes.md
@@ -1,0 +1,103 @@
+# On-device LLM runtimes — integration guide
+
+IDEaz ships a pluggable on-device model framework (`ai/local/`): a
+`LocalModelRuntime` registry, a multi-file `ModelDownloadManager`, a catalog, the
+`LocalLlmAdapter`, and the **On-device Models** Settings section.
+
+Working today:
+- **AICore (Gemini Nano)** — `AiCoreRuntime`, system-managed, no download.
+- **MediaPipe LLM Inference** — `MediaPipeRuntime`, wired (`com.google.mediapipe:tasks-genai`).
+
+Pending their native backends (this guide): **ONNX Runtime GenAI** and **llama.cpp**.
+Both are registered runtimes that report "backend not in this build" until wired,
+so the picker degrades cleanly.
+
+---
+
+## ONNX Runtime GenAI
+
+**Why it isn't wired yet:** `com.microsoft.onnxruntime:onnxruntime-genai-android`
+does **not** resolve from Maven Central (tried 0.5.2 and 0.6.0). Microsoft ships
+the GenAI **Android AAR via GitHub releases**, not Maven Central. So it must be
+vendored (or you must supply the exact Maven coordinates if a mirror publishes it).
+
+### 1. Vendor the AAR
+Download `onnxruntime-genai-android-<ver>.aar` from
+https://github.com/microsoft/onnxruntime-genai/releases into `app/libs/`, then in
+`app/build.gradle.kts`:
+```kotlin
+implementation(files("libs/onnxruntime-genai-android-<ver>.aar"))
+// GenAI depends on onnxruntime-android at runtime:
+implementation("com.microsoft.onnxruntime:onnxruntime-android:1.20.0")
+```
+
+### 2. Implement `OnnxGenAiRuntime.generate()` (in `ai/local/LocalModelRuntime.kt`)
+The model is a **directory** — our `ModelDownloadManager` already downloads all
+files into one (`additionalFiles`), so point the runtime at the parent dir:
+```kotlin
+override suspend fun generate(context: Context, modelFile: File, prompt: String): String =
+    withContext(Dispatchers.IO) {
+        val modelDir = modelFile.parentFile!!.absolutePath
+        ai.onnxruntime.genai.Model(modelDir).use { model ->
+            ai.onnxruntime.genai.Tokenizer(model).use { tok ->
+                val sequences = tok.encode(prompt)
+                ai.onnxruntime.genai.GeneratorParams(model).use { params ->
+                    params.setSearchOption("max_length", 1024.0)
+                    ai.onnxruntime.genai.Generator(model, params).use { gen ->
+                        gen.appendTokenSequences(sequences)
+                        val out = StringBuilder()
+                        ai.onnxruntime.genai.TokenizerStream(tok).use { stream ->
+                            while (!gen.isDone) {
+                                gen.generateNextToken()
+                                out.append(stream.decode(gen.getLastTokenInSequence(0)))
+                            }
+                        }
+                        out.toString()
+                    }
+                }
+            }
+        }
+    }
+```
+> The exact `ai.onnxruntime.genai` API varies across versions — confirm method
+> names against the AAR you vendored (`javap` the bundled `classes.jar`).
+
+### 3. R8 (`proguard-rules.pro`)
+```
+-keep class ai.onnxruntime.** { *; }
+-dontwarn ai.onnxruntime.**
+```
+
+### 4. Catalog
+The `phi3_5-mini-onnx` entry in `LocalModelCatalog` lists the model directory's
+files — **verify the file list/URLs** against the model card before shipping.
+
+---
+
+## llama.cpp (GGUF)
+
+**Why it isn't wired yet:** llama.cpp has **no published Android Maven artifact**.
+It needs an NDK module that builds `libllama` and exposes a JNI binding. A scaffold
+is provided in `/llama-cpp-module/` — see its `README.md`. Summary:
+
+1. Add llama.cpp as a submodule inside the module:
+   `git submodule add https://github.com/ggml-org/llama.cpp llama-cpp-module/llama.cpp`
+2. Include the module: in `settings.gradle.kts` add `include(":llama-cpp-module")`.
+3. Depend on it: in `app/build.gradle.kts` add
+   `implementation(project(":llama-cpp-module"))`.
+4. Replace `LlamaCppRuntime.generate()` with a direct call to
+   `android.llama.cpp.LLamaAndroid` (the scaffold's binding), e.g.:
+```kotlin
+override suspend fun generate(context: Context, modelFile: File, prompt: String): String {
+    val llm = android.llama.cpp.LLamaAndroid.instance()
+    llm.load(modelFile.absolutePath)
+    return try { llm.complete(prompt, maxTokens = 512) } finally { llm.unload() }
+}
+```
+5. R8 (`proguard-rules.pro`):
+```
+-keep class android.llama.cpp.** { *; }
+```
+
+`isAvailable()` already detects `android.llama.cpp.LLamaAndroid`, so the runtime
+activates automatically once the module is on the classpath.

--- a/llama-cpp-module/CMakeLists.txt
+++ b/llama-cpp-module/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.22.1)
+project("llama-android")
+
+# llama.cpp must be present as a git submodule at ./llama.cpp (see README.md).
+set(LLAMA_BUILD_TESTS    OFF CACHE BOOL "" FORCE)
+set(LLAMA_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+set(LLAMA_BUILD_SERVER   OFF CACHE BOOL "" FORCE)
+set(LLAMA_BUILD_COMMON   ON  CACHE BOOL "" FORCE)
+add_subdirectory(llama.cpp build-llama)
+
+add_library(llama-android SHARED llama-android.cpp)
+
+find_library(log-lib log)
+# `common` provides common_init_from_params / tokenization helpers used by the glue.
+target_link_libraries(llama-android llama common android ${log-lib})

--- a/llama-cpp-module/README.md
+++ b/llama-cpp-module/README.md
@@ -1,0 +1,34 @@
+# llama-cpp-module (scaffold)
+
+A starting point for running GGUF models on-device via llama.cpp. It is **not**
+wired into the IDEaz build (not in `settings.gradle.kts`), so the app builds
+without it. Activating it makes `LlamaCppRuntime` (`ai/local/LocalModelRuntime.kt`)
+usable, because that runtime already detects `android.llama.cpp.LLamaAndroid`.
+
+llama.cpp has no published Android Maven artifact, so it must be built from source
+with the NDK — hence a module rather than a dependency line.
+
+## Activate
+
+1. Add llama.cpp as a submodule inside this module:
+   ```
+   git submodule add https://github.com/ggml-org/llama.cpp llama-cpp-module/llama.cpp
+   ```
+   Pin a known-good tag; the C API in `llama-android.cpp` targets a recent
+   release and may need small adjustments to match the tag you pin.
+
+2. Include + depend on the module:
+   - `settings.gradle.kts`: `include(":llama-cpp-module")`
+   - `app/build.gradle.kts`: `implementation(project(":llama-cpp-module"))`
+
+3. Implement `LlamaCppRuntime.generate()` (see `docs/on-device-runtimes.md`) to
+   call `android.llama.cpp.LLamaAndroid`.
+
+4. R8 (`app/proguard-rules.pro`): `-keep class android.llama.cpp.** { *; }`
+
+## Notes
+- `abiFilters` is set to `arm64-v8a` only (most phones). Add `x86_64` for the
+  emulator. Each ABI multiplies native size + build time.
+- This adds tens of MB of native code; verify APK size and on-device inference
+  on real hardware. None of this can be compile- or run-verified without the
+  submodule + NDK toolchain.

--- a/llama-cpp-module/build.gradle.kts
+++ b/llama-cpp-module/build.gradle.kts
@@ -1,0 +1,42 @@
+// Android library module wrapping llama.cpp via JNI. NOT included in
+// settings.gradle.kts by default — see README.md to activate.
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "android.llama.cpp"
+    compileSdk = 37
+
+    defaultConfig {
+        minSdk = 30
+        ndk {
+            // Add "x86_64" for the emulator. Each ABI multiplies size + build time.
+            abiFilters += listOf("arm64-v8a")
+        }
+        externalNativeBuild {
+            cmake {
+                cppFlags += "-std=c++17"
+                arguments += listOf("-DGGML_OPENMP=OFF", "-DLLAMA_CURL=OFF")
+            }
+        }
+    }
+
+    externalNativeBuild {
+        cmake {
+            path = file("CMakeLists.txt")
+            version = "3.22.1"
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
+    }
+    kotlin { jvmToolchain(21) }
+}
+
+dependencies {
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.11.0")
+}

--- a/llama-cpp-module/src/main/AndroidManifest.xml
+++ b/llama-cpp-module/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest />

--- a/llama-cpp-module/src/main/cpp/llama-android.cpp
+++ b/llama-cpp-module/src/main/cpp/llama-android.cpp
@@ -1,0 +1,84 @@
+// JNI glue for llama.cpp — SKELETON.
+//
+// Targets a recent llama.cpp C API (llama_model_load_from_file / llama_init_from_model
+// / llama_sampler_*). The C API still shifts between releases, so match this to the
+// tag you pin as the ./llama.cpp submodule and adjust names if the build complains.
+// This cannot be compiled or run-verified without that submodule + the NDK.
+
+#include <jni.h>
+#include <android/log.h>
+#include <string>
+#include <vector>
+#include "llama.h"
+
+#define LOG_TAG "llama-android"
+#define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__)
+
+extern "C" JNIEXPORT jlong JNICALL
+Java_android_llama_cpp_LLamaAndroid_nativeLoad(JNIEnv *env, jobject, jstring jpath) {
+    static bool backend_inited = false;
+    if (!backend_inited) { llama_backend_init(); backend_inited = true; }
+
+    const char *path = env->GetStringUTFChars(jpath, nullptr);
+    llama_model_params mparams = llama_model_default_params();
+    llama_model *model = llama_model_load_from_file(path, mparams);
+    env->ReleaseStringUTFChars(jpath, path);
+    if (model == nullptr) { LOGE("model load failed"); return 0; }
+    return reinterpret_cast<jlong>(model);
+}
+
+extern "C" JNIEXPORT jstring JNICALL
+Java_android_llama_cpp_LLamaAndroid_nativeComplete(JNIEnv *env, jobject, jlong modelPtr,
+                                                   jstring jprompt, jint maxTokens) {
+    auto *model = reinterpret_cast<llama_model *>(modelPtr);
+    if (model == nullptr) return env->NewStringUTF("");
+    const llama_vocab *vocab = llama_model_get_vocab(model);
+
+    const char *prompt = env->GetStringUTFChars(jprompt, nullptr);
+    std::string promptStr(prompt);
+    env->ReleaseStringUTFChars(jprompt, prompt);
+
+    // Tokenize.
+    int n_prompt = -llama_tokenize(vocab, promptStr.c_str(), promptStr.size(),
+                                   nullptr, 0, true, true);
+    std::vector<llama_token> tokens(n_prompt);
+    if (llama_tokenize(vocab, promptStr.c_str(), promptStr.size(),
+                       tokens.data(), tokens.size(), true, true) < 0) {
+        return env->NewStringUTF("");
+    }
+
+    llama_context_params cparams = llama_context_default_params();
+    cparams.n_ctx = n_prompt + maxTokens + 8;
+    cparams.n_batch = cparams.n_ctx;
+    llama_context *ctx = llama_init_from_model(model, cparams);
+    if (ctx == nullptr) { LOGE("ctx init failed"); return env->NewStringUTF(""); }
+
+    // Greedy sampler.
+    llama_sampler *smpl = llama_sampler_chain_init(llama_sampler_chain_default_params());
+    llama_sampler_chain_add(smpl, llama_sampler_init_greedy());
+
+    std::string out;
+    llama_batch batch = llama_batch_get_one(tokens.data(), tokens.size());
+    int generated = 0;
+    char piece[256];
+
+    while (generated < maxTokens) {
+        if (llama_decode(ctx, batch) != 0) break;
+        llama_token next = llama_sampler_sample(smpl, ctx, -1);
+        if (llama_vocab_is_eog(vocab, next)) break;
+        int n = llama_token_to_piece(vocab, next, piece, sizeof(piece), 0, true);
+        if (n > 0) out.append(piece, n);
+        batch = llama_batch_get_one(&next, 1);
+        generated++;
+    }
+
+    llama_sampler_free(smpl);
+    llama_free(ctx);
+    return env->NewStringUTF(out.c_str());
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_android_llama_cpp_LLamaAndroid_nativeUnload(JNIEnv *, jobject, jlong modelPtr) {
+    auto *model = reinterpret_cast<llama_model *>(modelPtr);
+    if (model != nullptr) llama_model_free(model);
+}

--- a/llama-cpp-module/src/main/java/android/llama/cpp/LLamaAndroid.kt
+++ b/llama-cpp-module/src/main/java/android/llama/cpp/LLamaAndroid.kt
@@ -1,0 +1,51 @@
+package android.llama.cpp
+
+/**
+ * Minimal JNI binding to llama.cpp. Singleton because the native runtime is
+ * process-global. `LlamaCppRuntime` in the app detects this class by name, so its
+ * mere presence on the classpath activates the llama.cpp on-device runtime.
+ *
+ * Synchronous, blocking API (call off the main thread). A streaming variant can
+ * be added later (the official llama.android example returns a Flow).
+ */
+class LLamaAndroid private constructor() {
+
+    @Volatile private var modelPtr: Long = 0L
+
+    private external fun nativeLoad(modelPath: String): Long
+    private external fun nativeComplete(modelPtr: Long, prompt: String, maxTokens: Int): String
+    private external fun nativeUnload(modelPtr: Long)
+
+    /** Load a GGUF model from [path]. Replaces any previously loaded model. */
+    @Synchronized
+    fun load(path: String) {
+        if (modelPtr != 0L) nativeUnload(modelPtr)
+        modelPtr = nativeLoad(path)
+        require(modelPtr != 0L) { "Failed to load model: $path" }
+    }
+
+    /** Generate a completion for [prompt]. Blocks; run on a background thread. */
+    @Synchronized
+    fun complete(prompt: String, maxTokens: Int = 512): String {
+        check(modelPtr != 0L) { "No model loaded" }
+        return nativeComplete(modelPtr, prompt, maxTokens)
+    }
+
+    /** Free native resources. */
+    @Synchronized
+    fun unload() {
+        if (modelPtr != 0L) {
+            nativeUnload(modelPtr)
+            modelPtr = 0L
+        }
+    }
+
+    companion object {
+        private val INSTANCE = LLamaAndroid()
+        fun instance(): LLamaAndroid = INSTANCE
+
+        init {
+            System.loadLibrary("llama-android")
+        }
+    }
+}

--- a/version.properties
+++ b/version.properties
@@ -2,4 +2,4 @@
 build=43
 major=1
 minor=12
-patch=11
+patch=12


### PR DESCRIPTION
Neither native backend is wireable/verifiable from this environment, so this delivers everything to finish them without breaking the build.

- **ONNX**: `onnxruntime-genai-android` does **not** resolve from Maven Central (0.5.2 and 0.6.0 both fail — it ships via GitHub releases). `docs/on-device-runtimes.md` gives AAR-vendoring steps + a ready-to-paste `OnnxGenAiRuntime.generate()` over the multi-file model dir + R8 rules.
- **llama.cpp**: `llama-cpp-module/` — a self-contained NDK module scaffold (build.gradle.kts, CMakeLists, JNI glue, `LLamaAndroid` binding, README). **Not** in settings.gradle, so the app still builds; activates `LlamaCppRuntime` once the submodule + module are added.

Both stay graceful 'backend not in this build' until activated. Native code targets a recent llama.cpp C API and needs matching to your pinned tag — not compile/run-verifiable here. App compile-verified. 🤖 Generated with [Claude Code](https://claude.com/claude-code)