### PR TITLE
chore(capture): make MediaProjection screen-capture dormant in the PWA-only product

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,7 +19,11 @@
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+    <!-- Phase 2 (Android target screen capture). Disabled in the PWA-only product so
+         we don't carry the mediaProjection FGS permission (Play policy surface) while
+         it's unused. Re-add with OverlayDelegate.screenCaptureEnabled = true.
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
+    -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" tools:ignore="QueryAllPackagesPermission" />
@@ -100,10 +104,16 @@
                 android:resource="@xml/gemini_bridge_accessibility_config" />
         </service>
 
+        <!-- Phase 2 (Android target screen capture). Kept out of the manifest in the
+             PWA-only product so the mediaProjection foreground service can't be started
+             (or crash). ScreenshotService.kt is retained; re-declare this and the
+             FOREGROUND_SERVICE_MEDIA_PROJECTION permission, and set
+             OverlayDelegate.screenCaptureEnabled = true, to re-enable.
         <service
             android:name=".services.ScreenshotService"
             android:exported="false"
             android:foregroundServiceType="mediaProjection" />
+        -->
 
         <service
             android:name=".services.IdeazOverlayService"

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/SettingsScreen.kt
@@ -583,7 +583,6 @@ fun SettingsScreen(
                 val hasInstall by remember(refreshTrigger) {
                     mutableStateOf(if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) context.packageManager.canRequestPackageInstalls() else true)
                 }
-                val hasScreenshot by remember(viewModel.hasScreenCapturePermission()) { mutableStateOf(viewModel.hasScreenCapturePermission()) }
                 val hasAccessibility by remember(refreshTrigger) {
                     mutableStateOf(isAccessibilityServiceEnabled(context, ".services.IdeazAccessibilityService"))
                 }
@@ -642,17 +641,9 @@ fun SettingsScreen(
                     }
                 )
 
