### PR TITLE
Fix Protobuf duplicate class build failure

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -200,7 +200,9 @@ dependencies {
     // Used for libsodium-compatible crypto_box_seal (GithubSecretBox) to encrypt
     // GitHub Actions secrets. R8 strips the unused remainder of bcprov in release.
     implementation(libs.bouncycastle.bcprov)
-    implementation(libs.google.genai)
+    implementation(libs.google.genai) {
+        exclude(group = "com.google.protobuf", module = "protobuf-java")
+    }
     implementation(libs.google.ai.edge.aicore)
     implementation(libs.mediapipe.tasks.genai)
     implementation(libs.androidx.localbroadcastmanager)

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -15,3 +15,4 @@ When Phase 0 completes, this file will point to Phase 1's plan.
 - Fixed compilation error in `AiChatTab.kt` by updating it to pass `MainViewModel` to `ContextlessChatInput`.
 - Fixed CodeQL high priority "Zip Slip" vulnerability in `BackupManager.kt` and `RemoteBuildManager.kt`.
 - Improved crash reporting by allowing explicit stack trace strings in `GithubIssueReporter`, fixing an issue where fatal crashes had their stack traces truncated or lost.
+- Fixed a duplicate class build failure by excluding `protobuf-java` from the `google-genai` SDK in favor of the `protobuf-javalite` version required by MediaPipe.

--- a/version.properties
+++ b/version.properties
@@ -1,5 +1,5 @@
-#IDEaz version
-build=43
+#Fri Jun 05 15:13:47 UTC 2026
+build=51
 major=1
 minor=12
-patch=11
+patch=12


### PR DESCRIPTION
Resolved a build failure caused by duplicate class conflicts between `protobuf-java` and `protobuf-javalite`. The fix involved excluding the full Java Protobuf library from the `google-genai` dependency, allowing the application to use the Android-optimized Lite version provided by MediaPipe. Diagnostic files were cleaned up, and mandatory documentation/version updates from `AGENTS.md` were performed.

Fixes #688

---
*PR created automatically by Jules for task [13157576870930384609](https://jules.google.com/task/13157576870930384609) started by @HereLiesAz*