### PR TITLE
Fix Duplicate Protobuf Class Build Failure

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -200,7 +200,9 @@ dependencies {
     // Used for libsodium-compatible crypto_box_seal (GithubSecretBox) to encrypt
     // GitHub Actions secrets. R8 strips the unused remainder of bcprov in release.
     implementation(libs.bouncycastle.bcprov)
-    implementation(libs.google.genai)
+    implementation(libs.google.genai) {
+        exclude(group = "com.google.protobuf", module = "protobuf-java")
+    }
     implementation(libs.google.ai.edge.aicore)
     implementation(libs.mediapipe.tasks.genai)
     implementation(libs.androidx.localbroadcastmanager)

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -15,3 +15,4 @@ When Phase 0 completes, this file will point to Phase 1's plan.
 - Fixed compilation error in `AiChatTab.kt` by updating it to pass `MainViewModel` to `ContextlessChatInput`.
 - Fixed CodeQL high priority "Zip Slip" vulnerability in `BackupManager.kt` and `RemoteBuildManager.kt`.
 - Improved crash reporting by allowing explicit stack trace strings in `GithubIssueReporter`, fixing an issue where fatal crashes had their stack traces truncated or lost.
+- Resolved build failure caused by duplicate `protobuf` classes by excluding `protobuf-java` from `google-genai` and standardizing on `protobuf-javalite`.

--- a/version.properties
+++ b/version.properties
@@ -1,5 +1,5 @@
-#IDEaz version
-build=43
+#Fri Jun 05 15:03:28 UTC 2026
+build=44
 major=1
 minor=12
-patch=12
+patch=13


### PR DESCRIPTION
Resolved a build failure caused by duplicate classes in `protobuf-java` and `protobuf-javalite`. The conflict was introduced by `google-genai` (pulling `protobuf-java`) and `mediapipe-tasks-genai` (pulling `protobuf-javalite`). Since Android projects should prefer the Lite version, I excluded `protobuf-java` from the `google-genai` dependency configuration.

Verification:
- Ran `./gradlew :app:dependencies` to confirm `protobuf-java` is no longer in the runtime classpath.
- Verified Kotlin compilation with `./gradlew :app:compileDebugKotlin`.
- Incremented the patch version in `version.properties` as per `AGENTS.md`.

Fixes #692

---
*PR created automatically by Jules for task [16052780540460395317](https://jules.google.com/task/16052780540460395317) started by @HereLiesAz*