### PR TITLE
Fix build failure in app/build.gradle.kts

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -287,17 +287,18 @@ abstract class IncrementBuildNumberTask : DefaultTask() {
     @get:Internal
     abstract val versionFile: RegularFileProperty
 
+    @get:Input
+    @get:Optional
+    abstract val buildOverride: Property<Int>
+
     @TaskAction
     fun increment() {
-        val file = versionFile.get().asFile
-tasks.register("incrementBuildNumber") {
-    val versionFile = layout.projectDirectory.file("../version.properties").asFile
-    val buildOverride = versionBuildOverride
-    outputs.upToDateWhen { false }
-    doFirst {
+        val override = buildOverride.orNull
         // CI supplies the build component via -PversionBuild (commit count); leave
         // version.properties untouched in that case so the checkout stays clean.
-        if (buildOverride != null) return@doFirst
+        if (override != null) return
+
+        val file = versionFile.get().asFile
         val props = Properties()
         if (file.exists()) {
             file.inputStream().use { props.load(it) }
@@ -310,6 +311,7 @@ tasks.register("incrementBuildNumber") {
 
 tasks.register<IncrementBuildNumberTask>("incrementBuildNumber") {
     versionFile.set(rootProject.file("version.properties"))
+    buildOverride.set(versionBuildOverride)
     outputs.upToDateWhen { false }
 }
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -23,7 +23,7 @@ When Phase 0 completes, this file will point to Phase 1's plan.
 - Performed full User Flow & Navigation audit, mapping PWA loops, Editor flows, and Phase 1 transitions.
 - Resolved build failure caused by duplicate `protobuf` classes by excluding `protobuf-java` from `google-genai` and standardizing on `protobuf-javalite`.
 - Fixed build failure caused by the redundant `org.jetbrains.kotlin.android` plugin which is now integrated into AGP 9.0+.
-- Fixed Gradle configuration cache failure by refactoring the `incrementBuildNumber` task into a proper task class.
+- Fixed Gradle configuration cache failure and build script syntax error by refactoring the `incrementBuildNumber` task into a proper task class.
 - Resolved several deprecation and code health warnings:
     - Updated `Icons.Default.NoteAdd` to its `AutoMirrored` version in `FileExplorerScreen.kt`.
     - Removed an unnecessary safe call on `SourceContext` in `AIDelegate.kt`.

--- a/version.properties
+++ b/version.properties
@@ -1,5 +1,5 @@
-#Sat Jun 20 01:55:43 UTC 2026
-build=82
+#Sat Jun 20 14:46:35 UTC 2026
+build=86
 major=1
 minor=15
-patch=18
+patch=19


### PR DESCRIPTION
This PR fixes a build failure in the `app` module caused by a syntax error in its `build.gradle.kts` file. The error was due to an incorrectly nested `tasks.register` call within a task action. I've refactored this logic into a proper task class, which not only fixes the syntax error but also improves configuration cache compatibility. I've also incremented the patch version in `version.properties` as per the project's versioning strategy.

Fixes #725

---
*PR created automatically by Jules for task [9336612621733521352](https://jules.google.com/task/9336612621733521352) started by @HereLiesAz*