### PR TITLE
Fix duplicate class build failure (protobuf conflict)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -200,7 +200,9 @@ dependencies {
     // Used for libsodium-compatible crypto_box_seal (GithubSecretBox) to encrypt
     // GitHub Actions secrets. R8 strips the unused remainder of bcprov in release.
     implementation(libs.bouncycastle.bcprov)
-    implementation(libs.google.genai)
+    implementation(libs.google.genai) {
+        exclude(group = "com.google.protobuf", module = "protobuf-java")
+    }
     implementation(libs.google.ai.edge.aicore)
     implementation(libs.mediapipe.tasks.genai)
     implementation(libs.androidx.localbroadcastmanager)

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -15,3 +15,4 @@ When Phase 0 completes, this file will point to Phase 1's plan.
 - Fixed compilation error in `AiChatTab.kt` by updating it to pass `MainViewModel` to `ContextlessChatInput`.
 - Fixed CodeQL high priority "Zip Slip" vulnerability in `BackupManager.kt` and `RemoteBuildManager.kt`.
 - Improved crash reporting by allowing explicit stack trace strings in `GithubIssueReporter`, fixing an issue where fatal crashes had their stack traces truncated or lost.
+- Fixed duplicate class build failure (`protobuf-java` vs `protobuf-javalite`) by excluding `protobuf-java` from the `google-genai` dependency in `app/build.gradle.kts`.

--- a/version.properties
+++ b/version.properties
@@ -1,5 +1,5 @@
-#IDEaz version
-build=43
+#Fri Jun 05 15:25:07 UTC 2026
+build=51
 major=1
 minor=12
-patch=12
+patch=13


### PR DESCRIPTION
The build was failing due to duplicate class errors between `protobuf-java` (v3.25.5) and `protobuf-javalite` (v4.26.1). `google-genai` pulled in the full runtime while `mediapipe-tasks-genai` pulled in the lite runtime.

The fix involves excluding `protobuf-java` from `google-genai` in `app/build.gradle.kts`.

Verified the fix by:
1. Running `./gradlew :app:assembleDebug` (successfully built).
2. Running targeted unit tests for AI components (`./gradlew testDebugUnitTest --tests "com.hereliesaz.ideaz.ai.*"`).
3. Manually checking that no diagnostic files were left in the repository.

Fixes #693

---
*PR created automatically by Jules for task [16101754497708520320](https://jules.google.com/task/16101754497708520320) started by @HereLiesAz*