### PR TITLE
feat(phase 2-2c): PR-based Android loop — auto-merge Jules PR, rebuild, re-sideload

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ai/AgenticAiClient.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ai/AgenticAiClient.kt
@@ -19,9 +19,14 @@ sealed interface TaskEvent {
     /** A unidiff patch the agent produced, to apply to the working tree. */
     data class Patch(val unidiff: String) : TaskEvent
 
+    /**
+     * The agent opened a pull request — the terminal deliverable for the PR-based
+     * Android loop. The consumer auto-merges it and rebuilds/re-sideloads the APK.
+     */
+    data class PullRequest(val url: String, val title: String) : TaskEvent
+
     /** The agent didn't reach a terminal state within the poll window. */
     object TimedOut : TaskEvent
-    // PullRequest(url) is added with the PR-based loop increment (auto-merge + rebuild).
 }
 
 /**

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/api/GithubApiClient.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/api/GithubApiClient.kt
@@ -183,6 +183,39 @@ data class GitHubPagesResponse(
 )
 // --- END NEW ---
 
+// --- Pull Request Data Classes (PR-based Android loop) ---
+@Serializable
+data class GitHubPullRequest(
+    val number: Int,
+    val state: String, // "open" or "closed"
+    val merged: Boolean? = null,
+    @SerialName("merge_commit_sha") val mergeCommitSha: String? = null,
+    val head: GitHubPullRequestRef,
+    @SerialName("html_url") val htmlUrl: String
+)
+
+@Serializable
+data class GitHubPullRequestRef(
+    val ref: String,
+    val sha: String
+)
+
+@Serializable
+data class MergePullRequestRequest(
+    @SerialName("commit_title") val commitTitle: String? = null,
+    // "merge", "squash", or "rebase". Squash keeps the default branch history
+    // linear, which is what the rebuild loop polls against.
+    @SerialName("merge_method") val mergeMethod: String = "squash"
+)
+
+@Serializable
+data class GitHubMergeResult(
+    val sha: String? = null,
+    val merged: Boolean = false,
+    val message: String? = null
+)
+// --- END Pull Request Data Classes ---
+
 interface GitHubApi {
     @POST("user/repos")
     suspend fun createRepo(@Body request: CreateRepoRequest): GitHubRepoResponse
@@ -300,6 +333,26 @@ interface GitHubApi {
         @Path("repo") repo: String,
         @Path("job_id") jobId: Long
     ): retrofit2.Response<ResponseBody>
+
+    @retrofit2.http.GET("repos/{owner}/{repo}/pulls/{pull_number}")
+    suspend fun getPullRequest(
+        @Path("owner") owner: String,
+        @Path("repo") repo: String,
+        @Path("pull_number") pullNumber: Int
+    ): GitHubPullRequest
+
+    /**
+     * Merge a pull request. Returns a [retrofit2.Response] (not the bare body) so
+     * callers can distinguish a clean merge (200) from "not mergeable" (405) or a
+     * merge conflict (409) without an exception.
+     */
+    @retrofit2.http.PUT("repos/{owner}/{repo}/pulls/{pull_number}/merge")
+    suspend fun mergePullRequest(
+        @Path("owner") owner: String,
+        @Path("repo") repo: String,
+        @Path("pull_number") pullNumber: Int,
+        @Body request: MergePullRequestRequest
+    ): retrofit2.Response<GitHubMergeResult>
 
     @retrofit2.http.GET("user/repos?sort=updated&per_page=100")
     suspend fun listRepos(): List<GitHubRepoResponse>

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/buildlogic/PullRequestCoordinator.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/buildlogic/PullRequestCoordinator.kt
@@ -1,0 +1,50 @@
+package com.hereliesaz.ideaz.buildlogic
+
+import com.hereliesaz.ideaz.api.GitHubApi
+import com.hereliesaz.ideaz.api.MergePullRequestRequest
+
+/**
+ * Auto-merges a pull request opened by the agent (Jules) and resolves the merge
+ * commit SHA — the input the [RemoteBuildManager] needs to poll Actions for the
+ * rebuilt APK. This is the "auto-merge" half of the PR-based Android loop.
+ */
+class PullRequestCoordinator(private val api: GitHubApi) {
+
+    /**
+     * Merge the PR identified by [prUrl] and return its merge commit SHA, or null
+     * if the URL is unparseable or the merge fails (not mergeable / conflict /
+     * network). Idempotent: a PR that is already merged (e.g. on a retry) returns
+     * its existing merge commit instead of erroring.
+     */
+    suspend fun mergeAndGetSha(prUrl: String, mergeMethod: String = "squash"): String? {
+        val ref = parsePullRequestUrl(prUrl) ?: return null
+
+        // Already merged (retry / duplicate event): reuse the existing commit.
+        val existing = runCatching { api.getPullRequest(ref.owner, ref.repo, ref.number) }.getOrNull()
+        if (existing?.merged == true) return existing.mergeCommitSha
+
+        val response = runCatching {
+            api.mergePullRequest(
+                ref.owner, ref.repo, ref.number,
+                MergePullRequestRequest(mergeMethod = mergeMethod)
+            )
+        }.getOrNull() ?: return null
+
+        if (!response.isSuccessful) return null
+        return response.body()?.takeIf { it.merged }?.sha
+    }
+
+    data class PrRef(val owner: String, val repo: String, val number: Int)
+
+    companion object {
+        // Matches both the html_url (github.com/owner/repo/pull/5) and the API
+        // url (api.github.com/repos/owner/repo/pulls/5) shapes Jules may return.
+        private val PR_URL = Regex("""github\.com/(?:repos/)?([^/]+)/([^/]+)/pulls?/(\d+)""")
+
+        fun parsePullRequestUrl(url: String): PrRef? {
+            val match = PR_URL.find(url) ?: return null
+            val (owner, repo, number) = match.destructured
+            return PrRef(owner, repo, number.toIntOrNull() ?: return null)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/buildlogic/PullRequestCoordinator.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/buildlogic/PullRequestCoordinator.kt
@@ -2,6 +2,7 @@ package com.hereliesaz.ideaz.buildlogic
 
 import com.hereliesaz.ideaz.api.GitHubApi
 import com.hereliesaz.ideaz.api.MergePullRequestRequest
+import kotlinx.coroutines.CancellationException
 
 /**
  * Auto-merges a pull request opened by the agent (Jules) and resolves the merge
@@ -20,15 +21,27 @@ class PullRequestCoordinator(private val api: GitHubApi) {
         val ref = parsePullRequestUrl(prUrl) ?: return null
 
         // Already merged (retry / duplicate event): reuse the existing commit.
-        val existing = runCatching { api.getPullRequest(ref.owner, ref.repo, ref.number) }.getOrNull()
+        // Catch Exception (not runCatching) so cancellation propagates — otherwise a
+        // cancelled rebuild would return null and surface a misleading "Build failed".
+        val existing = try {
+            api.getPullRequest(ref.owner, ref.repo, ref.number)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            null
+        }
         if (existing?.merged == true) return existing.mergeCommitSha
 
-        val response = runCatching {
+        val response = try {
             api.mergePullRequest(
                 ref.owner, ref.repo, ref.number,
                 MergePullRequestRequest(mergeMethod = mergeMethod)
             )
-        }.getOrNull() ?: return null
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            return null
+        }
 
         if (!response.isSuccessful) return null
         return response.body()?.takeIf { it.merged }?.sha

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/jules/IJulesApiClient.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/jules/IJulesApiClient.kt
@@ -5,6 +5,7 @@ import com.hereliesaz.ideaz.api.*
 interface IJulesApiClient {
     suspend fun listSessions(pageSize: Int = 100, pageToken: String? = null): ListSessionsResponse
     suspend fun createSession(request: CreateSessionRequest): Session
+    suspend fun getSession(sessionId: String): Session
     suspend fun sendMessage(sessionId: String, request: SendMessageRequest)
     suspend fun listActivities(sessionId: String, pageSize: Int = 100, pageToken: String? = null): ListActivitiesResponse
     suspend fun listSources(pageSize: Int = 100, pageToken: String? = null): ListSourcesResponse

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/jules/JulesAdapter.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/jules/JulesAdapter.kt
@@ -79,6 +79,21 @@ class JulesAdapter(
                         ?.let { emit(TaskEvent.Patch(it)) }
                 }
             }
+
+            // A pull request is the terminal deliverable for the Android loop: once
+            // Jules has opened one (surfaced in the session's outputs), emit it and
+            // stop polling — the consumer takes over (auto-merge + rebuild).
+            val pr = try {
+                client.getSession(sessionId).outputs?.firstNotNullOfOrNull { it.pullRequest }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                null // transient — fall through and keep polling
+            }
+            if (pr != null) {
+                emit(TaskEvent.PullRequest(pr.url, pr.title))
+                return@flow
+            }
             attempts++
         }
         emit(TaskEvent.TimedOut)

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/jules/JulesApi.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/jules/JulesApi.kt
@@ -15,6 +15,11 @@ interface JulesApi {
         @Body request: CreateSessionRequest
     ): Session
 
+    @GET("sessions/{id}")
+    suspend fun getSession(
+        @Path("id") id: String
+    ): Session
+
     @POST("sessions/{id}:sendMessage")
     suspend fun sendMessage(
         @Path("id") id: String,

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/jules/JulesApiClient.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/jules/JulesApiClient.kt
@@ -80,6 +80,9 @@ object JulesApiClient : IJulesApiClient {
     override suspend fun createSession(request: CreateSessionRequest): Session =
         client.createSession(request)
 
+    override suspend fun getSession(sessionId: String): Session =
+        client.getSession(sessionId)
+
     override suspend fun sendMessage(sessionId: String, request: SendMessageRequest) =
         client.sendMessage(sessionId, request)
 

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/MainViewModel.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/MainViewModel.kt
@@ -143,6 +143,10 @@ class MainViewModel(
                 settings = settingsViewModel,
             )
         },
+        // PR-based Android loop: when Jules opens a PR, auto-merge it and rebuild +
+        // re-sideload the APK. buildDelegate is declared below; the lambda reads the
+        // property at call time, so the forward reference is fine.
+        onAgentPullRequest = { url -> buildDelegate.installFromMergedPr(url) },
     )
 
     /**

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/delegates/AIDelegate.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/delegates/AIDelegate.kt
@@ -377,9 +377,10 @@ class AIDelegate(
     /**
      * Reacts to a single [TaskEvent] from the Jules loop. Extracted from the
      * collector so it can be unit-tested directly without standing up the whole
-     * session/branch-resolution path.
+     * session/branch-resolution path. `suspend` because applying a patch
+     * ([onUnidiffPatchReceived]) is a suspend call.
      */
-    internal fun handleJulesEvent(event: TaskEvent) {
+    internal suspend fun handleJulesEvent(event: TaskEvent) {
         when (event) {
             is TaskEvent.SessionStarted -> {
                 _currentJulesSessionId.value = event.session.id

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/delegates/AIDelegate.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/delegates/AIDelegate.kt
@@ -86,6 +86,13 @@ class AIDelegate(
      * over the same [julesApiClient], so production and tests share one Jules path.
      */
     private val julesAdapter: AgenticAiClient = JulesAdapter(julesApiClient),
+    /**
+     * Called with a pull-request URL when the agent opens one (the terminal event
+     * of the PR-based Android loop). Production wires this to
+     * BuildDelegate.installFromMergedPr (auto-merge → rebuild → re-sideload).
+     * Default is a no-op for tests / the conversational paths.
+     */
+    private val onAgentPullRequest: (url: String) -> Unit = {},
 ) {
 
     // --- StateFlows ---
@@ -364,22 +371,33 @@ class AIDelegate(
         )
 
         julesAdapter.dispatchTask(promptText, sourceContext, _currentJulesSessionId.value)
-            .collect { event ->
-                when (event) {
-                    is TaskEvent.SessionStarted -> {
-                        _currentJulesSessionId.value = event.session.id
-                        _julesResponse.value = event.session
-                    }
-                    is TaskEvent.Message -> onOverlayLog("Jules: ${event.text}")
-                    is TaskEvent.Patch -> {
-                        onOverlayLog("Patch received. Applying...")
-                        val success = onUnidiffPatchReceived(event.unidiff)
-                        onOverlayLog(if (success) "Patch applied." else "Patch failed to apply.")
-                    }
-                    TaskEvent.TimedOut ->
-                        onOverlayLog("Jules: no response yet. Try resending or switching to Gemini.")
-                }
+            .collect { event -> handleJulesEvent(event) }
+    }
+
+    /**
+     * Reacts to a single [TaskEvent] from the Jules loop. Extracted from the
+     * collector so it can be unit-tested directly without standing up the whole
+     * session/branch-resolution path.
+     */
+    internal fun handleJulesEvent(event: TaskEvent) {
+        when (event) {
+            is TaskEvent.SessionStarted -> {
+                _currentJulesSessionId.value = event.session.id
+                _julesResponse.value = event.session
             }
+            is TaskEvent.Message -> onOverlayLog("Jules: ${event.text}")
+            is TaskEvent.Patch -> {
+                onOverlayLog("Patch received. Applying...")
+                val success = onUnidiffPatchReceived(event.unidiff)
+                onOverlayLog(if (success) "Patch applied." else "Patch failed to apply.")
+            }
+            is TaskEvent.PullRequest -> {
+                onOverlayLog("Jules opened a PR (${event.title}). Merging and rebuilding...")
+                onAgentPullRequest(event.url)
+            }
+            TaskEvent.TimedOut ->
+                onOverlayLog("Jules: no response yet. Try resending or switching to Gemini.")
+        }
     }
 
     companion object {

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/delegates/BuildDelegate.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/delegates/BuildDelegate.kt
@@ -8,6 +8,7 @@ import android.content.ServiceConnection
 import android.os.IBinder
 import com.hereliesaz.ideaz.IBuildService
 import com.hereliesaz.ideaz.api.GitHubApiClient
+import com.hereliesaz.ideaz.buildlogic.PullRequestCoordinator
 import com.hereliesaz.ideaz.buildlogic.RemoteBuildManager
 import com.hereliesaz.ideaz.models.ProjectType
 import com.hereliesaz.ideaz.services.BuildService
@@ -240,6 +241,48 @@ class BuildDelegate(
             handleSuccess(apkPath)
         } else {
             handleFailure("Remote Build Failed.")
+        }
+    }
+
+    /**
+     * The agent (Jules) opened a pull request. Auto-merge it, then poll Actions for
+     * the rebuilt APK and install it — the "merge → rebuild → re-sideload" half of
+     * the PR-based Android loop. Reuses [RemoteBuildManager] against the merge SHA
+     * (the merge already pushed to the default branch, so there's no commit/push to
+     * do here, unlike [startRemoteBuild]).
+     */
+    fun installFromMergedPr(prUrl: String) {
+        // Cancel any in-flight build so the merge-driven rebuild is authoritative.
+        buildJob?.cancel()
+        buildJob = scope.launch {
+            val token = settingsViewModel.getGithubToken()
+            val user = settingsViewModel.getGithubUser()
+            val repo = settingsViewModel.getAppName()
+            if (token.isNullOrBlank() || user.isNullOrBlank() || repo.isNullOrBlank()) {
+                handleFailure("Auto-merge requires GitHub token, user, and an open project.")
+                return@launch
+            }
+
+            val api = GitHubApiClient.createService(token)
+            onOverlayLog("Merging pull request...")
+            val mergeSha = PullRequestCoordinator(api).mergeAndGetSha(prUrl)
+            if (mergeSha == null) {
+                onLog("[IDE] Could not merge PR: $prUrl\n")
+                handleFailure("Failed to merge pull request. Check for conflicts or required reviews.")
+                return@launch
+            }
+
+            onLog("[IDE] PR merged. Rebuilding from ${mergeSha.take(7)}...\n")
+            val manager = RemoteBuildManager(
+                application, api, token, user, repo,
+                onLog = { msg -> pushLog(msg) }
+            )
+            val apkPath = manager.pollAndDownload(mergeSha)
+            if (apkPath != null) {
+                handleSuccess(apkPath)
+            } else {
+                handleFailure("Remote build after merge failed.")
+            }
         }
     }
 

--- a/app/src/test/java/com/hereliesaz/ideaz/buildlogic/PullRequestCoordinatorTest.kt
+++ b/app/src/test/java/com/hereliesaz/ideaz/buildlogic/PullRequestCoordinatorTest.kt
@@ -1,0 +1,88 @@
+package com.hereliesaz.ideaz.buildlogic
+
+import com.hereliesaz.ideaz.api.GitHubApi
+import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Retrofit
+
+class PullRequestCoordinatorTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var api: GitHubApi
+
+    @Before
+    fun setup() {
+        server = MockWebServer()
+        server.start()
+        api = Retrofit.Builder()
+            .baseUrl(server.url("/"))
+            .addConverterFactory(Json { ignoreUnknownKeys = true }.asConverterFactory("application/json".toMediaType()))
+            .build()
+            .create(GitHubApi::class.java)
+    }
+
+    @After
+    fun teardown() {
+        server.shutdown()
+    }
+
+    @Test
+    fun parsesHtmlAndApiPullRequestUrls() {
+        val html = PullRequestCoordinator.parsePullRequestUrl("https://github.com/octocat/hello/pull/42")!!
+        assertEquals("octocat", html.owner)
+        assertEquals("hello", html.repo)
+        assertEquals(42, html.number)
+
+        val apiUrl = PullRequestCoordinator.parsePullRequestUrl("https://api.github.com/repos/octocat/hello/pulls/7")!!
+        assertEquals("octocat", apiUrl.owner)
+        assertEquals("hello", apiUrl.repo)
+        assertEquals(7, apiUrl.number)
+
+        assertNull(PullRequestCoordinator.parsePullRequestUrl("https://example.com/not/a/pr"))
+    }
+
+    @Test
+    fun mergesAnOpenPrAndReturnsTheMergeSha() = runBlocking {
+        // getPullRequest (open, not merged) then PUT merge → 200 with sha.
+        server.enqueue(MockResponse().setBody("""{"number":42,"state":"open","merged":false,"head":{"ref":"jules","sha":"abc"},"html_url":"u"}"""))
+        server.enqueue(MockResponse().setBody("""{"sha":"mergesha123","merged":true,"message":"Merged"}"""))
+
+        val sha = PullRequestCoordinator(api).mergeAndGetSha("https://github.com/o/r/pull/42")
+
+        assertEquals("mergesha123", sha)
+    }
+
+    @Test
+    fun returnsExistingMergeShaWhenAlreadyMerged() = runBlocking {
+        // Idempotent retry path: PR already merged → reuse its commit, no PUT issued.
+        server.enqueue(MockResponse().setBody("""{"number":42,"state":"closed","merged":true,"merge_commit_sha":"already","head":{"ref":"j","sha":"a"},"html_url":"u"}"""))
+
+        val sha = PullRequestCoordinator(api).mergeAndGetSha("https://github.com/o/r/pull/42")
+
+        assertEquals("already", sha)
+    }
+
+    @Test
+    fun returnsNullOnUnparseableUrl() = runBlocking {
+        assertNull(PullRequestCoordinator(api).mergeAndGetSha("not a url"))
+    }
+
+    @Test
+    fun returnsNullWhenMergeFails() = runBlocking {
+        server.enqueue(MockResponse().setBody("""{"number":1,"state":"open","merged":false,"head":{"ref":"j","sha":"a"},"html_url":"u"}"""))
+        server.enqueue(MockResponse().setResponseCode(409).setBody("""{"message":"conflict"}"""))
+
+        val sha = PullRequestCoordinator(api).mergeAndGetSha("https://github.com/o/r/pull/1")
+
+        assertNull(sha)
+    }
+}

--- a/app/src/test/java/com/hereliesaz/ideaz/buildlogic/RemoteBuildManagerTest.kt
+++ b/app/src/test/java/com/hereliesaz/ideaz/buildlogic/RemoteBuildManagerTest.kt
@@ -69,6 +69,8 @@ class RemoteBuildManagerTest {
 
         override suspend fun getRunJobs(owner: String, repo: String, runId: Long) = GitHubJobsResponse(emptyList())
         override suspend fun getJobLogs(owner: String, repo: String, jobId: Long) = Response.success("".toResponseBody(null))
+        override suspend fun getPullRequest(owner: String, repo: String, pullNumber: Int) = throw NotImplementedError()
+        override suspend fun mergePullRequest(owner: String, repo: String, pullNumber: Int, request: MergePullRequestRequest) = throw NotImplementedError()
         override suspend fun listRepos() = emptyList<GitHubRepoResponse>()
     }
 

--- a/app/src/test/java/com/hereliesaz/ideaz/jules/JulesAdapterTest.kt
+++ b/app/src/test/java/com/hereliesaz/ideaz/jules/JulesAdapterTest.kt
@@ -10,8 +10,10 @@ import com.hereliesaz.ideaz.api.GitPatch
 import com.hereliesaz.ideaz.api.ListActivitiesResponse
 import com.hereliesaz.ideaz.api.ListSessionsResponse
 import com.hereliesaz.ideaz.api.ListSourcesResponse
+import com.hereliesaz.ideaz.api.PullRequest
 import com.hereliesaz.ideaz.api.SendMessageRequest
 import com.hereliesaz.ideaz.api.Session
+import com.hereliesaz.ideaz.api.SessionOutput
 import com.hereliesaz.ideaz.api.SourceContext
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
@@ -36,6 +38,7 @@ class JulesAdapterTest {
     /** Fake that returns the same activity page on every poll (exercises dedup). */
     private class FakeClient(
         private val activities: List<Activity>,
+        private val sessionOutputs: List<SessionOutput>? = null,
     ) : IJulesApiClient {
         var created: CreateSessionRequest? = null
         var sentTo: String? = null
@@ -48,6 +51,9 @@ class JulesAdapterTest {
             created = request
             return Session(name = "sessions/s1", id = "s1", prompt = request.prompt, sourceContext = request.sourceContext)
         }
+
+        override suspend fun getSession(sessionId: String): Session =
+            Session(name = "sessions/$sessionId", id = sessionId, prompt = "", sourceContext = SourceContext(source = "s"), outputs = sessionOutputs)
 
         override suspend fun sendMessage(sessionId: String, request: SendMessageRequest) {
             sentTo = sessionId
@@ -105,5 +111,20 @@ class JulesAdapterTest {
         assertTrue(events.none { it is TaskEvent.Patch })
         assertTrue(events.none { it is TaskEvent.Message })
         assertEquals(TaskEvent.TimedOut, events.last())
+    }
+
+    @Test
+    fun `emits PullRequest and stops polling once a PR appears in session outputs`() = runTest {
+        val pr = PullRequest(url = "https://github.com/o/r/pull/7", title = "Add feature", description = "body")
+        val client = FakeClient(emptyList(), sessionOutputs = listOf(SessionOutput(pullRequest = pr)))
+        val adapter = JulesAdapter(client, pollDelayMs = 1, maxPollAttempts = 5)
+
+        val events = adapter.dispatchTask("do the thing", sourceContext, existingSessionId = null).toList()
+
+        val prEvent = events.filterIsInstance<TaskEvent.PullRequest>().single()
+        assertEquals("https://github.com/o/r/pull/7", prEvent.url)
+        assertEquals("Add feature", prEvent.title)
+        // The PR is terminal — the loop returns without ever timing out.
+        assertTrue(events.none { it is TaskEvent.TimedOut })
     }
 }

--- a/app/src/test/java/com/hereliesaz/ideaz/ui/delegates/AIDelegateTest.kt
+++ b/app/src/test/java/com/hereliesaz/ideaz/ui/delegates/AIDelegateTest.kt
@@ -2,6 +2,7 @@ package com.hereliesaz.ideaz.ui.delegates
 
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.hereliesaz.ideaz.ai.TaskEvent
 import com.hereliesaz.ideaz.api.*
 import com.hereliesaz.ideaz.jules.IJulesApiClient
 import com.hereliesaz.ideaz.models.ProjectType
@@ -43,6 +44,13 @@ class AIDelegateTest {
             )
             return createdSession!!
         }
+
+        override suspend fun getSession(sessionId: String): Session = Session(
+            id = sessionId,
+            name = "sessions/$sessionId",
+            prompt = "",
+            sourceContext = SourceContext(source = "sources/github/user/repo")
+        )
 
         override suspend fun sendMessage(sessionId: String, request: SendMessageRequest) {
             lastMessage = request
@@ -104,6 +112,22 @@ class AIDelegateTest {
     fun webLikeProjectsDefaultToGemini() {
         assertEquals(AiModels.GEMINI, AIDelegate.defaultOverlayModel(null, ProjectType.PWA))
         assertEquals(AiModels.GEMINI, AIDelegate.defaultOverlayModel(null, ProjectType.WEB))
+    }
+
+    @Test
+    fun pullRequestEventForwardsUrlToCallback() {
+        var capturedUrl: String? = null
+        val scope = CoroutineScope(Dispatchers.Unconfined)
+        val delegate = AIDelegate(
+            settingsViewModel, scope, {}, { true }, mockApiClient,
+            onAgentPullRequest = { capturedUrl = it }
+        )
+
+        delegate.handleJulesEvent(
+            TaskEvent.PullRequest(url = "https://github.com/o/r/pull/9", title = "Add feature")
+        )
+
+        assertEquals("https://github.com/o/r/pull/9", capturedUrl)
     }
 
     @Test

--- a/app/src/test/java/com/hereliesaz/ideaz/ui/delegates/AIDelegateTest.kt
+++ b/app/src/test/java/com/hereliesaz/ideaz/ui/delegates/AIDelegateTest.kt
@@ -115,7 +115,7 @@ class AIDelegateTest {
     }
 
     @Test
-    fun pullRequestEventForwardsUrlToCallback() {
+    fun pullRequestEventForwardsUrlToCallback() = runBlocking {
         var capturedUrl: String? = null
         val scope = CoroutineScope(Dispatchers.Unconfined)
         val delegate = AIDelegate(

--- a/docs/file_descriptions.md
+++ b/docs/file_descriptions.md
@@ -37,10 +37,11 @@
 *   `JulesApiClient.kt`: Client for Jules API. Stubbed in Phase 0; restored in Phase 2.
 *   `JulesApi.kt`: Retrofit interface for Jules.
 *   `IJulesApiClient.kt`: Interface definition.
-*   `JulesAdapter.kt`: `AgenticAiClient` over `JulesApiClient` — owns the create/resume-session + activity-poll lifecycle and emits `TaskEvent`s (the single source of truth `AIDelegate` collects).
+*   `JulesAdapter.kt`: `AgenticAiClient` over `JulesApiClient` — owns the create/resume-session + activity-poll lifecycle and emits `TaskEvent`s (the single source of truth `AIDelegate` collects). Polls `getSession` for `outputs[].pullRequest` and emits a terminal `TaskEvent.PullRequest`.
 
 #### buildlogic/
 *   `RemoteBuildManager.kt`: Dispatches and polls remote GitHub Actions builds. The only build path that survived Phase 0.
+*   `PullRequestCoordinator.kt`: Auto-merges an agent-opened PR (parse URL → `GitHubApi.mergePullRequest`) and returns the merge commit SHA for `RemoteBuildManager` to rebuild against. The "auto-merge" half of the PR-based Android loop.
 
 #### git/
 *   `GitManager.kt`: Wrapper around JGit for version control operations.

--- a/docs/jules-integration.md
+++ b/docs/jules-integration.md
@@ -36,11 +36,22 @@ for both the PWA-loop (Gemini) and Android-loop (Jules) targets.
 explicit Settings → AI Assignments choice always wins; otherwise **Android targets
 default to Jules**, web-like projects default to Gemini.
 
-**Output model:** the current loop applies Jules' returned unidiff patches to the
-working tree. The Phase-2 target (per the design) is **PR-based** — Jules opens a PR,
-IDEaz auto-merges, GitHub Actions rebuilds the APK, and `ApkInstaller` re-sideloads.
-That PR/auto-merge/build loop is the next increment (adding a `PullRequest` `TaskEvent`
-and consuming `Session.outputs[].pullRequest`).
+**Output model — PR-based loop (implemented):** when Jules opens a pull request it
+surfaces in `Session.outputs[].pullRequest`. `JulesAdapter` polls `getSession` and,
+when a PR appears, emits a terminal `TaskEvent.PullRequest(url, title)`. `AIDelegate`
+forwards the URL via its `onAgentPullRequest` callback to
+`BuildDelegate.installFromMergedPr`, which:
+
+1. `PullRequestCoordinator.mergeAndGetSha(url)` — parse owner/repo/number, auto-merge
+   (squash) via `GitHubApi.mergePullRequest`, return the merge commit SHA (idempotent:
+   reuses the existing merge if the PR is already merged).
+2. `RemoteBuildManager.pollAndDownload(mergeSha)` — poll GitHub Actions for the rebuilt
+   APK on the merge commit, download it, and `ApkInstaller` sideloads it.
+
+Unidiff `Patch` events are still applied to the working tree (the non-PR path); the two
+are additive. Auto-launching the freshly installed APK is a follow-up — it needs the
+async `PackageInstaller` result callback, so for now install lands via the system
+installer prompt as before.
 
 ## Jules CLI — REMOVED
 

--- a/version.properties
+++ b/version.properties
@@ -1,5 +1,5 @@
 #Fri Jun 05 21:45:00 CDT 2026
 build=72
 major=1
-minor=14
+minor=15
 patch=17


### PR DESCRIPTION
Second Phase-2 increment (2C), building on the 2A abstraction (#715). Implements the design's **PR-based output model**: when Jules opens a pull request, IDEaz auto-merges it, rebuilds the APK via GitHub Actions, and re-sideloads it — closing the agentic round-trip.

Crucially this **reuses existing infrastructure**: `RemoteBuildManager` already polls Actions → downloads the artifact → installs via `ApkInstaller`. So the new code is just the *merge* half plus the event plumbing.

## Flow
`Jules opens PR` → `JulesAdapter` (sees it in `Session.outputs[].pullRequest`) emits `TaskEvent.PullRequest` → `AIDelegate.onAgentPullRequest` → `BuildDelegate.installFromMergedPr`:
1. `PullRequestCoordinator.mergeAndGetSha(url)` — parse owner/repo/number, squash-merge via `GitHubApi.mergePullRequest`, return the merge commit SHA (idempotent if already merged).
2. `RemoteBuildManager.pollAndDownload(mergeSha)` — poll Actions for the rebuilt APK on the merge commit → download → `ApkInstaller` sideload.

## Changes
- **`TaskEvent.PullRequest(url, title)`** — terminal event for the Android loop (`ai/AgenticAiClient.kt`).
- **Jules `getSession`** (`JulesApi` / `IJulesApiClient` / `JulesApiClient`) so `JulesAdapter` can read `Session.outputs[].pullRequest`; the adapter polls it and emits the PR, then stops.
- **`GitHubApi.getPullRequest` + `mergePullRequest`** (+ models). `mergePullRequest` returns a `retrofit2.Response` so 405 (not mergeable) / 409 (conflict) are distinguishable from success without throwing.
- **`PullRequestCoordinator`** (`buildlogic/`) — URL parsing (html + api shapes) → squash-merge → merge SHA, idempotent.
- **`AIDelegate`** — `onAgentPullRequest` callback; event handling extracted to `internal handleJulesEvent` for direct unit testing.
- **`BuildDelegate.installFromMergedPr`** — coordinator merge → `RemoteBuildManager` against the merge SHA → install. Wired in `MainViewModel`.

## Tests
- `PullRequestCoordinatorTest` — URL parsing (both shapes + reject), merge→SHA, already-merged short-circuit, unparseable, and merge-failure paths (MockWebServer-backed `GitHubApi`).
- `JulesAdapterTest` — emits `PullRequest` and stops once a PR appears in outputs.
- `AIDelegateTest` — `handleJulesEvent(PullRequest)` forwards the URL to the callback.
- Existing fakes (`MockJulesApiClient`, `FakeClient`, `FakeGitHubApi`) updated for the new interface methods.

## Scope / honesty notes
- **Patch-apply (non-PR path) is unchanged and additive** — if Jules emits unidiff patches instead of (or before) a PR, the existing 2A behavior still applies them to the working tree. The two coexist; the PR-merge rebuild is authoritative for the running APK.
- **Auto-launch after install is deferred** — correct post-install launch needs the async `PackageInstaller` result callback (device-bound); changing the working install path blind is risky. Install lands via the system installer prompt as today. Flagged as a follow-up.
- ⚠️ The merge/rebuild/install chain itself is **device + live-Jules/GitHub bound** and can't run in CI; the new *logic* (URL parsing, merge decisions, event emission, callback wiring) is fully unit-tested. CI validates the build + tests.

## Next
2B (overlay/accessibility element capture + re-enable target-window MediaProjection) is the remaining Phase-2 increment — coming as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nw6AHh15NTE63WQKU5qbY8)_