### PR TITLE
feat(phase 2-2b): enable Android-target screen capture (MediaProjection)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,11 +19,10 @@
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
-    <!-- Phase 2 (Android target screen capture). Disabled in the PWA-only product so
-         we don't carry the mediaProjection FGS permission (Play policy surface) while
-         it's unused. Re-add with OverlayDelegate.screenCaptureEnabled = true.
+    <!-- Android target screen capture (Phase 2). Gated at runtime to Android target
+         projects via OverlayDelegate.isScreenCaptureEnabled(); web/PWA projects never
+         start the mediaProjection service or raise the consent dialog. -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
-    -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" tools:ignore="QueryAllPackagesPermission" />
@@ -104,16 +103,13 @@
                 android:resource="@xml/gemini_bridge_accessibility_config" />
         </service>
 
-        <!-- Phase 2 (Android target screen capture). Kept out of the manifest in the
-             PWA-only product so the mediaProjection foreground service can't be started
-             (or crash). ScreenshotService.kt is retained; re-declare this and the
-             FOREGROUND_SERVICE_MEDIA_PROJECTION permission, and set
-             OverlayDelegate.screenCaptureEnabled = true, to re-enable.
+        <!-- Android target screen capture (Phase 2). Started only for Android target
+             projects (OverlayDelegate.isScreenCaptureEnabled()); never reached on
+             web/PWA, so the mediaProjection FGS can't be started there. -->
         <service
             android:name=".services.ScreenshotService"
             android:exported="false"
             android:foregroundServiceType="mediaProjection" />
-        -->
 
         <service
             android:name=".services.IdeazOverlayService"

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/SettingsScreen.kt
@@ -641,9 +641,10 @@ fun SettingsScreen(
                     }
                 )
 
