### PR TITLE
Fix Gradle syntax error and refactor build number increment logic

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -287,17 +287,17 @@ abstract class IncrementBuildNumberTask : DefaultTask() {
     @get:Internal
     abstract val versionFile: RegularFileProperty
 
+    @get:Input
+    @get:Optional
+    abstract val versionBuildOverride: Property<Int>
+
     @TaskAction
     fun increment() {
-        val file = versionFile.get().asFile
-tasks.register("incrementBuildNumber") {
-    val versionFile = layout.projectDirectory.file("../version.properties").asFile
-    val buildOverride = versionBuildOverride
-    outputs.upToDateWhen { false }
-    doFirst {
         // CI supplies the build component via -PversionBuild (commit count); leave
         // version.properties untouched in that case so the checkout stays clean.
-        if (buildOverride != null) return@doFirst
+        if (versionBuildOverride.isPresent) return
+
+        val file = versionFile.get().asFile
         val props = Properties()
         if (file.exists()) {
             file.inputStream().use { props.load(it) }
@@ -310,6 +310,9 @@ tasks.register("incrementBuildNumber") {
 
 tasks.register<IncrementBuildNumberTask>("incrementBuildNumber") {
     versionFile.set(rootProject.file("version.properties"))
+    versionBuildOverride.set(project.provider {
+        project.findProperty("versionBuild")?.toString()?.toIntOrNull()
+    })
     outputs.upToDateWhen { false }
 }
 


### PR DESCRIPTION
The build failure was caused by a syntax error in `app/build.gradle.kts` where a task registration was incorrectly nested within a class member, leading to mismatched braces. 

This PR refactors the `IncrementBuildNumberTask` into a clean `DefaultTask` implementation, ensuring it is compatible with the Gradle configuration cache. It also cleans up the task registration logic, using lazy providers to handle optional CI build number overrides (`-PversionBuild`) securely and without shadowing script-level variables. 

Verified that the Gradle configuration is now valid (`./gradlew help`) and that the application module compiles successfully.

Fixes #724

---
*PR created automatically by Jules for task [10599487450557406354](https://jules.google.com/task/10599487450557406354) started by @HereLiesAz*