### PR TITLE
Fix AGP 9.0+ Kotlin plugin compatibility error

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.serialization)
-    alias(libs.plugins.kotlin.android)
 }
 
 val versionProps = Properties()
@@ -263,11 +262,6 @@ tasks.register("incrementBuildNumber") {
         val currentBuild = props.getProperty("build", "0").toInt()
         props.setProperty("build", (currentBuild + 1).toString())
         versionFile.outputStream().use { props.store(it, null) }
-    }
-}
-android {
-    kotlinOptions {
-        jvmTarget = "21"
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,4 @@
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.compose) apply false
-    alias(libs.plugins.kotlin.android) apply false
 }

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -22,3 +22,4 @@ When Phase 0 completes, this file will point to Phase 1's plan.
 - Pinned `run-gemini-cli` to a specific SHA in CI workflows to mitigate supply chain vulnerabilities.
 - Performed full User Flow & Navigation audit, mapping PWA loops, Editor flows, and Phase 1 transitions.
 - Resolved build failure caused by duplicate `protobuf` classes by excluding `protobuf-java` from `google-genai` and standardizing on `protobuf-javalite`.
+- Fixed build failure caused by the redundant `org.jetbrains.kotlin.android` plugin which is now integrated into AGP 9.0+.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -101,5 +101,4 @@ core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtxV
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }

--- a/llama-cpp-module/build.gradle.kts
+++ b/llama-cpp-module/build.gradle.kts
@@ -2,7 +2,6 @@
 // settings.gradle.kts by default — see README.md to activate.
 plugins {
     id("com.android.library")
-    id("org.jetbrains.kotlin.android")
 }
 
 android {

--- a/version.properties
+++ b/version.properties
@@ -1,5 +1,5 @@
-#Fri Jun 05 11:55:59 CDT 2026
-build=57
+#Fri Jun 05 17:50:47 UTC 2026
+build=63
 major=1
 minor=12
-patch=14
+patch=15


### PR DESCRIPTION
Fixed the build failure caused by applying the `org.jetbrains.kotlin.android` plugin with AGP 9.0+. The plugin is now built-in and redundant.

Changes:
- Removed `alias(libs.plugins.kotlin.android)` from `app/build.gradle.kts`.
- Removed `alias(libs.plugins.kotlin.android) apply false` from the root `build.gradle.kts`.
- Removed `id("org.jetbrains.kotlin.android")` from `llama-cpp-module/build.gradle.kts`.
- Removed `kotlin-android` from `gradle/libs.versions.toml`.
- Removed the now-redundant `kotlinOptions` block from `app/build.gradle.kts`.
- Incremented patch version in `version.properties`.
- Updated `docs/TODO.md`.

Fixes #699

---
*PR created automatically by Jules for task [13661103803243029330](https://jules.google.com/task/13661103803243029330) started by @HereLiesAz*