### PR TITLE
Fix Gradle build failure in app/build.gradle.kts

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -287,17 +287,17 @@ abstract class IncrementBuildNumberTask : DefaultTask() {
     @get:Internal
     abstract val versionFile: RegularFileProperty
 
+    @get:Input
+    @get:Optional
+    abstract val buildOverride: Property<Int>
+
     @TaskAction
     fun increment() {
-        val file = versionFile.get().asFile
-tasks.register("incrementBuildNumber") {
-    val versionFile = layout.projectDirectory.file("../version.properties").asFile
-    val buildOverride = versionBuildOverride
-    outputs.upToDateWhen { false }
-    doFirst {
         // CI supplies the build component via -PversionBuild (commit count); leave
         // version.properties untouched in that case so the checkout stays clean.
-        if (buildOverride != null) return@doFirst
+        if (buildOverride.isPresent) return
+
+        val file = versionFile.get().asFile
         val props = Properties()
         if (file.exists()) {
             file.inputStream().use { props.load(it) }
@@ -310,6 +310,7 @@ tasks.register("incrementBuildNumber") {
 
 tasks.register<IncrementBuildNumberTask>("incrementBuildNumber") {
     versionFile.set(rootProject.file("version.properties"))
+    buildOverride.set(versionBuildOverride)
     outputs.upToDateWhen { false }
 }
 

--- a/version.properties
+++ b/version.properties
@@ -1,5 +1,5 @@
-#Sat Jun 20 01:55:43 UTC 2026
-build=82
+#Sat Jun 20 14:37:10 UTC 2026
+build=84
 major=1
 minor=15
-patch=18
+patch=19


### PR DESCRIPTION
This PR fixes a build failure in `app/build.gradle.kts` where a syntax error (missing/mismatched braces) was introduced due to a malformed `incrementBuildNumber` task registration. 

The fix involves refactoring the ad-hoc task into a proper `DefaultTask` subclass, which not only resolves the syntax error but also improves compatibility with the Gradle configuration cache by using the `Property` API. 

Verification steps taken:
- Ran `./gradlew :app:help` to ensure the build script compiles.
- Ran `./gradlew :app:assembleDebug` to verify the full build process.
- Manually verified that the `incrementBuildNumber` task correctly updates `version.properties` and respects build overrides.
- Updated the project version to 1.15.19.

Fixes #727

---
*PR created automatically by Jules for task [9217469560646522074](https://jules.google.com/task/9217469560646522074) started by @HereLiesAz*