### PR TITLE
Resolve Protobuf duplicate class conflict in app build

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -145,7 +145,14 @@ configurations.all {
             "org.bouncycastle:bcpkix-jdk18on:1.84",
             "org.bouncycastle:bcutil-jdk18on:1.84",
             "org.apache.commons:commons-lang3:3.20.0",
+            "com.google.protobuf:protobuf-java:3.25.5",
+            "com.google.protobuf:protobuf-kotlin:3.25.5",
         )
+        dependencySubstitution {
+            substitute(module("com.google.protobuf:protobuf-javalite"))
+                .using(module("com.google.protobuf:protobuf-java:3.25.5"))
+                .because("Android cannot have both javalite and full protobuf-java on the same classpath")
+        }
         eachDependency {
             when {
                 // Jackson arrives as core/databind/annotations + datatype modules and a

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -15,3 +15,4 @@ When Phase 0 completes, this file will point to Phase 1's plan.
 - Fixed compilation error in `AiChatTab.kt` by updating it to pass `MainViewModel` to `ContextlessChatInput`.
 - Fixed CodeQL high priority "Zip Slip" vulnerability in `BackupManager.kt` and `RemoteBuildManager.kt`.
 - Improved crash reporting by allowing explicit stack trace strings in `GithubIssueReporter`, fixing an issue where fatal crashes had their stack traces truncated or lost.
+- Resolved build failure caused by duplicate Protobuf classes (`protobuf-java` vs `protobuf-javalite`) by implementing a global `dependencySubstitution` in `app/build.gradle.kts`.

--- a/version.properties
+++ b/version.properties
@@ -1,5 +1,5 @@
-#IDEaz version
-build=43
+#Fri Jun 05 16:30:00 UTC 2026
+build=54
 major=1
 minor=12
-patch=11
+patch=12


### PR DESCRIPTION
The build was failing due to a conflict between `protobuf-java` (required by `com.google.genai:google-genai`) and `protobuf-javalite` (required by `com.google.mediapipe:tasks-genai`). Since both libraries share the same packages and classes, the Android build system reported numerous "Duplicate class" errors.

I resolved this by:
1. Using Gradle's `dependencySubstitution` to replace all occurrences of `com.google.protobuf:protobuf-javalite` with `com.google.protobuf:protobuf-java:3.25.5` globally.
2. Adding `com.google.protobuf:protobuf-java:3.25.5` and `com.google.protobuf:protobuf-kotlin:3.25.5` to the forced versions list in `resolutionStrategy`.
3. Updating documentation and versioning as required by the repository guidelines.

Verified the fix by running `./gradlew :app:assembleDebug`, which now completes successfully.

Fixes #687

---
*PR created automatically by Jules for task [1519734354175036028](https://jules.google.com/task/1519734354175036028) started by @HereLiesAz*