-                // "Screen Capture" (MediaProjection) is a Phase-2 (Android target)
-                // feature and is intentionally not exposed in the PWA-only product —
-                // see OverlayDelegate.screenCaptureEnabled.
+                // "Screen Capture" (MediaProjection) consent is requested on demand for
+                // Android target projects when entering select mode — see
+                // OverlayDelegate.isScreenCaptureEnabled(). No standing permission row is
+                // shown here because the grant is a per-session MediaProjection token.
 
                 PermissionCheckRow(
                     name = "Manage All Files (Storage)",

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/delegates/OverlayDelegate.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/delegates/OverlayDelegate.kt
@@ -5,6 +5,7 @@ import android.app.Application
 import android.content.Intent
 import android.graphics.Rect
 import android.net.Uri
+import com.hereliesaz.ideaz.models.ProjectType
 import com.hereliesaz.ideaz.services.ScreenshotService
 import com.hereliesaz.ideaz.ui.SettingsViewModel
 import com.hereliesaz.ideaz.utils.SourceContextHelper
@@ -93,14 +94,16 @@ class OverlayDelegate(
     private var deferredCaptureRect: Rect? = null
 
     /**
-     * Phase gate for MediaProjection screen capture. The product is **PWA-only**
-     * right now: web inspection uses DOM/source context (no screen capture), so the
-     * MediaProjection consent dialog and [ScreenshotService] are kept fully dormant
-     * to avoid prompting or crashing users. The capture path (and its
-     * `ScreenshotService` + manifest `mediaProjection` declarations) is preserved for
-     * Phase 2 (the Android target app) — flip this to re-enable it.
+     * Whether MediaProjection screen capture is active for the current project.
+     * Enabled only for **Android target** projects, where tapping the sideloaded
+     * app's real UI benefits from a screenshot attached to the prompt (for
+     * image-capable models). Web/PWA projects inspect via DOM/source context and
+     * must never raise the MediaProjection consent dialog, so capture stays dormant
+     * there (and its `ScreenshotService` + manifest `mediaProjection` declarations
+     * go unused). Re-evaluated per call so switching projects takes effect live.
      */
-    private val screenCaptureEnabled = false
+    internal fun isScreenCaptureEnabled(): Boolean =
+        ProjectType.fromString(settingsViewModel.getProjectType()) == ProjectType.ANDROID
 
     // --- Public Operations ---
 
@@ -137,7 +140,7 @@ class OverlayDelegate(
         setInternalSelectMode(enable)
 
         // Pre-emptively request screen capture permission if missing. Routed through
-        // requestScreenCapturePermission() so it respects the screenCaptureEnabled
+        // requestScreenCapturePermission() so it respects the isScreenCaptureEnabled()
         // gate — otherwise enabling select mode would still raise the MediaProjection
         // consent dialog in the PWA-only product.
         if (enable && !hasScreenCapturePermission()) {
@@ -215,13 +218,13 @@ class OverlayDelegate(
             // (e.g., a Web inspection where we only have a CSS / DOM id and
             // no on-screen bounds). The pendingContextInfo is still set above.
             if (!rect.isEmpty) {
-                if (screenCaptureEnabled) {
+                if (isScreenCaptureEnabled()) {
                     takeScreenshot(rect)
                 } else {
-                    // Screen capture is a Phase-2 (Android target) feature; in the
-                    // PWA product just show the contextual chat with the context we
-                    // have — no screenshot, no MediaProjection prompt. Clear any prior
-                    // screenshot so stale image data can't ride along with new context.
+                    // Web/PWA inspection: just show the contextual chat with the
+                    // context we have — no screenshot, no MediaProjection prompt.
+                    // Clear any prior screenshot so stale image data can't ride
+                    // along with new context.
                     pendingBase64Screenshot = null
                     _isContextualChatVisible.value = true
                 }
@@ -301,9 +304,9 @@ class OverlayDelegate(
 
     fun hasScreenCapturePermission() = screenCaptureData != null
     fun requestScreenCapturePermission() {
-        // Dormant in the PWA-only product — see [screenCaptureEnabled]. Never raise
-        // the MediaProjection consent dialog so it can't prompt or crash users.
-        if (!screenCaptureEnabled) return
+        // Dormant for non-Android projects — see [isScreenCaptureEnabled]. Never raise
+        // the MediaProjection consent dialog there so it can't prompt or crash users.
+        if (!isScreenCaptureEnabled()) return
         _requestScreenCapture.value = true
     }
     fun screenCaptureRequestHandled() { _requestScreenCapture.value = false }

--- a/app/src/test/java/com/hereliesaz/ideaz/ui/delegates/OverlayDelegateWebContextTest.kt
+++ b/app/src/test/java/com/hereliesaz/ideaz/ui/delegates/OverlayDelegateWebContextTest.kt
@@ -73,6 +73,16 @@ class OverlayDelegateWebContextTest {
         val webVm: SettingsViewModel = mock()
         whenever(webVm.getProjectType()).thenReturn("WEB")
         assertFalse(OverlayDelegate(app, webVm, this, {}).isScreenCaptureEnabled())
+
+        // Null (no project loaded) and unrecognized strings are safe — ProjectType
+        // .fromString maps both to UNKNOWN (never throws), so capture stays off.
+        val nullVm: SettingsViewModel = mock()
+        whenever(nullVm.getProjectType()).thenReturn(null)
+        assertFalse(OverlayDelegate(app, nullVm, this, {}).isScreenCaptureEnabled())
+
+        val invalidVm: SettingsViewModel = mock()
+        whenever(invalidVm.getProjectType()).thenReturn("INVALID")
+        assertFalse(OverlayDelegate(app, invalidVm, this, {}).isScreenCaptureEnabled())
     }
 
     @Test

--- a/app/src/test/java/com/hereliesaz/ideaz/ui/delegates/OverlayDelegateWebContextTest.kt
+++ b/app/src/test/java/com/hereliesaz/ideaz/ui/delegates/OverlayDelegateWebContextTest.kt
@@ -9,6 +9,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 
 class OverlayDelegateWebContextTest {
 
@@ -61,5 +62,38 @@ class OverlayDelegateWebContextTest {
         delegate.clearSelection()
 
         assertFalse(delegate.isContextualChatVisible.first())
+    }
+
+    @Test
+    fun `screen capture is enabled only for android target projects`() = runTest {
+        val androidVm: SettingsViewModel = mock()
+        whenever(androidVm.getProjectType()).thenReturn("ANDROID")
+        assertTrue(OverlayDelegate(app, androidVm, this, {}).isScreenCaptureEnabled())
+
+        val webVm: SettingsViewModel = mock()
+        whenever(webVm.getProjectType()).thenReturn("WEB")
+        assertFalse(OverlayDelegate(app, webVm, this, {}).isScreenCaptureEnabled())
+    }
+
+    @Test
+    fun `requestScreenCapturePermission stays dormant for web projects`() = runTest {
+        val webVm: SettingsViewModel = mock()
+        whenever(webVm.getProjectType()).thenReturn("WEB")
+        val delegate = OverlayDelegate(app, webVm, this, {})
+
+        delegate.requestScreenCapturePermission()
+
+        assertFalse(delegate.requestScreenCapture.first())
+    }
+
+    @Test
+    fun `requestScreenCapturePermission fires for android target projects`() = runTest {
+        val androidVm: SettingsViewModel = mock()
+        whenever(androidVm.getProjectType()).thenReturn("ANDROID")
+        val delegate = OverlayDelegate(app, androidVm, this, {})
+
+        delegate.requestScreenCapturePermission()
+
+        assertTrue(delegate.requestScreenCapture.first())
     }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -41,7 +41,7 @@ Git is the source of truth. There is no offline build path — builds are always
 * **`IdeazOverlayService`**: `TYPE_APPLICATION_OVERLAY` window for Phase 2 element-tap on the sideloaded target app. Wired but inert until Phase 2.
 * **`IdeazAccessibilityService`**: `AccessibilityNodeInfo` walk for Phase 2 element capture. Wired but inert until Phase 2.
 * **`CrashReportingService`** (`:crash_reporter`): isolated process so crashes still report.
-* **`ScreenshotService`**: `MediaProjection` virtual display for region screenshots — kept for Phase 2 (Android target) but **dormant in the PWA-only product**: undeclared in the manifest and gated off by `OverlayDelegate.screenCaptureEnabled`, so no consent prompt or foreground service runs today.
+* **`ScreenshotService`**: `MediaProjection` virtual display for region screenshots. Declared in the manifest (`mediaProjection` FGS) and started **only for Android target projects**, gated at runtime by `OverlayDelegate.isScreenCaptureEnabled()`; web/PWA projects never raise the consent prompt or start the service.
 
 ## 5. File System
 

--- a/docs/file_descriptions.md
+++ b/docs/file_descriptions.md
@@ -53,10 +53,10 @@
 
 #### services/
 *   `BuildService.kt`: Foreground service in `:build_process`. Post-Phase-0 it is a thin shell around `RemoteBuildManager`.
-*   `IdeazAccessibilityService.kt`: Accessibility Service for Phase 2 element capture (wired but inert until Phase 2).
+*   `IdeazAccessibilityService.kt`: Accessibility Service that captures tapped elements in the sideloaded target app — resolves the tapped node's `viewIdResourceName` + screen bounds (→ source file/line context) and reports the target app's window bounds to the overlay.
 *   `IdeazOverlayService.kt`: System Alert Window overlay for Phase 2 (wired but inert until Phase 2).
 *   `CrashReportingService.kt`: Service for fatal error reporting in `:crash_reporter`.
-*   `ScreenshotService.kt`: `MediaProjection` virtual display for region screenshots. **Dormant in the PWA-only product** (Phase 2 / Android target) — not declared in the manifest and never started; gated by `OverlayDelegate.screenCaptureEnabled`.
+*   `ScreenshotService.kt`: `MediaProjection` virtual display for region screenshots. Declared in the manifest (`mediaProjection` FGS) and started **only for Android target projects**, gated at runtime by `OverlayDelegate.isScreenCaptureEnabled()`; web/PWA projects never raise the consent dialog. The captured PNG is attached to the contextual prompt for image-capable models (and embedded for Jules).
 
 #### ai/
 *   `AiAdapterFactory.kt`: Centralized factory that maps AI models to concrete adapters.
@@ -112,7 +112,7 @@
 *   `AIDelegate.kt`: AI sessions (Phase 1 Gemini conversational; Phase 2 Jules agentic).
 *   `BuildDelegate.kt`: BuildService binding; remote build dispatch + poll + install.
 *   `GitDelegate.kt`: Git operations and state.
-*   `OverlayDelegate.kt`: Visual overlay and selection mode (Phase 2).
+*   `OverlayDelegate.kt`: Visual overlay and selection mode. `isScreenCaptureEnabled()` gates MediaProjection capture to Android target projects (web/PWA never prompt).
 *   `RepoDelegate.kt`: GitHub repo fetch / create. `uploadProjectSecrets` is currently a no-op stub — see `docs/plans/phase-0-followups.md`.
 *   `StateDelegate.kt`: Centralized shared UI state.
 *   `SystemEventDelegate.kt`: BroadcastReceivers for system events.

--- a/version.properties
+++ b/version.properties
@@ -1,5 +1,5 @@
 #Fri Jun 05 21:45:00 CDT 2026
 build=72
 major=1
-minor=14
+minor=15
 patch=17


### PR DESCRIPTION
Third Phase-2 increment (2B), independent of #716. Re-enables **target-window MediaProjection** so tapping an element in the sideloaded Android app captures a region screenshot that's attached to the contextual prompt.

Most of this already existed and was just gated off:
- **Element capture** (`IdeazAccessibilityService`) is already active — a tap resolves the node's `viewIdResourceName` + screen bounds → source file/line context, and reports the target app's window bounds to the overlay.
- **The screenshot→prompt plumbing** already exists in `MainViewModel.submitContextualPrompt` (embeds the PNG for Jules, attaches `ChatPart.Image` for image-capable models).
- **`ScreenshotService`** (MediaProjection → PNG) was retained but dormant.

So this PR is the focused re-enable:

## Changes
- **`OverlayDelegate`** — replace the hardcoded `screenCaptureEnabled = false` with `isScreenCaptureEnabled()`, gated to `ProjectType.ANDROID`. Web/PWA projects inspect via DOM/source context and **never** raise the MediaProjection consent dialog or start the FGS. Re-evaluated per call, so switching projects takes effect live.
- **`AndroidManifest.xml`** — re-declare the `ScreenshotService` (`mediaProjection` FGS) and the `FOREGROUND_SERVICE_MEDIA_PROJECTION` permission.
- **Tests** — gating matrix: capture enabled for Android, dormant for web; `requestScreenCapturePermission` fires only for Android.
- Docs/comments updated (`architecture.md`, `file_descriptions.md`, `SettingsScreen` comment).

## Scope / honesty notes
- ⚠️ **Play policy surface:** re-declaring the `mediaProjection` foreground-service type adds it back to the manifest. It's only *started* for Android target projects, but the declaration is always present — a Play submission may need a `mediaProjection` justification. Flagging since it was originally disabled for exactly this reason; easy to revert if you'd rather keep it off.
- ⚠️ **Device-bound:** the actual capture path (MediaProjection consent, `VirtualDisplay`, accessibility node walk) can't run in CI/unit tests — only the project-type **gating** is unit-tested. The capture/plumbing code itself is unchanged from what already existed.
- For the default **Android → Jules** routing, Jules consumes the screenshot as an embedded data-URI in the prompt text (it's repo/text-oriented); image-capable assignments (Gemini/OpenAI/Claude) get it as a native image part.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nw6AHh15NTE63WQKU5qbY8)_