-                PermissionCheckRow(
-                    name = "Screen Capture",
-                    granted = hasScreenshot,
-                    onClick = {
-                        if (!hasScreenshot) {
-                            viewModel.requestScreenCapturePermission()
-                        } else {
-                            Toast.makeText(context, "Permission already granted", Toast.LENGTH_SHORT).show()
-                        }
-                    }
-                )
+                // "Screen Capture" (MediaProjection) is a Phase-2 (Android target)
+                // feature and is intentionally not exposed in the PWA-only product —
+                // see OverlayDelegate.screenCaptureEnabled.
 
                 PermissionCheckRow(
                     name = "Manage All Files (Storage)",

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/delegates/OverlayDelegate.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/delegates/OverlayDelegate.kt
@@ -92,6 +92,16 @@ class OverlayDelegate(
      */
     private var deferredCaptureRect: Rect? = null
 
+    /**
+     * Phase gate for MediaProjection screen capture. The product is **PWA-only**
+     * right now: web inspection uses DOM/source context (no screen capture), so the
+     * MediaProjection consent dialog and [ScreenshotService] are kept fully dormant
+     * to avoid prompting or crashing users. The capture path (and its
+     * `ScreenshotService` + manifest `mediaProjection` declarations) is preserved for
+     * Phase 2 (the Android target app) — flip this to re-enable it.
+     */
+    private val screenCaptureEnabled = false
+
     // --- Public Operations ---
 
     /**
@@ -202,7 +212,14 @@ class OverlayDelegate(
             // (e.g., a Web inspection where we only have a CSS / DOM id and
             // no on-screen bounds). The pendingContextInfo is still set above.
             if (!rect.isEmpty) {
-                takeScreenshot(rect)
+                if (screenCaptureEnabled) {
+                    takeScreenshot(rect)
+                } else {
+                    // Screen capture is a Phase-2 (Android target) feature; in the
+                    // PWA product just show the contextual chat with the context we
+                    // have — no screenshot, no MediaProjection prompt.
+                    _isContextualChatVisible.value = true
+                }
             }
         }
     }
@@ -278,7 +295,12 @@ class OverlayDelegate(
     // --- Permission Management ---
 
     fun hasScreenCapturePermission() = screenCaptureData != null
-    fun requestScreenCapturePermission() { _requestScreenCapture.value = true }
+    fun requestScreenCapturePermission() {
+        // Dormant in the PWA-only product — see [screenCaptureEnabled]. Never raise
+        // the MediaProjection consent dialog so it can't prompt or crash users.
+        if (!screenCaptureEnabled) return
+        _requestScreenCapture.value = true
+    }
     fun screenCaptureRequestHandled() { _requestScreenCapture.value = false }
 
     /**

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/delegates/OverlayDelegate.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/delegates/OverlayDelegate.kt
@@ -136,9 +136,12 @@ class OverlayDelegate(
 
         setInternalSelectMode(enable)
 
-        // Pre-emptively request screen capture permission if missing
+        // Pre-emptively request screen capture permission if missing. Routed through
+        // requestScreenCapturePermission() so it respects the screenCaptureEnabled
+        // gate — otherwise enabling select mode would still raise the MediaProjection
+        // consent dialog in the PWA-only product.
         if (enable && !hasScreenCapturePermission()) {
-            _requestScreenCapture.value = true
+            requestScreenCapturePermission()
         }
     }
 
@@ -217,7 +220,9 @@ class OverlayDelegate(
                 } else {
                     // Screen capture is a Phase-2 (Android target) feature; in the
                     // PWA product just show the contextual chat with the context we
-                    // have — no screenshot, no MediaProjection prompt.
+                    // have — no screenshot, no MediaProjection prompt. Clear any prior
+                    // screenshot so stale image data can't ride along with new context.
+                    pendingBase64Screenshot = null
                     _isContextualChatVisible.value = true
                 }
             }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -41,7 +41,7 @@ Git is the source of truth. There is no offline build path — builds are always
 * **`IdeazOverlayService`**: `TYPE_APPLICATION_OVERLAY` window for Phase 2 element-tap on the sideloaded target app. Wired but inert until Phase 2.
 * **`IdeazAccessibilityService`**: `AccessibilityNodeInfo` walk for Phase 2 element capture. Wired but inert until Phase 2.
 * **`CrashReportingService`** (`:crash_reporter`): isolated process so crashes still report.
-* **`ScreenshotService`**: `MediaProjection` virtual display for region screenshots — kept (its proper use of `VirtualDisplay`).
+* **`ScreenshotService`**: `MediaProjection` virtual display for region screenshots — kept for Phase 2 (Android target) but **dormant in the PWA-only product**: undeclared in the manifest and gated off by `OverlayDelegate.screenCaptureEnabled`, so no consent prompt or foreground service runs today.
 
 ## 5. File System
 

--- a/docs/file_descriptions.md
+++ b/docs/file_descriptions.md
@@ -55,7 +55,7 @@
 *   `IdeazAccessibilityService.kt`: Accessibility Service for Phase 2 element capture (wired but inert until Phase 2).
 *   `IdeazOverlayService.kt`: System Alert Window overlay for Phase 2 (wired but inert until Phase 2).
 *   `CrashReportingService.kt`: Service for fatal error reporting in `:crash_reporter`.
-*   `ScreenshotService.kt`: `MediaProjection` virtual display for region screenshots.
+*   `ScreenshotService.kt`: `MediaProjection` virtual display for region screenshots. **Dormant in the PWA-only product** (Phase 2 / Android target) — not declared in the manifest and never started; gated by `OverlayDelegate.screenCaptureEnabled`.
 
 #### ai/
 *   `AiAdapterFactory.kt`: Centralized factory that maps AI models to concrete adapters.

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -39,7 +39,9 @@
     * **GitHub Personal Access Token**: Input for the GitHub PAT used for repo management and automated issue reporting.
     * **Jules / AI Studio Keys**: Inputs for other AI providers.
 * **Permissions Section**
-    * ... (Overlay, Accessibility, Notification, Install, Screen Capture checks)
+    * ... (Overlay, Accessibility, Notification, Install checks). The Screen Capture
+      (MediaProjection) row was removed — that's a Phase-2 (Android target) feature,
+      dormant in the PWA-only product.
 * **Preferences Section**
     * **Show Cancel Warning Checkbox**: Toggles cancellation dialog.
     * **Auto-report IDE internal errors Checkbox**: Toggles the automated GitHub issue reporting feature (`GithubIssueReporter`).

--- a/version.properties
+++ b/version.properties
@@ -2,4 +2,4 @@
 build=72
 major=1
 minor=13
-patch=16
+patch=17


### PR DESCRIPTION
## Why
The product currently forces a **PWA** workflow; MediaProjection screen capture is only needed for the future **Phase-2 Android target**. But that machinery was still reachable and tripping users — the pasted crash was `ScreenshotService` failing to start a `mediaProjection` foreground service (`SecurityException`), and the Settings "Screen Capture" button could pop the consent dialog in a PWA project. Per direction ("we don't need its infrastructure causing anyone to trip or getting in the way"), this makes the whole capture path **dormant but cleanly restorable** for Phase 2.

Note: the normal PWA web-inspection flow already never triggered MediaProjection (web taps use an empty rect and skip the screenshot, relying on rich DOM/source context). So this removes the trip hazards without changing the everyday flow. (A `PixelCopy`-based own-window capture — the earlier idea — isn't needed now since DOM context already drives web prompts; it can return with Phase 2.)

## Changes
- **`OverlayDelegate`** — new `screenCaptureEnabled` flag (false). `requestScreenCapturePermission()` is a no-op while off (no consent dialog); a non-empty-rect selection now shows the contextual chat with DOM/source context only, instead of starting a capture.
- **`SettingsScreen`** — removed the user-facing **"Screen Capture"** permission row (the one way a PWA user could trigger the consent dialog).
- **`AndroidManifest.xml`** — commented out the `FOREGROUND_SERVICE_MEDIA_PROJECTION` permission and the `ScreenshotService` `mediaProjection` service declaration (removes the Play-policy surface), with Phase-2 restore notes. `ScreenshotService.kt` is retained untouched.
- Docs (`architecture.md`, `file_descriptions.md`, `manifest.md`) updated; patch version bump.

## Restoring for Phase 2
Set `OverlayDelegate.screenCaptureEnabled = true` and un-comment the two manifest entries. Everything else (the `ScreenshotService`, the consent launcher in `MainActivity`, the single-use-token handling) is intact.

## Verification
- ⚠️ Couldn't run `./gradlew` here — the environment's network policy blocks the Android Gradle Plugin / Maven. CI validates the build.
- Manual: in a PWA project, confirm Settings no longer shows a "Screen Capture" row, tapping/selecting a web element opens the contextual chat (with DOM context, no screenshot), and nothing requests a screen-capture consent dialog or starts a foreground service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nw6AHh15NTE63WQKU5qbY8)_