### PR TITLE
Fix duplicate Protobuf class conflict in build

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -200,7 +200,9 @@ dependencies {
     // Used for libsodium-compatible crypto_box_seal (GithubSecretBox) to encrypt
     // GitHub Actions secrets. R8 strips the unused remainder of bcprov in release.
     implementation(libs.bouncycastle.bcprov)
-    implementation(libs.google.genai)
+    implementation(libs.google.genai) {
+        exclude(group = "com.google.protobuf", module = "protobuf-java")
+    }
     implementation(libs.google.ai.edge.aicore)
     implementation(libs.mediapipe.tasks.genai)
     implementation(libs.androidx.localbroadcastmanager)

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -15,3 +15,4 @@ When Phase 0 completes, this file will point to Phase 1's plan.
 - Fixed compilation error in `AiChatTab.kt` by updating it to pass `MainViewModel` to `ContextlessChatInput`.
 - Fixed CodeQL high priority "Zip Slip" vulnerability in `BackupManager.kt` and `RemoteBuildManager.kt`.
 - Improved crash reporting by allowing explicit stack trace strings in `GithubIssueReporter`, fixing an issue where fatal crashes had their stack traces truncated or lost.
+- Resolved build failure caused by duplicate Protobuf classes (`protobuf-java` vs `protobuf-javalite`) by excluding the full Java runtime from `google-genai` in favor of the lite version used by MediaPipe and AI Core.

--- a/version.properties
+++ b/version.properties
@@ -2,4 +2,4 @@
 build=43
 major=1
 minor=12
-patch=10
+patch=11


### PR DESCRIPTION
This PR resolves the build failure on `feat/mediapipe-runtime` by addressing the conflict between `protobuf-java` and `protobuf-javalite`. By excluding the full Java runtime from the `google-genai` dependency, the build correctly falls back to the lite version provided by MediaPipe and AI Core, which is standard for Android applications.

Changes:
- Modified `app/build.gradle.kts` to add the exclusion rule to `libs.google.genai`.
- Incremented `patch` version in `version.properties` to `11`.
- Updated `docs/TODO.md` to reflect the fix.

Fixes #684

---
*PR created automatically by Jules for task [15927248180756798066](https://jules.google.com/task/15927248180756798066) started by @HereLiesAz*