### PR TITLE
Fix Gradle build script syntax error and refactor incrementBuildNumber task

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -287,17 +287,17 @@ abstract class IncrementBuildNumberTask : DefaultTask() {
     @get:Internal
     abstract val versionFile: RegularFileProperty
 
+    @get:Input
+    @get:Optional
+    abstract val buildOverride: Property<Int>
+
     @TaskAction
     fun increment() {
-        val file = versionFile.get().asFile
-tasks.register("incrementBuildNumber") {
-    val versionFile = layout.projectDirectory.file("../version.properties").asFile
-    val buildOverride = versionBuildOverride
-    outputs.upToDateWhen { false }
-    doFirst {
         // CI supplies the build component via -PversionBuild (commit count); leave
         // version.properties untouched in that case so the checkout stays clean.
-        if (buildOverride != null) return@doFirst
+        if (buildOverride.orNull != null) return
+
+        val file = versionFile.get().asFile
         val props = Properties()
         if (file.exists()) {
             file.inputStream().use { props.load(it) }
@@ -310,6 +310,7 @@ tasks.register("incrementBuildNumber") {
 
 tasks.register<IncrementBuildNumberTask>("incrementBuildNumber") {
     versionFile.set(rootProject.file("version.properties"))
+    buildOverride.set(versionBuildOverride)
     outputs.upToDateWhen { false }
 }
 

--- a/version.properties
+++ b/version.properties
@@ -1,5 +1,5 @@
-#Sat Jun 20 01:55:43 UTC 2026
-build=82
+#Sat Jun 20 14:48:11 UTC 2026
+build=87
 major=1
 minor=15
 patch=18


### PR DESCRIPTION
This change fixes a build failure in `app/build.gradle.kts` caused by a malformed `IncrementBuildNumberTask` definition. The task was missing closing braces and contained a nested, redundant task registration. I refactored it into a clean, configuration-cache safe task class and verified the fix with `./gradlew help` and `./gradlew :app:compileDebugKotlin`.

Fixes #726

---
*PR created automatically by Jules for task [2009142595155916708](https://jules.google.com/task/2009142595155916708) started by @HereLiesAz*