### PR TITLE
feat(on-device): show only runnable models; implement GGUF + ONNX backends; fix ScreenshotService FGS crash

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -248,6 +248,19 @@ dependencies {
 
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.webkit)
+
+    // On-device GGUF backend: the :llama-cpp-module NDK library is only on the
+    // classpath when its llama.cpp submodule is present (matched in settings.gradle.kts),
+    // so the app builds without the NDK toolchain. LlamaCppRuntime detects it by name.
+    if (rootProject.file("llama-cpp-module/llama.cpp").exists()) {
+        implementation(project(":llama-cpp-module"))
+    }
+
+    // On-device ONNX GenAI backend (OnnxGenAiRuntime). The GenAI Android AAR is NOT
+    // on Maven Central — vendor it from the onnxruntime-genai GitHub releases (see
+    // docs/on-device-runtimes.md), then OnnxGenAiRuntime detects it by name:
+    //   implementation(files("libs/onnxruntime-genai-android-<ver>.aar"))
+    //   implementation("com.microsoft.onnxruntime:onnxruntime-android:1.20.0")
 }
 
 tasks.register("incrementBuildNumber") {

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -62,6 +62,12 @@
 -dontwarn org.eclipse.jgit.**
 -dontwarn org.slf4j.**
 
+# ---- On-device runtimes (reflection-detected; keep their public API) -------
+-keep class android.llama.cpp.** { *; }
+-keep class ai.onnxruntime.genai.** { *; }
+-dontwarn android.llama.cpp.**
+-dontwarn ai.onnxruntime.genai.**
+
 # ---- Android / WebView JS bridge ------------------------------------------
 -keepclassmembers class * {
     @android.webkit.JavascriptInterface <methods>;

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ai/local/DeviceCapabilities.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ai/local/DeviceCapabilities.kt
@@ -1,0 +1,29 @@
+package com.hereliesaz.ideaz.ai.local
+
+import android.app.ActivityManager
+import android.content.Context
+import android.os.Build
+
+/**
+ * Reads the device's hardware capabilities relevant to running on-device models:
+ * total RAM and supported CPU ABIs. Kept tiny and Android-facing so the decision
+ * logic in [LocalModelAvailability] can stay pure and unit-tested.
+ */
+object DeviceCapabilities {
+
+    /** Total physical RAM in bytes, or 0 if it can't be determined. */
+    fun totalRamBytes(context: Context): Long {
+        val am = context.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager ?: return 0L
+        return try {
+            val mi = ActivityManager.MemoryInfo()
+            am.getMemoryInfo(mi)
+            mi.totalMem
+        } catch (e: Exception) {
+            0L
+        }
+    }
+
+    /** CPU ABIs this device supports (e.g. "arm64-v8a"). Empty if unknown. */
+    fun supportedAbis(): Set<String> =
+        Build.SUPPORTED_ABIS?.toSet() ?: emptySet()
+}

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ai/local/LocalModelAvailability.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ai/local/LocalModelAvailability.kt
@@ -1,0 +1,54 @@
+package com.hereliesaz.ideaz.ai.local
+
+/**
+ * Pure decision logic for "can this device actually use this model right now?".
+ * Framework-free so it can be unit-tested; the Settings UI feeds it real device
+ * signals (RAM, ABIs, backend presence, auth) and shows only the [Status.Usable]
+ * models, listing the rest with a reason.
+ */
+object LocalModelAvailability {
+
+    sealed interface Status {
+        /** The model can be selected (and downloaded) on this device/build. */
+        object Usable : Status
+
+        /** The model can't be used now; [reason] is a short user-facing explanation. */
+        data class Unsupported(val reason: String) : Status
+    }
+
+    /**
+     * @param backendAvailable whether the model's runtime backend is present AND
+     *   (for system-managed runtimes like AICore) actually supported by the device.
+     * @param backendName display name of the runtime, for the "not in this build" reason.
+     * @param totalRamBytes device RAM; 0 means unknown (RAM check skipped).
+     * @param abis device-supported ABIs; empty means unknown (ABI check skipped).
+     * @param hasAuthToken whether a download/auth token is present (for gated models).
+     */
+    fun evaluate(
+        model: LocalModel,
+        backendAvailable: Boolean,
+        backendName: String,
+        totalRamBytes: Long,
+        abis: Set<String>,
+        hasAuthToken: Boolean,
+    ): Status {
+        if (!backendAvailable) {
+            return Status.Unsupported(
+                if (model.systemManaged) "Not supported on this device"
+                else "$backendName backend not in this build",
+            )
+        }
+        val abi = model.requiredAbi
+        if (abi != null && abis.isNotEmpty() && abi !in abis) {
+            return Status.Unsupported("Needs a $abi CPU")
+        }
+        if (model.minRamBytes > 0 && totalRamBytes > 0 && totalRamBytes < model.minRamBytes) {
+            val gb = (model.minRamBytes + 999_999_999) / 1_000_000_000 // round up
+            return Status.Unsupported("Needs ~$gb GB RAM")
+        }
+        if (model.requiresAuth && !hasAuthToken) {
+            return Status.Unsupported("Needs a Hugging Face token")
+        }
+        return Status.Usable
+    }
+}

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ai/local/LocalModelCatalog.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ai/local/LocalModelCatalog.kt
@@ -27,6 +27,18 @@ data class LocalModel(
      * models (MediaPipe `.task`, llama.cpp `.gguf`).
      */
     val additionalFiles: List<LocalModelFile> = emptyList(),
+    /**
+     * Minimum total device RAM (bytes) the model realistically needs to load and
+     * run. 0 = no requirement (e.g. system-managed AICore). Used to hide models a
+     * device can't actually run.
+     */
+    val minRamBytes: Long = 0,
+    /**
+     * CPU ABI the model's runtime needs (e.g. "arm64-v8a" for the native GGUF /
+     * ONNX backends). null = no requirement. Used to hide models whose native code
+     * can't run on this device's architecture.
+     */
+    val requiredAbi: String? = null,
     val notes: String = "",
 )
 
@@ -55,6 +67,8 @@ object LocalModelCatalog {
             url = "https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/main/qwen2.5-0.5b-instruct-q4_k_m.gguf",
             approxSizeBytes = 400_000_000,
             fileName = "qwen2.5-0.5b-instruct-q4_k_m.gguf",
+            minRamBytes = 2_000_000_000,
+            requiredAbi = "arm64-v8a",
             notes = "Tiny and fast; good for low-RAM devices.",
         ),
         LocalModel(
@@ -64,6 +78,8 @@ object LocalModelCatalog {
             url = "https://huggingface.co/lmstudio-community/gemma-3n-E2B-it-text-GGUF/resolve/main/gemma-3n-E2B-it-Q4_K_M.gguf",
             approxSizeBytes = 3_000_000_000,
             fileName = "gemma-3n-e2b-it-Q4_K_M.gguf",
+            minRamBytes = 4_000_000_000,
+            requiredAbi = "arm64-v8a",
             notes = "Gemma 3 Nano E2B (2B effective parameters). Good balance of speed and quality.",
         ),
         LocalModel(
@@ -73,6 +89,8 @@ object LocalModelCatalog {
             url = "https://huggingface.co/unsloth/gemma-3n-E4B-it-GGUF/resolve/main/gemma-3n-E4B-it-Q4_K_M.gguf",
             approxSizeBytes = 4_500_000_000,
             fileName = "gemma-3n-e4b-it-Q4_K_M.gguf",
+            minRamBytes = 6_000_000_000,
+            requiredAbi = "arm64-v8a",
             notes = "Gemma 3 Nano E4B (4B effective parameters). Needs ~5 GB RAM.",
         ),
         LocalModel(
@@ -82,6 +100,8 @@ object LocalModelCatalog {
             url = "https://huggingface.co/unsloth/gemma-2-2b-it-GGUF/resolve/main/gemma-2-2b-it.Q4_K_M.gguf",
             approxSizeBytes = 1_700_000_000,
             fileName = "gemma-2-2b-it.Q4_K_M.gguf",
+            minRamBytes = 4_000_000_000,
+            requiredAbi = "arm64-v8a",
             notes = "Stronger; wants ~3 GB free RAM.",
         ),
         run {
@@ -101,6 +121,8 @@ object LocalModelCatalog {
                     LocalModelFile(base + "tokenizer_config.json", "tokenizer_config.json"),
                     LocalModelFile(base + "special_tokens_map.json", "special_tokens_map.json"),
                 ),
+                minRamBytes = 4_000_000_000,
+                requiredAbi = "arm64-v8a",
                 notes = "ONNX Runtime GenAI; multi-file model directory. Verify file list before use.",
             )
         },
@@ -112,6 +134,8 @@ object LocalModelCatalog {
             approxSizeBytes = 1_300_000_000,
             fileName = "gemma-2-2b-it.task",
             requiresAuth = true,
+            minRamBytes = 4_000_000_000,
+            requiredAbi = "arm64-v8a",
             notes = "Gated by Google — requires a Hugging Face token with access granted.",
         ),
     )

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ai/local/LocalModelRuntime.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ai/local/LocalModelRuntime.kt
@@ -5,6 +5,8 @@ import com.google.ai.edge.aicore.GenerativeModel
 import com.google.ai.edge.aicore.generationConfig
 import com.google.mediapipe.tasks.genai.llminference.LlmInference
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import java.io.File
 
@@ -68,22 +70,29 @@ object MediaPipeRuntime : LocalModelRuntime {
 object LlamaCppRuntime : LocalModelRuntime {
     override val id = "llamacpp"
     override val displayName = "llama.cpp (GGUF)"
+
+    // LLamaAndroid is a process-global singleton (one native model at a time), so
+    // serialize whole load→complete→unload cycles; concurrent generate() calls would
+    // otherwise corrupt state (e.g. unload while another is mid-complete).
+    private val mutex = Mutex()
+
     override fun isAvailable(context: Context) =
         classPresent("android.llama.cpp.LLamaAndroid")
 
     override suspend fun generate(context: Context, modelFile: File, prompt: String): String =
-        withContext(Dispatchers.IO) {
-            val cls = runCatching { Class.forName("android.llama.cpp.LLamaAndroid") }.getOrNull()
-                ?: throw LocalRuntimeUnavailableException(displayName)
-            // LLamaAndroid is a process-global singleton: instance() → load(path) →
-            // complete(prompt, maxTokens) → unload(). Synchronous; we're on IO.
-            val instance = cls.getMethod("instance").invoke(null)
-            cls.getMethod("load", String::class.java).invoke(instance, modelFile.absolutePath)
-            try {
-                cls.getMethod("complete", String::class.java, Int::class.javaPrimitiveType)
-                    .invoke(instance, prompt, 512) as String
-            } finally {
-                runCatching { cls.getMethod("unload").invoke(instance) }
+        mutex.withLock {
+            withContext(Dispatchers.IO) {
+                val cls = runCatching { Class.forName("android.llama.cpp.LLamaAndroid") }.getOrNull()
+                    ?: throw LocalRuntimeUnavailableException(displayName)
+                // instance() → load(path) → complete(prompt, maxTokens) → unload().
+                val instance = cls.getMethod("instance").invoke(null)
+                cls.getMethod("load", String::class.java).invoke(instance, modelFile.absolutePath)
+                try {
+                    cls.getMethod("complete", String::class.java, Int::class.javaPrimitiveType)
+                        .invoke(instance, prompt, 512) as String
+                } finally {
+                    runCatching { cls.getMethod("unload").invoke(instance) }
+                }
             }
         }
 }
@@ -113,41 +122,47 @@ object OnnxGenAiRuntime : LocalModelRuntime {
             val sequencesCls = Class.forName("$pkg.Sequences")
 
             // GenAI loads a directory (model + genai_config.json + tokenizer files).
+            // Model/Tokenizer/Sequences/GeneratorParams/Generator all wrap native
+            // memory (AutoCloseable); close every one to avoid native leaks/OOM.
             val dir = (modelFile.parentFile ?: modelFile).absolutePath
             val model = modelCls.getConstructor(String::class.java).newInstance(dir)
+            var tokenizer: Any? = null
+            var encoded: Any? = null
+            var params: Any? = null
+            var generator: Any? = null
             try {
-                val tokenizer = tokenizerCls.getConstructor(modelCls).newInstance(model)
-                val encoded = tokenizerCls.getMethod("encode", String::class.java).invoke(tokenizer, prompt)
-                val params = paramsCls.getConstructor(modelCls).newInstance(model)
+                tokenizer = tokenizerCls.getConstructor(modelCls).newInstance(model)
+                encoded = tokenizerCls.getMethod("encode", String::class.java).invoke(tokenizer, prompt)
+                params = paramsCls.getConstructor(modelCls).newInstance(model)
                 paramsCls.getMethod("setSearchOption", String::class.java, Double::class.javaPrimitiveType)
                     .invoke(params, "max_length", 1024.0)
-                val generator = generatorCls.getConstructor(modelCls, paramsCls).newInstance(model, params)
-                try {
-                    // Feed prompt tokens. Newer API: Generator.appendTokenSequences(Sequences);
-                    // older API: GeneratorParams.setInput(Sequences) before generation.
+                generator = generatorCls.getConstructor(modelCls, paramsCls).newInstance(model, params)
+                // Feed prompt tokens. Newer API: Generator.appendTokenSequences(Sequences);
+                // older API: GeneratorParams.setInput(Sequences) before generation.
+                runCatching {
+                    generatorCls.getMethod("appendTokenSequences", sequencesCls).invoke(generator, encoded)
+                }.onFailure {
                     runCatching {
-                        generatorCls.getMethod("appendTokenSequences", sequencesCls).invoke(generator, encoded)
-                    }.onFailure {
-                        runCatching {
-                            paramsCls.getMethod("setInput", sequencesCls).invoke(params, encoded)
-                        }
+                        paramsCls.getMethod("setInput", sequencesCls).invoke(params, encoded)
                     }
-                    val isDone = generatorCls.getMethod("isDone")
-                    val computeLogits = runCatching { generatorCls.getMethod("computeLogits") }.getOrNull()
-                    val generateNextToken = generatorCls.getMethod("generateNextToken")
-                    val getSequence = generatorCls.getMethod("getSequence", Long::class.javaPrimitiveType)
-                    var guard = 0
-                    while (isDone.invoke(generator) == false && guard < 4096) {
-                        computeLogits?.invoke(generator)
-                        generateNextToken.invoke(generator)
-                        guard++
-                    }
-                    val outIds = getSequence.invoke(generator, 0L) as IntArray
-                    tokenizerCls.getMethod("decode", IntArray::class.java).invoke(tokenizer, outIds) as String
-                } finally {
-                    runCatching { (generator as? AutoCloseable)?.close() }
                 }
+                val isDone = generatorCls.getMethod("isDone")
+                val computeLogits = runCatching { generatorCls.getMethod("computeLogits") }.getOrNull()
+                val generateNextToken = generatorCls.getMethod("generateNextToken")
+                val getSequence = generatorCls.getMethod("getSequence", Long::class.javaPrimitiveType)
+                var guard = 0
+                while (isDone.invoke(generator) == false && guard < 4096) {
+                    computeLogits?.invoke(generator)
+                    generateNextToken.invoke(generator)
+                    guard++
+                }
+                val outIds = getSequence.invoke(generator, 0L) as IntArray
+                tokenizerCls.getMethod("decode", IntArray::class.java).invoke(tokenizer, outIds) as String
             } finally {
+                runCatching { (generator as? AutoCloseable)?.close() }
+                runCatching { (params as? AutoCloseable)?.close() }
+                runCatching { (encoded as? AutoCloseable)?.close() }
+                runCatching { (tokenizer as? AutoCloseable)?.close() }
                 runCatching { (model as? AutoCloseable)?.close() }
             }
         }

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ai/local/LocalModelRuntime.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ai/local/LocalModelRuntime.kt
@@ -58,34 +58,99 @@ object MediaPipeRuntime : LocalModelRuntime {
 }
 
 /**
- * llama.cpp — any GGUF model. Pending its native backend: llama.cpp has no
- * published Android Maven artifact, so enabling it means adding an NDK module
- * (CMake build of libllama + the `android.llama.cpp.LLamaAndroid` JNI class).
- * Until that's present [isAvailable] is false and [generate] reports it.
+ * llama.cpp — any GGUF model, via the `android.llama.cpp.LLamaAndroid` JNI binding
+ * in the `:llama-cpp-module` NDK module. llama.cpp has no published Android Maven
+ * artifact, so the module is included only when its `llama.cpp` submodule is
+ * present (see its README). [generate] talks to the binding by reflection so the
+ * app compiles whether or not the module is on the classpath; when it's absent
+ * [isAvailable] is false and the model is hidden.
  */
 object LlamaCppRuntime : LocalModelRuntime {
     override val id = "llamacpp"
     override val displayName = "llama.cpp (GGUF)"
     override fun isAvailable(context: Context) =
-        classPresent("android.llama.cpp.LLamaAndroid") || classPresent("de.kherud.llama.LlamaModel")
+        classPresent("android.llama.cpp.LLamaAndroid")
+
     override suspend fun generate(context: Context, modelFile: File, prompt: String): String =
-        throw LocalRuntimeUnavailableException(displayName)
+        withContext(Dispatchers.IO) {
+            val cls = runCatching { Class.forName("android.llama.cpp.LLamaAndroid") }.getOrNull()
+                ?: throw LocalRuntimeUnavailableException(displayName)
+            // LLamaAndroid is a process-global singleton: instance() → load(path) →
+            // complete(prompt, maxTokens) → unload(). Synchronous; we're on IO.
+            val instance = cls.getMethod("instance").invoke(null)
+            cls.getMethod("load", String::class.java).invoke(instance, modelFile.absolutePath)
+            try {
+                cls.getMethod("complete", String::class.java, Int::class.javaPrimitiveType)
+                    .invoke(instance, prompt, 512) as String
+            } finally {
+                runCatching { cls.getMethod("unload").invoke(instance) }
+            }
+        }
 }
 
 /**
- * ONNX Runtime GenAI — Phi-3/3.5, Qwen (multi-file model directory). Pending its
- * backend: add the `com.microsoft.onnxruntime:onnxruntime-genai-android` AAR
- * (confirm the published version/coordinates), then drive `ai.onnxruntime.genai`
- * (SimpleGenAI/Model) over the downloaded model directory ([modelFile]'s parent).
- * Until the dependency is present [isAvailable] is false and [generate] reports it.
+ * ONNX Runtime GenAI — Phi-3/3.5, Qwen (a multi-file model *directory*). Enable by
+ * adding the `com.microsoft.onnxruntime:onnxruntime-genai-android` AAR (see
+ * `docs/on-device-runtimes.md`). [generate] drives `ai.onnxruntime.genai`
+ * (Model/Tokenizer/Generator) over the downloaded model directory ([modelFile]'s
+ * parent) by reflection, so the app compiles without the AAR; when it's absent
+ * [isAvailable] is false and the model is hidden.
  */
 object OnnxGenAiRuntime : LocalModelRuntime {
     override val id = "onnx"
     override val displayName = "ONNX Runtime GenAI"
     override fun isAvailable(context: Context) =
         classPresent("ai.onnxruntime.genai.Model")
+
     override suspend fun generate(context: Context, modelFile: File, prompt: String): String =
-        throw LocalRuntimeUnavailableException(displayName)
+        withContext(Dispatchers.IO) {
+            val pkg = "ai.onnxruntime.genai"
+            val modelCls = runCatching { Class.forName("$pkg.Model") }.getOrNull()
+                ?: throw LocalRuntimeUnavailableException(displayName)
+            val tokenizerCls = Class.forName("$pkg.Tokenizer")
+            val paramsCls = Class.forName("$pkg.GeneratorParams")
+            val generatorCls = Class.forName("$pkg.Generator")
+            val sequencesCls = Class.forName("$pkg.Sequences")
+
+            // GenAI loads a directory (model + genai_config.json + tokenizer files).
+            val dir = (modelFile.parentFile ?: modelFile).absolutePath
+            val model = modelCls.getConstructor(String::class.java).newInstance(dir)
+            try {
+                val tokenizer = tokenizerCls.getConstructor(modelCls).newInstance(model)
+                val encoded = tokenizerCls.getMethod("encode", String::class.java).invoke(tokenizer, prompt)
+                val params = paramsCls.getConstructor(modelCls).newInstance(model)
+                paramsCls.getMethod("setSearchOption", String::class.java, Double::class.javaPrimitiveType)
+                    .invoke(params, "max_length", 1024.0)
+                val generator = generatorCls.getConstructor(modelCls, paramsCls).newInstance(model, params)
+                try {
+                    // Feed prompt tokens. Newer API: Generator.appendTokenSequences(Sequences);
+                    // older API: GeneratorParams.setInput(Sequences) before generation.
+                    runCatching {
+                        generatorCls.getMethod("appendTokenSequences", sequencesCls).invoke(generator, encoded)
+                    }.onFailure {
+                        runCatching {
+                            paramsCls.getMethod("setInput", sequencesCls).invoke(params, encoded)
+                        }
+                    }
+                    val isDone = generatorCls.getMethod("isDone")
+                    val computeLogits = runCatching { generatorCls.getMethod("computeLogits") }.getOrNull()
+                    val generateNextToken = generatorCls.getMethod("generateNextToken")
+                    val getSequence = generatorCls.getMethod("getSequence", Long::class.javaPrimitiveType)
+                    var guard = 0
+                    while (isDone.invoke(generator) == false && guard < 4096) {
+                        computeLogits?.invoke(generator)
+                        generateNextToken.invoke(generator)
+                        guard++
+                    }
+                    val outIds = getSequence.invoke(generator, 0L) as IntArray
+                    tokenizerCls.getMethod("decode", IntArray::class.java).invoke(tokenizer, outIds) as String
+                } finally {
+                    runCatching { (generator as? AutoCloseable)?.close() }
+                }
+            } finally {
+                runCatching { (model as? AutoCloseable)?.close() }
+            }
+        }
 }
 
 /**

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/services/ScreenshotService.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/services/ScreenshotService.kt
@@ -62,19 +62,8 @@ class ScreenshotService : Service() {
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        val notification: Notification = Notification.Builder(this, "screenshot_service")
-            .setContentTitle("IDEaz")
-            .setContentText("Selection service is active.")
-            .setSmallIcon(R.mipmap.ic_launcher) // Make sure you have this
-            .build()
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            startForeground(SERVICE_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION)
-        } else {
-            startForeground(SERVICE_ID, notification)
-        }
-
         val resultCode = intent?.getIntExtra(EXTRA_RESULT_CODE, Activity.RESULT_CANCELED)
+            ?: Activity.RESULT_CANCELED
 
         val data: Intent? = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             intent?.getParcelableExtra(EXTRA_DATA, Intent::class.java)
@@ -89,13 +78,45 @@ class ScreenshotService : Service() {
             intent?.getParcelableExtra(EXTRA_RECT)
         }
 
-        if (resultCode == Activity.RESULT_OK && data != null && rect != null) {
+        // A mediaProjection foreground service may only be started while the app
+        // holds a fresh MediaProjection consent (the project_media app-op). Starting
+        // it without one throws SecurityException on Android 14+, so bail BEFORE
+        // calling startForeground if the consent token is missing/invalid.
+        if (resultCode != Activity.RESULT_OK || data == null || rect == null) {
+            stopSelf()
+            return START_NOT_STICKY
+        }
+
+        val notification: Notification = Notification.Builder(this, "screenshot_service")
+            .setContentTitle("IDEaz")
+            .setContentText("Selection service is active.")
+            .setSmallIcon(R.mipmap.ic_launcher) // Make sure you have this
+            .build()
+
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                startForeground(SERVICE_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION)
+            } else {
+                startForeground(SERVICE_ID, notification)
+            }
             startCapture(resultCode, data, rect)
-        } else {
-            stopSelf() // Invalid start
+        } catch (e: Exception) {
+            // e.g. SecurityException if the consent isn't actually held, or the
+            // projection token was already consumed. Fail cleanly, don't crash.
+            reportError("Screen capture unavailable: ${e.message}")
+            stopCapture()
         }
 
         return START_NOT_STICKY
+    }
+
+    /** Tell the UI a capture failed so it isn't left waiting silently. */
+    private fun reportError(message: String) {
+        val intent = Intent("com.hereliesaz.ideaz.SCREENSHOT_FAILED").apply {
+            setPackage(packageName)
+            putExtra("MESSAGE", message)
+        }
+        sendBroadcast(intent)
     }
 
     private fun startCapture(resultCode: Int, data: Intent, rect: Rect) {

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/OnDeviceModelsSection.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/OnDeviceModelsSection.kt
@@ -109,27 +109,34 @@ fun OnDeviceModelsSection(settingsViewModel: SettingsViewModel) {
     val hfToken = settingsViewModel.getApiKey(SettingsViewModel.KEY_HF_API_KEY).orEmpty()
     val hasToken = hfToken.isNotBlank()
 
-    @Suppress("UNUSED_EXPRESSION") refresh // re-evaluate download state when bumped
-    val entries = LocalModelCatalog.models.map { model ->
-        val runtime = LocalModelRuntimes.byId(model.runtimeId)
-        // AICore's true availability is the hardware probe; others use class presence.
-        val backendOk = if (model.runtimeId == "aicore") {
-            aicoreSupported == true
-        } else {
-            runtime?.isAvailable(context) == true
+    @Suppress("UNUSED_EXPRESSION") refresh // re-read per-card download state when bumped
+
+    // Cache the mapping: it runs reflective isAvailable() lookups, so recomputing it
+    // on every recomposition (e.g. download progress ticks) would stutter the UI.
+    // Only the dynamic inputs (AICore probe result, token presence) are keys; RAM/ABI
+    // are read once above. Download state is handled per-card via `refresh`, not here.
+    val entries = remember(aicoreSupported, hasToken) {
+        LocalModelCatalog.models.map { model ->
+            val runtime = LocalModelRuntimes.byId(model.runtimeId)
+            // AICore's true availability is the hardware probe; others use class presence.
+            val backendOk = if (model.runtimeId == "aicore") {
+                aicoreSupported == true
+            } else {
+                runtime?.isAvailable(context) == true
+            }
+            val status = LocalModelAvailability.evaluate(
+                model = model,
+                backendAvailable = backendOk,
+                backendName = runtime?.displayName ?: model.runtimeId,
+                totalRamBytes = totalRam,
+                abis = abis,
+                hasAuthToken = hasToken,
+            )
+            ModelEntry(model, runtime, status)
         }
-        val status = LocalModelAvailability.evaluate(
-            model = model,
-            backendAvailable = backendOk,
-            backendName = runtime?.displayName ?: model.runtimeId,
-            totalRamBytes = totalRam,
-            abis = abis,
-            hasAuthToken = hasToken,
-        )
-        ModelEntry(model, runtime, status)
     }
-    val usable = entries.filter { it.status is LocalModelAvailability.Status.Usable }
-    val unavailable = entries.filter { it.status is LocalModelAvailability.Status.Unsupported }
+    val usable = remember(entries) { entries.filter { it.status is LocalModelAvailability.Status.Usable } }
+    val unavailable = remember(entries) { entries.filter { it.status is LocalModelAvailability.Status.Unsupported } }
 
     if (usable.isEmpty()) {
         Text(

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/OnDeviceModelsSection.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/OnDeviceModelsSection.kt
@@ -11,10 +11,10 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableIntStateOf
@@ -22,6 +22,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.foundation.clickable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -30,7 +31,12 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.hereliesaz.aznavrail.AzButton
 import com.hereliesaz.aznavrail.model.AzButtonShape
+import com.hereliesaz.ideaz.ai.GeminiNanoAdapter
+import com.hereliesaz.ideaz.ai.local.DeviceCapabilities
+import com.hereliesaz.ideaz.ai.local.LocalModel
+import com.hereliesaz.ideaz.ai.local.LocalModelAvailability
 import com.hereliesaz.ideaz.ai.local.LocalModelCatalog
+import com.hereliesaz.ideaz.ai.local.LocalModelRuntime
 import com.hereliesaz.ideaz.ai.local.LocalModelRuntimes
 import com.hereliesaz.ideaz.ai.local.LocalModelStore
 import com.hereliesaz.ideaz.ai.local.ModelDownloadManager
@@ -43,10 +49,21 @@ private fun humanSize(bytes: Long): String = when {
     else -> "%.0f KB".format(bytes / 1e3)
 }
 
+private class ModelEntry(
+    val model: LocalModel,
+    val runtime: LocalModelRuntime?,
+    val status: LocalModelAvailability.Status,
+)
+
 /**
  * Settings section that lets the user download an on-device model (per runtime)
- * and select which one the "On-device model" AI provider uses. AICore is offered
- * as a no-download, system-managed entry.
+ * and select which one the "On-device model" AI provider uses.
+ *
+ * Only models this device can actually use *right now* are listed — the runtime
+ * backend must be in the build (and, for AICore, supported by the hardware), the
+ * device must meet the model's RAM/ABI needs, and any required token must be
+ * present. Everything else is summarized under a collapsible "unavailable" note
+ * so the list isn't a wall of disabled, un-runnable entries.
  */
 @Composable
 fun OnDeviceModelsSection(settingsViewModel: SettingsViewModel) {
@@ -60,6 +77,18 @@ fun OnDeviceModelsSection(settingsViewModel: SettingsViewModel) {
     val downloading = remember { mutableStateMapOf<String, Boolean>() }
     val errors = remember { mutableStateMapOf<String, String>() }
     var refresh by remember { mutableIntStateOf(0) }
+    var showUnavailable by remember { mutableStateOf(false) }
+
+    // Static device signals (read once).
+    val totalRam = remember { DeviceCapabilities.totalRamBytes(context) }
+    val abis = remember { DeviceCapabilities.supportedAbis() }
+
+    // AICore support needs the real engine probe (not just class presence); run it
+    // once. null = still checking → treat as unsupported until it resolves.
+    var aicoreSupported by remember { mutableStateOf<Boolean?>(null) }
+    LaunchedEffect(Unit) {
+        aicoreSupported = runCatching { GeminiNanoAdapter.isAvailable(context) }.getOrDefault(false)
+    }
 
     Text(
         "On-device Models",
@@ -70,18 +99,50 @@ fun OnDeviceModelsSection(settingsViewModel: SettingsViewModel) {
     Spacer(Modifier.height(8.dp))
     Text(
         "Run the AI fully on-device. Download a model (or use the system AICore model), " +
-            "select it below, then choose \"On-device model\" as an AI Assignment above.",
+            "select it below, then choose \"On-device model\" as an AI Assignment above. " +
+            "Only models this device can run are shown.",
         color = MaterialTheme.colorScheme.onSurfaceVariant,
         style = MaterialTheme.typography.bodySmall,
     )
     Spacer(Modifier.height(8.dp))
 
     val hfToken = settingsViewModel.getApiKey(SettingsViewModel.KEY_HF_API_KEY).orEmpty()
+    val hasToken = hfToken.isNotBlank()
 
-    LocalModelCatalog.models.forEach { model ->
+    @Suppress("UNUSED_EXPRESSION") refresh // re-evaluate download state when bumped
+    val entries = LocalModelCatalog.models.map { model ->
         val runtime = LocalModelRuntimes.byId(model.runtimeId)
-        val backendOk = runtime?.isAvailable(context) == true
-        @Suppress("UNUSED_EXPRESSION") refresh // re-read download state when bumped
+        // AICore's true availability is the hardware probe; others use class presence.
+        val backendOk = if (model.runtimeId == "aicore") {
+            aicoreSupported == true
+        } else {
+            runtime?.isAvailable(context) == true
+        }
+        val status = LocalModelAvailability.evaluate(
+            model = model,
+            backendAvailable = backendOk,
+            backendName = runtime?.displayName ?: model.runtimeId,
+            totalRamBytes = totalRam,
+            abis = abis,
+            hasAuthToken = hasToken,
+        )
+        ModelEntry(model, runtime, status)
+    }
+    val usable = entries.filter { it.status is LocalModelAvailability.Status.Usable }
+    val unavailable = entries.filter { it.status is LocalModelAvailability.Status.Unsupported }
+
+    if (usable.isEmpty()) {
+        Text(
+            "No on-device models are usable on this device or build yet.",
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        Spacer(Modifier.height(8.dp))
+    }
+
+    usable.forEach { entry ->
+        val model = entry.model
+        val runtime = entry.runtime
         val downloaded = downloads.isDownloaded(model)
 
         Card(
@@ -95,7 +156,7 @@ fun OnDeviceModelsSection(settingsViewModel: SettingsViewModel) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     RadioButton(
                         selected = activeId == model.id,
-                        enabled = downloaded && backendOk,
+                        enabled = downloaded,
                         onClick = {
                             activeId = model.id
                             store.activeModelId = model.id
@@ -115,14 +176,6 @@ fun OnDeviceModelsSection(settingsViewModel: SettingsViewModel) {
                             Text(
                                 model.notes,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                style = MaterialTheme.typography.bodySmall,
-                            )
-                        }
-                        if (!backendOk) {
-                            Text(
-                                if (model.systemManaged) "Not available on this device."
-                                else "Runtime backend not included in this build yet.",
-                                color = MaterialTheme.colorScheme.error,
                                 style = MaterialTheme.typography.bodySmall,
                             )
                         }
@@ -180,7 +233,6 @@ fun OnDeviceModelsSection(settingsViewModel: SettingsViewModel) {
                                 },
                                 text = "Download",
                                 shape = AzButtonShape.RECTANGLE,
-                                enabled = !model.requiresAuth || hfToken.isNotBlank(),
                             )
                         }
                     }
@@ -188,5 +240,30 @@ fun OnDeviceModelsSection(settingsViewModel: SettingsViewModel) {
             }
         }
     }
+
+    if (unavailable.isNotEmpty()) {
+        Text(
+            text = (if (showUnavailable) "▾ " else "▸ ") +
+                "${unavailable.size} model(s) unavailable on this device",
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            style = MaterialTheme.typography.bodySmall,
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable { showUnavailable = !showUnavailable }
+                .padding(vertical = 4.dp),
+        )
+        if (showUnavailable) {
+            unavailable.forEach { entry ->
+                val reason = (entry.status as LocalModelAvailability.Status.Unsupported).reason
+                Text(
+                    "• ${entry.model.name} — $reason",
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier.padding(start = 8.dp, bottom = 2.dp),
+                )
+            }
+        }
+    }
+
     Spacer(Modifier.height(24.dp))
 }

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/delegates/OverlayDelegate.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/delegates/OverlayDelegate.kt
@@ -84,6 +84,14 @@ class OverlayDelegate(
 
     private var pendingRect: Rect? = null
 
+    /**
+     * A capture rect that is waiting for a fresh MediaProjection consent. Set when
+     * [takeScreenshot] runs without a valid token; replayed once the user grants
+     * consent in [setScreenCapturePermission]. Distinct from [pendingRect], which
+     * is kept for restoring the highlight after the capture completes.
+     */
+    private var deferredCaptureRect: Rect? = null
+
     // --- Public Operations ---
 
     /**
@@ -220,10 +228,18 @@ class OverlayDelegate(
      * Uses [ScreenshotService] (foreground service) because MediaProjection requires a foreground service context on newer Android versions.
      */
     private fun takeScreenshot(rect: Rect) {
-        if (!hasScreenCapturePermission()) {
-            onOverlayLog("Error: Missing screen capture permission.")
+        val code = screenCaptureResultCode
+        val data = screenCaptureData
+        if (code == null || data == null) {
+            // No (or already-consumed) consent. MediaProjection tokens are single-use
+            // on Android 14+, so request a fresh one and replay this capture on grant.
+            deferredCaptureRect = rect
+            requestScreenCapturePermission()
             return
         }
+        // Consume the token now — it can't be reused for a second capture.
+        screenCaptureResultCode = null
+        screenCaptureData = null
 
         scope.launch {
             // Temporarily hide the highlight to get a clean screenshot
@@ -235,8 +251,8 @@ class OverlayDelegate(
             delay(250) // Wait for UI to update
 
             val serviceIntent = Intent(application, ScreenshotService::class.java).apply {
-                putExtra(ScreenshotService.EXTRA_RESULT_CODE, screenCaptureResultCode)
-                putExtra(ScreenshotService.EXTRA_DATA, screenCaptureData)
+                putExtra(ScreenshotService.EXTRA_RESULT_CODE, code)
+                putExtra(ScreenshotService.EXTRA_DATA, data)
                 putExtra(ScreenshotService.EXTRA_RECT, rect)
             }
             application.startForegroundService(serviceIntent)
@@ -269,9 +285,17 @@ class OverlayDelegate(
      * Stores the MediaProjection permission result for later use by the ScreenshotService.
      */
     fun setScreenCapturePermission(code: Int, data: Intent?) {
-        if (code == Activity.RESULT_OK) {
+        if (code == Activity.RESULT_OK && data != null) {
             screenCaptureResultCode = code
             screenCaptureData = data
+            // Replay a capture that was waiting on this consent.
+            deferredCaptureRect?.let { rect ->
+                deferredCaptureRect = null
+                takeScreenshot(rect)
+            }
+        } else {
+            deferredCaptureRect = null
+            onOverlayLog("Screen capture permission denied.")
         }
     }
 }

--- a/app/src/test/java/com/hereliesaz/ideaz/ai/local/LocalModelAvailabilityTest.kt
+++ b/app/src/test/java/com/hereliesaz/ideaz/ai/local/LocalModelAvailabilityTest.kt
@@ -1,0 +1,80 @@
+package com.hereliesaz.ideaz.ai.local
+
+import com.hereliesaz.ideaz.ai.local.LocalModelAvailability.Status
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LocalModelAvailabilityTest {
+
+    private val arm64 = setOf("arm64-v8a", "armeabi-v7a")
+
+    private fun gguf(
+        minRam: Long = 2_000_000_000,
+        abi: String? = "arm64-v8a",
+        auth: Boolean = false,
+    ) = LocalModel(
+        id = "m", name = "M", runtimeId = "llamacpp", url = "u",
+        approxSizeBytes = 1, fileName = "m.gguf",
+        requiresAuth = auth, minRamBytes = minRam, requiredAbi = abi,
+    )
+
+    private fun aicore() = LocalModel(
+        id = "aicore", name = "Nano", runtimeId = "aicore", url = "",
+        approxSizeBytes = 0, fileName = "", systemManaged = true,
+    )
+
+    @Test
+    fun `usable when backend present and device meets needs`() {
+        val s = LocalModelAvailability.evaluate(gguf(), true, "llama.cpp", 8_000_000_000, arm64, false)
+        assertEquals(Status.Usable, s)
+    }
+
+    @Test
+    fun `backend missing is unsupported with build reason`() {
+        val s = LocalModelAvailability.evaluate(gguf(), false, "llama.cpp", 8_000_000_000, arm64, false)
+        assertTrue(s is Status.Unsupported && "build" in s.reason)
+    }
+
+    @Test
+    fun `system-managed backend missing says not supported on device`() {
+        val s = LocalModelAvailability.evaluate(aicore(), false, "AICore", 8_000_000_000, arm64, false)
+        assertTrue(s is Status.Unsupported && "device" in s.reason)
+    }
+
+    @Test
+    fun `wrong abi is unsupported`() {
+        val s = LocalModelAvailability.evaluate(gguf(abi = "arm64-v8a"), true, "llama.cpp", 8_000_000_000, setOf("x86_64"), false)
+        assertTrue(s is Status.Unsupported && "arm64-v8a" in s.reason)
+    }
+
+    @Test
+    fun `insufficient ram is unsupported`() {
+        val s = LocalModelAvailability.evaluate(gguf(minRam = 6_000_000_000), true, "llama.cpp", 3_000_000_000, arm64, false)
+        assertTrue(s is Status.Unsupported && "RAM" in s.reason)
+    }
+
+    @Test
+    fun `gated model without token is unsupported`() {
+        val s = LocalModelAvailability.evaluate(gguf(auth = true), true, "llama.cpp", 8_000_000_000, arm64, false)
+        assertTrue(s is Status.Unsupported && "token" in s.reason)
+    }
+
+    @Test
+    fun `gated model with token is usable`() {
+        val s = LocalModelAvailability.evaluate(gguf(auth = true), true, "llama.cpp", 8_000_000_000, arm64, true)
+        assertEquals(Status.Usable, s)
+    }
+
+    @Test
+    fun `unknown ram (zero) skips the ram check`() {
+        val s = LocalModelAvailability.evaluate(gguf(minRam = 6_000_000_000), true, "llama.cpp", 0, arm64, false)
+        assertEquals(Status.Usable, s)
+    }
+
+    @Test
+    fun `unknown abis (empty) skips the abi check`() {
+        val s = LocalModelAvailability.evaluate(gguf(abi = "arm64-v8a"), true, "llama.cpp", 8_000_000_000, emptySet(), false)
+        assertEquals(Status.Usable, s)
+    }
+}

--- a/docs/file_descriptions.md
+++ b/docs/file_descriptions.md
@@ -69,8 +69,10 @@
 *   `ToolSchema.kt`: JSON schemas for tools.
 
 #### ai/local/
-*   `LocalModelRuntime.kt`: Interface and implementations for on-device backends (MediaPipe, AICore, etc.).
-*   `LocalModelCatalog.kt`: Curated list of downloadable on-device models.
+*   `LocalModelRuntime.kt`: Interface and implementations for on-device backends — AICore + MediaPipe (wired) and llama.cpp/GGUF + ONNX GenAI (reflection-driven `generate()`, active once their library is on the classpath).
+*   `LocalModelCatalog.kt`: Curated list of downloadable on-device models, with per-model RAM/ABI/auth requirements used for filtering.
+*   `DeviceCapabilities.kt`: Reads device RAM (`ActivityManager.MemoryInfo`) and supported CPU ABIs (`Build.SUPPORTED_ABIS`).
+*   `LocalModelAvailability.kt`: Pure, unit-tested logic deciding whether a model is usable on this device/build (backend present, RAM, ABI, token) — drives the Settings list filtering.
 *   `LocalModelStore.kt`: Manages locally stored model files and metadata.
 *   `ModelDownloadManager.kt`: Handles background downloading of model files with auth support.
 

--- a/docs/on-device-runtimes.md
+++ b/docs/on-device-runtimes.md
@@ -4,13 +4,18 @@ IDEaz ships a pluggable on-device model framework (`ai/local/`): a
 `LocalModelRuntime` registry, a multi-file `ModelDownloadManager`, a catalog, the
 `LocalLlmAdapter`, and the **On-device Models** Settings section.
 
-Working today:
+Working today (dependency in the build):
 - **AICore (Gemini Nano)** — `AiCoreRuntime`, system-managed, no download.
 - **MediaPipe LLM Inference** — `MediaPipeRuntime`, wired (`com.google.mediapipe:tasks-genai`).
 
-Pending their native backends (this guide): **ONNX Runtime GenAI** and **llama.cpp**.
-Both are registered runtimes that report "backend not in this build" until wired,
-so the picker degrades cleanly.
+**ONNX Runtime GenAI** (`OnnxGenAiRuntime`) and **llama.cpp** (`LlamaCppRuntime`)
+now have their `generate()` **implemented** (against `ai.onnxruntime.genai` and
+`android.llama.cpp.LLamaAndroid` respectively, via reflection so the app compiles
+without the heavy native deps). They stay dormant until their library is on the
+classpath: `isAvailable()` is false, and the **On-device Models** picker hides any
+model whose backend isn't actually usable on the device (it also filters by RAM,
+CPU ABI, and required tokens — see `LocalModelAvailability`). Add the library
+(below) and the matching models appear automatically.
 
 ---
 
@@ -31,9 +36,13 @@ implementation(files("libs/onnxruntime-genai-android-<ver>.aar"))
 implementation("com.microsoft.onnxruntime:onnxruntime-android:1.20.0")
 ```
 
-### 2. Implement `OnnxGenAiRuntime.generate()` (in `ai/local/LocalModelRuntime.kt`)
-The model is a **directory** — our `ModelDownloadManager` already downloads all
-files into one (`additionalFiles`), so point the runtime at the parent dir:
+### 2. `OnnxGenAiRuntime.generate()` is already implemented
+It's in `ai/local/LocalModelRuntime.kt`, driving `ai.onnxruntime.genai`
+(Model/Tokenizer/GeneratorParams/Generator) **by reflection** over the model
+directory (`modelFile.parentFile`). Once the AAR is on the classpath it activates
+automatically. If the vendored version's API differs from the reflected calls
+(method names/signatures drift across releases), adjust them there. For reference,
+the equivalent typed code is:
 ```kotlin
 override suspend fun generate(context: Context, modelFile: File, prompt: String): String =
     withContext(Dispatchers.IO) {
@@ -63,6 +72,8 @@ override suspend fun generate(context: Context, modelFile: File, prompt: String)
 > names against the AAR you vendored (`javap` the bundled `classes.jar`).
 
 ### 3. R8 (`proguard-rules.pro`)
+Keep rules for `ai.onnxruntime.genai.**` (and `android.llama.cpp.**`) are already
+in `proguard-rules.pro`. If you vendor the broader `ai.onnxruntime.**` runtime, add:
 ```
 -keep class ai.onnxruntime.** { *; }
 -dontwarn ai.onnxruntime.**
@@ -82,22 +93,15 @@ is provided in `/llama-cpp-module/` — see its `README.md`. Summary:
 
 1. Add llama.cpp as a submodule inside the module:
    `git submodule add https://github.com/ggml-org/llama.cpp llama-cpp-module/llama.cpp`
-2. Include the module: in `settings.gradle.kts` add `include(":llama-cpp-module")`.
-3. Depend on it: in `app/build.gradle.kts` add
-   `implementation(project(":llama-cpp-module"))`.
-4. Replace `LlamaCppRuntime.generate()` with a direct call to
-   `android.llama.cpp.LLamaAndroid` (the scaffold's binding), e.g.:
-```kotlin
-override suspend fun generate(context: Context, modelFile: File, prompt: String): String {
-    val llm = android.llama.cpp.LLamaAndroid.instance()
-    llm.load(modelFile.absolutePath)
-    return try { llm.complete(prompt, maxTokens = 512) } finally { llm.unload() }
-}
-```
-5. R8 (`proguard-rules.pro`):
-```
--keep class android.llama.cpp.** { *; }
-```
 
-`isAvailable()` already detects `android.llama.cpp.LLamaAndroid`, so the runtime
-activates automatically once the module is on the classpath.
+That's the only manual step. `settings.gradle.kts` and `app/build.gradle.kts` now
+**conditionally** include/depend on `:llama-cpp-module` when that submodule
+directory exists, so a plain checkout still builds without the NDK and the module
+activates automatically once the submodule is present. `LlamaCppRuntime.generate()`
+is already implemented (it calls `android.llama.cpp.LLamaAndroid` by reflection),
+`isAvailable()` already detects the binding, and the R8 keep rule
+(`-keep class android.llama.cpp.** { *; }`) is in `proguard-rules.pro`.
+
+> The C API in `llama-android.cpp` targets a recent llama.cpp release; pin a
+> known-good tag and adjust if the API drifted. None of this can be compile- or
+> run-verified without the submodule + NDK toolchain.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -34,3 +34,11 @@ dependencyResolutionManagement {
 
 rootProject.name = "IDEaz"
 include(":app")
+
+// llama.cpp GGUF backend (LlamaCppRuntime). An NDK module that builds libllama
+// from a git submodule at llama-cpp-module/llama.cpp. Included only when that
+// submodule is present so a plain checkout still builds without the NDK/submodule;
+// see llama-cpp-module/README.md to activate.
+if (file("llama-cpp-module/llama.cpp").exists()) {
+    include(":llama-cpp-module")
+}

--- a/version.properties
+++ b/version.properties
@@ -1,5 +1,5 @@
 #Fri Jun 05 21:45:00 CDT 2026
 build=72
 major=1
-minor=12
+minor=13
 patch=16


### PR DESCRIPTION
Addresses two requests plus a crash report from the device.

## 1. On-device model list shows only what the device can use
The **Settings → On-device Models** list previously rendered all 7 catalog models with no capability checks (just a disabled radio + "Runtime backend not included in this build yet" text). Now it shows only models that are actually runnable *right now* and summarizes the rest.

- `LocalModel` gains `minRamBytes` and `requiredAbi`; the catalog sets them per model.
- New `DeviceCapabilities` reads RAM (`ActivityManager.MemoryInfo.totalMem`) and CPU ABIs (`Build.SUPPORTED_ABIS`).
- New **pure, unit-tested** `LocalModelAvailability.evaluate(...)` decides usability from: backend present, RAM, ABI, and (for gated models) token present. Unknown RAM/ABI is treated as "don't filter."
- `OnDeviceModelsSection` filters to usable models. **AICore uses the real `GeminiNanoAdapter.isAvailable` hardware probe** (not just class presence), so Gemini Nano only appears on supported hardware. Everything filtered out is listed with its reason under a collapsible "N model(s) unavailable on this device".

## 2. Backend frameworks implemented
`LlamaCppRuntime.generate()` (GGUF) and `OnnxGenAiRuntime.generate()` (ONNX GenAI) were stubs that threw. Both are now implemented against `android.llama.cpp.LLamaAndroid` and `ai.onnxruntime.genai` respectively, **via reflection** — so the app still compiles without the heavy native deps, and each backend activates automatically once its library is on the classpath (matching the existing `classPresent` detection used by MediaPipe/AICore).
- `settings.gradle.kts` / `app/build.gradle.kts` now **conditionally** include + depend on `:llama-cpp-module` when its `llama.cpp` submodule is present — a plain checkout still builds without the NDK.
- ONNX GenAI: documented the vendored-AAR activation (the AAR isn't on Maven Central); R8 keep rules added for both.

> ⚠️ The native backends can't be compiled or run-verified in this environment (no NDK; the ONNX AAR isn't on Maven Central). Their `generate()` and wiring are complete and gated behind library presence, so until the libs are added the matching models simply stay hidden (no build/CI impact). The reflection calls target documented API versions and may need adjustment against the exact vendored version — noted in `docs/on-device-runtimes.md`.

## 3. ScreenshotService crash fix (from the pasted log)
`SecurityException: Starting FGS with type mediaProjection ... requires ... project_media`. Two causes, both fixed:
- The service called `startForeground(mediaProjection)` **unconditionally**, before validating the consent token. Now it validates `resultCode`/`data`/`rect` first and bails cleanly if absent, and wraps the FGS start + capture in try/catch (broadcasts `SCREENSHOT_FAILED` instead of crashing).
- MediaProjection tokens are **single-use** on Android 14+, but `OverlayDelegate` cached and reused one. It now consumes the token per capture and auto re-requests fresh consent (deferring + replaying the pending capture on grant).

## Verification
- ⚠️ Couldn't run `./gradlew` here — the environment's network policy drops TLS to `dl.google.com`/Maven Central, so the Android Gradle Plugin can't resolve. CI validates the build and runs the new `LocalModelAvailabilityTest`.
- Manual: open Settings → On-device Models on devices of varying RAM/ABI/token state and confirm only runnable models show (with the rest under the collapsible note); trigger a region screenshot twice and confirm no `mediaProjection` crash and that consent is re-requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nw6AHh15NTE63WQKU5qbY8)_