### PR TITLE
fix(gemini-bridge): type prompt via accessibility + reliable touch block

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ai/bridge/BridgeHeuristics.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ai/bridge/BridgeHeuristics.kt
@@ -30,7 +30,9 @@ object BridgeHeuristics {
     fun extractResponse(snapshot: String, prompt: String): String {
         var text = snapshot
         if (prompt.isNotBlank()) {
-            text = text.replace(prompt, "").trim()
+            // Case-insensitive: Gemini sometimes echoes the prompt with altered
+            // casing (e.g. a capitalized first letter), which a literal replace misses.
+            text = text.replace(prompt, "", ignoreCase = true).trim()
         }
         for (junk in CHROME_STRINGS) {
             text = text.replace(junk, "", ignoreCase = true)

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ai/bridge/BridgeHeuristics.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ai/bridge/BridgeHeuristics.kt
@@ -1,0 +1,51 @@
+package com.hereliesaz.ideaz.ai.bridge
+
+/**
+ * Pure, framework-free predicates for matching nodes in the Gemini app's
+ * accessibility tree. Kept separate from [GeminiAppBridgeAccessibilityService]
+ * so the substring/casing rules can be unit-tested without Android.
+ *
+ * All matchers are case-insensitive `contains` over a node's text /
+ * contentDescription / hintText. Liberal on purpose: the Gemini app's labels
+ * shift across versions, so we match on stable keywords rather than exact ids.
+ */
+object BridgeHeuristics {
+
+    /** Hints that mark the prompt input field ("Ask Gemini", "Enter a prompt", …). */
+    val INPUT_HINTS = listOf("ask gemini", "enter a prompt", "message", "talk", "prompt")
+
+    /** Hints that mark the submit affordance (the up-arrow ≈ contentDescription "Send"). */
+    val SEND_HINTS = listOf("send", "submit", "run")
+
+    /** Hints that mark a "copy response/code" affordance. */
+    val COPY_HINTS = listOf("copy")
+
+    /** Input-field chrome that leaks into a scrape and must be stripped. */
+    val CHROME_STRINGS = listOf("Enter a prompt here", "Listening", "Tap to talk")
+
+    /**
+     * Reduce a full window scrape to just the model's reply: strip the prompt we
+     * sent (the Gemini app echoes it) and known input chrome.
+     */
+    fun extractResponse(snapshot: String, prompt: String): String {
+        var text = snapshot
+        if (prompt.isNotBlank()) {
+            text = text.replace(prompt, "").trim()
+        }
+        for (junk in CHROME_STRINGS) {
+            text = text.replace(junk, "", ignoreCase = true)
+        }
+        return text.trim()
+    }
+
+    fun isInputHint(hint: String?): Boolean = matches(hint, INPUT_HINTS)
+
+    fun isSendHint(hint: String?): Boolean = matches(hint, SEND_HINTS)
+
+    fun isCopyHint(hint: String?): Boolean = matches(hint, COPY_HINTS)
+
+    private fun matches(hint: String?, needles: List<String>): Boolean {
+        val h = hint?.lowercase() ?: return false
+        return needles.any { h.contains(it) }
+    }
+}

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ai/bridge/GeminiAppBridge.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ai/bridge/GeminiAppBridge.kt
@@ -19,9 +19,23 @@ import kotlinx.coroutines.channels.Channel
  */
 object GeminiAppBridge {
 
+    /**
+     * Where the bridge is in its run:
+     *  - [IDLE]: no run in flight.
+     *  - [INPUT]: intent fired; the accessibility service is waiting for Gemini's
+     *    compose screen so it can type [pendingPrompt] and tap Send.
+     *  - [AWAIT_RESPONSE]: prompt submitted; the service is scraping the reply.
+     */
+    enum class BridgePhase { IDLE, INPUT, AWAIT_RESPONSE }
+
     @Volatile var pendingPrompt: String? = null
 
     @Volatile var isWaiting: Boolean = false
+
+    @Volatile var phase: BridgePhase = BridgePhase.IDLE
+
+    /** Set once the prompt has been typed and Send clicked — guards double-submit. */
+    @Volatile var promptSubmitted: Boolean = false
 
     val channel: Channel<String> = Channel(
         capacity = 1,
@@ -44,6 +58,8 @@ object GeminiAppBridge {
      * the adapter immediately before firing an intent.
      */
     fun reset() {
+        phase = BridgePhase.IDLE
+        promptSubmitted = false
         // Non-blocking drain.
         while (channel.tryReceive().getOrNull() != null) { /* discard */ }
         while (decisionChannel.tryReceive().getOrNull() != null) { /* discard */ }

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ai/bridge/GeminiAppBridgeAccessibilityService.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ai/bridge/GeminiAppBridgeAccessibilityService.kt
@@ -1,32 +1,46 @@
 package com.hereliesaz.ideaz.ai.bridge
 
 import android.accessibilityservice.AccessibilityService
+import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
+import android.content.Intent
+import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
+import android.provider.Settings
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
+import android.view.accessibility.AccessibilityWindowInfo
+import com.hereliesaz.ideaz.services.IdeazOverlayService
 
 /**
- * Captures the Gemini app's response and pipes it back to
- * [GeminiAppBridgeAdapter] via [GeminiAppBridge.channel]. Only active while
- * [GeminiAppBridge.isWaiting] is true.
+ * Drives the Gemini app for [GeminiAppBridgeAdapter] over [GeminiAppBridge]. Two
+ * phases, both gated on [GeminiAppBridge.isWaiting]:
  *
- * Capture strategy, in order of preference:
- *  1. **Copy button.** The Gemini app always renders a "Copy" affordance for a
- *     response. Once the content stabilises we click the latest one and read the
- *     clipboard — that yields the FULL response verbatim, regardless of scroll
- *     position or formatting. (Background clipboard reads are restricted on
- *     Android 10+, so this can come back empty; if so we fall back.)
- *  2. **Text scrape.** Walk the window's node tree, join visible text, and strip
- *     the prompt. Liberal and version-tolerant, but only sees on-screen text.
+ *  1. **INPUT** ([GeminiAppBridge.BridgePhase.INPUT]) — the share intent has
+ *     opened Gemini's compose screen with `project.txt` attached, but Gemini
+ *     drops the intent's `EXTRA_TEXT`, so the prompt field is empty. We find the
+ *     editable field, type [GeminiAppBridge.pendingPrompt] into it, then tap Send.
+ *  2. **AWAIT_RESPONSE** ([GeminiAppBridge.BridgePhase.AWAIT_RESPONSE]) — capture
+ *     the reply, in order of preference:
+ *       a. **Copy button.** Click the latest "Copy" affordance and read the
+ *          clipboard — the FULL response verbatim. (Background clipboard reads are
+ *          restricted on Android 10+, so this can come back empty; if so we fall back.)
+ *       b. **Text scrape.** Walk the node tree, join visible text, strip the prompt.
+ *
+ * On the first Gemini event of a run we also re-assert the touch-block scrim, in
+ * case [GeminiAppBridgeAdapter] raced it up before Gemini came to the foreground.
  */
 class GeminiAppBridgeAccessibilityService : AccessibilityService() {
 
     private val handler = Handler(Looper.getMainLooper())
     private var lastSnapshot: String = ""
     private var stableJob: Runnable? = null
+    private var inputJob: Runnable? = null
+
+    /** Re-assert the block scrim only once per run (reset when the run ends). */
+    private var blockReasserted = false
 
     override fun onAccessibilityEvent(event: AccessibilityEvent?) {
         if (!GeminiAppBridge.isWaiting) return
@@ -39,22 +53,124 @@ class GeminiAppBridgeAccessibilityService : AccessibilityService() {
             type != AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED
         ) return
 
-        val root = rootInActiveWindow ?: return
-        val snapshot = collectText(root).trim()
-        if (snapshot.isEmpty()) return
-        if (snapshot == lastSnapshot) return
-        lastSnapshot = snapshot
+        // Gemini is now foreground — make sure the scrim is on top of it.
+        reassertBlock()
 
-        // Debounce: act once the content has stopped changing (response done).
-        stableJob?.let { handler.removeCallbacks(it) }
-        val job = Runnable { onStable(snapshot) }
-        stableJob = job
-        handler.postDelayed(job, STABLE_MS)
+        when (GeminiAppBridge.phase) {
+            GeminiAppBridge.BridgePhase.INPUT -> {
+                inputJob?.let { handler.removeCallbacks(it) }
+                val job = Runnable { onInputStable() }
+                inputJob = job
+                handler.postDelayed(job, INPUT_STABLE_MS)
+            }
+
+            GeminiAppBridge.BridgePhase.AWAIT_RESPONSE -> {
+                val root = geminiRoot() ?: return
+                val snapshot = collectText(root).trim()
+                if (snapshot.isEmpty()) return
+                if (snapshot == lastSnapshot) return
+                lastSnapshot = snapshot
+
+                // Debounce: act once the content has stopped changing (response done).
+                stableJob?.let { handler.removeCallbacks(it) }
+                val job = Runnable { onStable(snapshot) }
+                stableJob = job
+                handler.postDelayed(job, STABLE_MS)
+            }
+
+            GeminiAppBridge.BridgePhase.IDLE -> { /* nothing to do */ }
+        }
     }
+
+    // ---- INPUT phase ---------------------------------------------------------
+
+    /**
+     * Type the prompt and submit, idempotently across the storm of content
+     * changes Gemini fires while it ingests the attached file. We fill on one
+     * pass and click Send on a later pass: setting the text re-fires a content
+     * change, by which point Send has enabled itself.
+     */
+    private fun onInputStable() {
+        if (!GeminiAppBridge.isWaiting) return
+        if (GeminiAppBridge.phase != GeminiAppBridge.BridgePhase.INPUT) return
+        if (GeminiAppBridge.promptSubmitted) return
+
+        val root = geminiRoot() ?: return
+        val field = findInputField(root) ?: return // not laid out yet — retry next event
+        val prompt = GeminiAppBridge.pendingPrompt.orEmpty()
+        if (prompt.isBlank()) return
+
+        // Fill first; only once the field holds our prompt do we try Send.
+        if (field.text?.toString() != prompt) {
+            setInputText(field, prompt) // failure just means we retry next event
+            return
+        }
+
+        val send = findSendButton(root) ?: return
+        if (!send.isEnabled) return // present but disabled — wait for it to enable
+        if (send.performAction(AccessibilityNodeInfo.ACTION_CLICK)) {
+            GeminiAppBridge.promptSubmitted = true
+            GeminiAppBridge.phase = GeminiAppBridge.BridgePhase.AWAIT_RESPONSE
+            lastSnapshot = "" // fresh baseline so the reply isn't mistaken for stale chrome
+        }
+    }
+
+    /** Last editable node, preferring one whose hint marks it as the prompt field. */
+    private fun findInputField(root: AccessibilityNodeInfo): AccessibilityNodeInfo? {
+        var hinted: AccessibilityNodeInfo? = null
+        var anyEditable: AccessibilityNodeInfo? = null
+        fun walk(n: AccessibilityNodeInfo?) {
+            if (n == null) return
+            val editable = n.isEditable || (n.className?.toString()?.contains("EditText") == true)
+            if (editable) {
+                anyEditable = n
+                val hint = n.text?.toString()
+                    ?: n.contentDescription?.toString()
+                    ?: n.hintText?.toString()
+                if (BridgeHeuristics.isInputHint(hint)) hinted = n
+            }
+            for (i in 0 until n.childCount) walk(n.getChild(i))
+        }
+        walk(root)
+        return hinted ?: anyEditable
+    }
+
+    /** Set the field's text via ACTION_SET_TEXT, falling back to clipboard paste. */
+    private fun setInputText(field: AccessibilityNodeInfo, text: String): Boolean {
+        val args = Bundle().apply {
+            putCharSequence(AccessibilityNodeInfo.ACTION_ARGUMENT_SET_TEXT_CHARSEQUENCE, text)
+        }
+        if (field.performAction(AccessibilityNodeInfo.ACTION_SET_TEXT, args)) return true
+
+        // Some Compose editors reject ACTION_SET_TEXT — focus + paste instead.
+        field.performAction(AccessibilityNodeInfo.ACTION_FOCUS)
+        return try {
+            val cm = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+            cm.setPrimaryClip(ClipData.newPlainText("ideaz-prompt", text))
+            field.performAction(AccessibilityNodeInfo.ACTION_PASTE)
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    /** Last enabled, clickable node that looks like a Send/Submit affordance. */
+    private fun findSendButton(root: AccessibilityNodeInfo): AccessibilityNodeInfo? {
+        var match: AccessibilityNodeInfo? = null
+        fun walk(n: AccessibilityNodeInfo?) {
+            if (n == null) return
+            val hint = n.contentDescription?.toString() ?: n.text?.toString()
+            if (n.isClickable && BridgeHeuristics.isSendHint(hint)) match = n
+            for (i in 0 until n.childCount) walk(n.getChild(i))
+        }
+        walk(root)
+        return match
+    }
+
+    // ---- AWAIT_RESPONSE phase ------------------------------------------------
 
     private fun onStable(snapshot: String) {
         if (!GeminiAppBridge.isWaiting) return
-        val root = rootInActiveWindow
+        val root = geminiRoot()
         val copyNode = root?.let { findLatestCopyNode(it) }
         if (copyNode != null && copyNode.performAction(AccessibilityNodeInfo.ACTION_CLICK)) {
             // Give the app a beat to populate the clipboard, then read it.
@@ -74,7 +190,7 @@ class GeminiAppBridgeAccessibilityService : AccessibilityService() {
         }
         val text = clip?.trim()
         if (!text.isNullOrBlank()) {
-            GeminiAppBridge.isWaiting = false
+            finishRun()
             GeminiAppBridge.channel.trySend(text)
         } else {
             // Clipboard empty/unreadable (background-read restriction) — scrape.
@@ -84,9 +200,10 @@ class GeminiAppBridgeAccessibilityService : AccessibilityService() {
 
     private fun deliverScraped(snapshot: String) {
         if (!GeminiAppBridge.isWaiting) return
-        val response = extractResponse(snapshot, GeminiAppBridge.pendingPrompt.orEmpty())
+        val response =
+            BridgeHeuristics.extractResponse(snapshot, GeminiAppBridge.pendingPrompt.orEmpty())
         if (response.isBlank()) return
-        GeminiAppBridge.isWaiting = false
+        finishRun()
         GeminiAppBridge.channel.trySend(response)
     }
 
@@ -98,25 +215,54 @@ class GeminiAppBridgeAccessibilityService : AccessibilityService() {
         var match: AccessibilityNodeInfo? = null
         fun walk(n: AccessibilityNodeInfo?) {
             if (n == null) return
-            val hint = (n.contentDescription?.toString() ?: n.text?.toString())?.lowercase()
-            if (hint != null && n.isClickable && COPY_HINTS.any { hint.contains(it) }) {
-                match = n
-            }
+            val hint = n.contentDescription?.toString() ?: n.text?.toString()
+            if (n.isClickable && BridgeHeuristics.isCopyHint(hint)) match = n
             for (i in 0 until n.childCount) walk(n.getChild(i))
         }
         walk(root)
         return match
     }
 
-    private fun extractResponse(snapshot: String, prompt: String): String {
-        var text = snapshot
-        if (prompt.isNotBlank()) {
-            text = text.replace(prompt, "").trim()
+    // ---- shared --------------------------------------------------------------
+
+    /**
+     * The Gemini window's root. Prefers [rootInActiveWindow] when it actually
+     * belongs to Gemini, but the block scrim (even non-focusable) can leave the
+     * active window ambiguous, so fall back to scanning [getWindows] by package.
+     */
+    private fun geminiRoot(): AccessibilityNodeInfo? {
+        rootInActiveWindow
+            ?.takeIf { it.packageName?.toString() in MONITORED_PACKAGES }
+            ?.let { return it }
+        return try {
+            windows
+                .filter { it.type == AccessibilityWindowInfo.TYPE_APPLICATION }
+                .mapNotNull { it.root }
+                .firstOrNull { it.packageName?.toString() in MONITORED_PACKAGES }
+        } catch (e: Exception) {
+            null
         }
-        for (junk in CHROME_STRINGS) {
-            text = text.replace(junk, "", ignoreCase = true)
+    }
+
+    /** Lift the touch-block scrim onto the now-foreground Gemini window, once. */
+    private fun reassertBlock() {
+        if (blockReasserted) return
+        blockReasserted = true
+        if (!Settings.canDrawOverlays(this)) return
+        try {
+            startForegroundService(
+                Intent(this, IdeazOverlayService::class.java).putExtra("STATE", "wait")
+            )
+        } catch (e: Exception) {
+            // Best-effort — the adapter already requested the scrim.
         }
-        return text.trim()
+    }
+
+    /** End-of-run bookkeeping so the next run starts clean. */
+    private fun finishRun() {
+        GeminiAppBridge.isWaiting = false
+        GeminiAppBridge.phase = GeminiAppBridge.BridgePhase.IDLE
+        blockReasserted = false
     }
 
     private fun collectText(node: AccessibilityNodeInfo?, out: StringBuilder = StringBuilder()): String {
@@ -139,31 +285,26 @@ class GeminiAppBridgeAccessibilityService : AccessibilityService() {
 
     override fun onInterrupt() {
         stableJob?.let { handler.removeCallbacks(it) }
+        inputJob?.let { handler.removeCallbacks(it) }
         stableJob = null
+        inputJob = null
         lastSnapshot = ""
     }
 
     override fun onServiceConnected() {
         super.onServiceConnected()
         lastSnapshot = ""
+        blockReasserted = false
     }
 
     companion object {
         private const val STABLE_MS = 2_500L
+        private const val INPUT_STABLE_MS = 600L
         private const val CLIP_DELAY_MS = 350L
 
         private val MONITORED_PACKAGES = setOf(
             "com.google.android.apps.bard",
             "com.google.android.googlequicksearchbox",
-        )
-
-        // Substrings that mark a "copy response/code" button (case-insensitive).
-        private val COPY_HINTS = listOf("copy")
-
-        private val CHROME_STRINGS = listOf(
-            "Enter a prompt here",
-            "Listening",
-            "Tap to talk",
         )
     }
 }

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ai/bridge/GeminiAppBridgeAccessibilityService.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ai/bridge/GeminiAppBridgeAccessibilityService.kt
@@ -58,10 +58,19 @@ class GeminiAppBridgeAccessibilityService : AccessibilityService() {
 
         when (GeminiAppBridge.phase) {
             GeminiAppBridge.BridgePhase.INPUT -> {
-                inputJob?.let { handler.removeCallbacks(it) }
-                val job = Runnable { onInputStable() }
-                inputJob = job
-                handler.postDelayed(job, INPUT_STABLE_MS)
+                // Throttle, don't debounce: Gemini fires a continuous stream of
+                // events while ingesting the file (cursor blink, animations), so
+                // resetting the timer each time could starve onInputStable. Only
+                // schedule when nothing is pending — it then fires after the delay
+                // regardless of how many more events arrive.
+                if (inputJob == null) {
+                    val job = Runnable {
+                        inputJob = null
+                        onInputStable()
+                    }
+                    inputJob = job
+                    handler.postDelayed(job, INPUT_STABLE_MS)
+                }
             }
 
             GeminiAppBridge.BridgePhase.AWAIT_RESPONSE -> {
@@ -235,10 +244,15 @@ class GeminiAppBridgeAccessibilityService : AccessibilityService() {
             ?.takeIf { it.packageName?.toString() in MONITORED_PACKAGES }
             ?.let { return it }
         return try {
-            windows
-                .filter { it.type == AccessibilityWindowInfo.TYPE_APPLICATION }
-                .mapNotNull { it.root }
-                .firstOrNull { it.packageName?.toString() in MONITORED_PACKAGES }
+            // Each window.root is a fresh AccessibilityNodeInfo — recycle the
+            // ones we don't keep so we don't exhaust the node pool on older OSes.
+            for (window in windows) {
+                if (window.type != AccessibilityWindowInfo.TYPE_APPLICATION) continue
+                val root = window.root ?: continue
+                if (root.packageName?.toString() in MONITORED_PACKAGES) return root
+                root.recycle()
+            }
+            null
         } catch (e: Exception) {
             null
         }

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ai/bridge/GeminiAppBridgeAdapter.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ai/bridge/GeminiAppBridgeAdapter.kt
@@ -94,6 +94,10 @@ class GeminiAppBridgeAdapter(
 
         GeminiAppBridge.reset()
         GeminiAppBridge.pendingPrompt = outboundText
+        // The accessibility service types the prompt + taps Send (Gemini drops
+        // EXTRA_TEXT when a file is attached), then flips to AWAIT_RESPONSE itself.
+        GeminiAppBridge.phase = GeminiAppBridge.BridgePhase.INPUT
+        GeminiAppBridge.promptSubmitted = false
         GeminiAppBridge.isWaiting = true
 
         val streams = ArrayList(listOfNotNull(projectUri, imageUri))

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/services/IdeazOverlayService.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/services/IdeazOverlayService.kt
@@ -287,8 +287,12 @@ class IdeazOverlayService : Service() {
             WindowManager.LayoutParams.MATCH_PARENT,
             WindowManager.LayoutParams.MATCH_PARENT,
             WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY,
-            // Focusable so the buttons take taps reliably.
-            WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN,
+            // Touchable (absorbs the user's taps; the Wait/Cancel buttons still
+            // fire) but NOT focusable: a focusable overlay would become the active
+            // window and make the bridge's AccessibilityService see the scrim
+            // instead of Gemini, breaking prompt-typing and response-scraping.
+            WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN or
+                WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE,
             PixelFormat.TRANSLUCENT
         )
         try {

--- a/app/src/test/java/com/hereliesaz/ideaz/ai/bridge/BridgeHeuristicsTest.kt
+++ b/app/src/test/java/com/hereliesaz/ideaz/ai/bridge/BridgeHeuristicsTest.kt
@@ -1,0 +1,59 @@
+package com.hereliesaz.ideaz.ai.bridge
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BridgeHeuristicsTest {
+
+    @Test
+    fun `input hint matches Gemini compose labels case-insensitively`() {
+        assertTrue(BridgeHeuristics.isInputHint("Ask Gemini"))
+        assertTrue(BridgeHeuristics.isInputHint("Enter a prompt here"))
+        assertTrue(BridgeHeuristics.isInputHint("Message"))
+        assertTrue(BridgeHeuristics.isInputHint("Tap to talk"))
+    }
+
+    @Test
+    fun `input hint rejects unrelated, null and blank`() {
+        assertFalse(BridgeHeuristics.isInputHint("Copy"))
+        assertFalse(BridgeHeuristics.isInputHint(null))
+        assertFalse(BridgeHeuristics.isInputHint(""))
+    }
+
+    @Test
+    fun `send hint matches submit affordances`() {
+        assertTrue(BridgeHeuristics.isSendHint("Send"))
+        assertTrue(BridgeHeuristics.isSendHint("SUBMIT"))
+        assertTrue(BridgeHeuristics.isSendHint("Run prompt"))
+        assertFalse(BridgeHeuristics.isSendHint("Ask Gemini"))
+        assertFalse(BridgeHeuristics.isSendHint(null))
+    }
+
+    @Test
+    fun `copy hint matches the copy button`() {
+        assertTrue(BridgeHeuristics.isCopyHint("Copy"))
+        assertTrue(BridgeHeuristics.isCopyHint("copy code"))
+        assertFalse(BridgeHeuristics.isCopyHint("Share"))
+        assertFalse(BridgeHeuristics.isCopyHint(null))
+    }
+
+    @Test
+    fun `extractResponse strips the echoed prompt`() {
+        val prompt = "Edit the project"
+        val snapshot = "$prompt\nHere is the reply"
+        assertEquals("Here is the reply", BridgeHeuristics.extractResponse(snapshot, prompt))
+    }
+
+    @Test
+    fun `extractResponse strips input chrome`() {
+        val snapshot = "the answer\nEnter a prompt here\nListening"
+        assertEquals("the answer", BridgeHeuristics.extractResponse(snapshot, ""))
+    }
+
+    @Test
+    fun `extractResponse tolerates a blank prompt`() {
+        assertEquals("only text", BridgeHeuristics.extractResponse("only text", ""))
+    }
+}

--- a/app/src/test/java/com/hereliesaz/ideaz/ai/bridge/BridgeHeuristicsTest.kt
+++ b/app/src/test/java/com/hereliesaz/ideaz/ai/bridge/BridgeHeuristicsTest.kt
@@ -53,6 +53,13 @@ class BridgeHeuristicsTest {
     }
 
     @Test
+    fun `extractResponse strips the prompt despite altered casing`() {
+        val prompt = "Edit the project"
+        val snapshot = "edit the PROJECT\nHere is the reply"
+        assertEquals("Here is the reply", BridgeHeuristics.extractResponse(snapshot, prompt))
+    }
+
+    @Test
     fun `extractResponse tolerates a blank prompt`() {
         assertEquals("only text", BridgeHeuristics.extractResponse("only text", ""))
     }

--- a/app/src/test/java/com/hereliesaz/ideaz/ai/bridge/GeminiAppBridgeTest.kt
+++ b/app/src/test/java/com/hereliesaz/ideaz/ai/bridge/GeminiAppBridgeTest.kt
@@ -1,0 +1,26 @@
+package com.hereliesaz.ideaz.ai.bridge
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class GeminiAppBridgeTest {
+
+    @Test
+    fun `reset clears phase, submit flag and drains channels`() {
+        GeminiAppBridge.pendingPrompt = "x"
+        GeminiAppBridge.isWaiting = true
+        GeminiAppBridge.phase = GeminiAppBridge.BridgePhase.AWAIT_RESPONSE
+        GeminiAppBridge.promptSubmitted = true
+        GeminiAppBridge.channel.trySend("stale response")
+        GeminiAppBridge.decisionChannel.trySend(true)
+
+        GeminiAppBridge.reset()
+
+        assertEquals(GeminiAppBridge.BridgePhase.IDLE, GeminiAppBridge.phase)
+        assertFalse(GeminiAppBridge.promptSubmitted)
+        assertNull(GeminiAppBridge.channel.tryReceive().getOrNull())
+        assertNull(GeminiAppBridge.decisionChannel.tryReceive().getOrNull())
+    }
+}

--- a/docs/file_descriptions.md
+++ b/docs/file_descriptions.md
@@ -74,6 +74,12 @@
 *   `LocalModelStore.kt`: Manages locally stored model files and metadata.
 *   `ModelDownloadManager.kt`: Handles background downloading of model files with auth support.
 
+#### ai/bridge/
+*   `GeminiAppBridgeAdapter.kt`: `ConversationalAiClient` that routes prompts through the user's installed Gemini app — attaches the project as `project.txt` and raises the touch-block scrim, then waits for the scraped reply.
+*   `GeminiAppBridge.kt`: Process singleton mailbox between the adapter and the accessibility service (`pendingPrompt`, `isWaiting`, `phase`, `promptSubmitted`, response/decision channels).
+*   `GeminiAppBridgeAccessibilityService.kt`: Drives the Gemini app — INPUT phase types the prompt into the compose field and taps Send; AWAIT_RESPONSE phase scrapes the reply (Copy button → clipboard, else text scrape).
+*   `BridgeHeuristics.kt`: Pure, unit-tested predicates for matching the Gemini app's input/send/copy nodes and stripping the prompt from a scrape.
+
 #### ui/
 *   `MainViewModel.kt`: Coordinator. Logic delegated to `ui/delegates/`.
 *   `SettingsViewModel.kt`: Manages user preferences.

--- a/version.properties
+++ b/version.properties
@@ -2,4 +2,4 @@
 build=72
 major=1
 minor=12
-patch=15
+patch=16


### PR DESCRIPTION
## Problem

From a user screenshot: when the Gemini App Bridge fires its initial prompt, the Gemini app opens with `project.txt` attached as a chip, but:

1. **The prompt text is never entered** into the "Ask Gemini" field — it stays empty.
2. **The screen is not blocked from touch** during automation — the user can interfere.

### Root causes
1. The bridge passed the prompt as `Intent.EXTRA_TEXT` in the share intent, but **the Gemini app drops `EXTRA_TEXT` when a file stream is also attached**. The file (`EXTRA_STREAM`) lands; the text does not. The accessibility service was passive — it only scraped the *response*, never typed anything.
2. The "please wait" scrim was created **focusable**. A focusable `TYPE_APPLICATION_OVERLAY` can become the active window, which makes `rootInActiveWindow` return the scrim instead of Gemini — which would also break the new typing path *and* the existing scrape. Plus `setUserBlock("wait")` started the overlay async while the intent fired immediately, so it lagged.

## Fix

**Type the prompt via accessibility (Fix 1).** Keep firing the share intent (the file attach works and it opens Gemini's compose screen, EXTRA_TEXT kept as a harmless fallback). Add an `INPUT` phase to `GeminiAppBridgeAccessibilityService`: find the editable compose field, set its text via `ACTION_SET_TEXT` (focus + clipboard `ACTION_PASTE` fallback), then tap Send — driven by a `BridgePhase { IDLE, INPUT, AWAIT_RESPONSE }` state machine + `promptSubmitted` guard in `GeminiAppBridge`. Fill-on-one-pass / click-on-the-next naturally handles "Send disabled until text present" without sleeps; idempotency guards survive the storm of content-changes Gemini fires while ingesting the file.

**Reliable, accessibility-compatible touch block (Fix 2).**
- Make the scrim **non-focusable but still touchable** (`FLAG_NOT_FOCUSABLE`, no `FLAG_NOT_TOUCHABLE`) — it absorbs the user's taps and its Wait/Cancel buttons still fire, while Gemini stays the active window. This is the key fix that also unblocks Fix 1.
- Resolve Gemini's window via `getWindows()` as a fallback to `rootInActiveWindow`.
- Re-assert the scrim from the service once Gemini is foreground (closes the start-up race).

**Tests.** Node-matching and response-stripping moved to pure `BridgeHeuristics`; covered with JUnit (`BridgeHeuristicsTest`), plus `GeminiAppBridge.reset()` (`GeminiAppBridgeTest`).

## Files
- `ai/bridge/GeminiAppBridge.kt` — `BridgePhase` enum, `phase` / `promptSubmitted`, `reset()` clears them.
- `ai/bridge/GeminiAppBridgeAccessibilityService.kt` — INPUT phase (find/fill/submit), `geminiRoot()`, block re-assert; delegates matching to `BridgeHeuristics`.
- `ai/bridge/GeminiAppBridgeAdapter.kt` — set `phase = INPUT`.
- `ai/bridge/BridgeHeuristics.kt` *(new)* — pure predicates + `extractResponse`.
- `services/IdeazOverlayService.kt` — non-focusable scrim flags.
- tests + `version.properties` (patch bump) + `docs/file_descriptions.md`.

## Verification
- ⚠️ Could **not** run `./gradlew` in the web session — this environment's network policy drops TLS to `dl.google.com` / Maven Central, so the Android Gradle Plugin can't be resolved. CI (GitHub Actions) will validate the build and run `BridgeHeuristicsTest` / `GeminiAppBridgeTest`.
- Manual end-to-end (device with Gemini + accessibility + "draw over other apps" granted): trigger a bridge prompt → confirm (1) `project.txt` attaches, (2) the prompt appears in "Ask Gemini" and is auto-submitted, (3) a dark scrim covers the screen and absorbs taps while Wait/Cancel still work, (4) the reply is scraped and applied.

https://claude.ai/code/session_01Nw6AHh15NTE63WQKU5qbY8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nw6AHh15NTE63WQKU5qbY8)_