### PR TITLE
fix(build): repair broken master — incrementBuildNumber merge, versionCode, AAB minSdk

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -44,10 +44,11 @@ extensions.configure<com.android.build.api.dsl.ApplicationExtension> {
         minSdk = 30
 
         targetSdk = 37
-        // With an explicit override use it verbatim (monotonic commit count); the
-        // packed major/minor/patch/build formula stays for local file-driven builds.
-        versionCode = versionBuildOverride
-            ?: (major * 1000000 + minor * 10000 + patch * 100 + buildNumber)
+        // One packed formula for both local and CI builds. `buildNumber` is the CI
+        // commit count when -PversionBuild is passed, else the file build number;
+        // either way the code is monotonic and stays >= existing released codes, so it
+        // never downgrades an installed build or gets rejected by Play.
+        versionCode = major * 1000000 + minor * 10000 + patch * 100 + buildNumber
         versionName = "$major.$minor.$patch.$buildNumber"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
@@ -287,17 +288,15 @@ abstract class IncrementBuildNumberTask : DefaultTask() {
     @get:Internal
     abstract val versionFile: RegularFileProperty
 
+    @get:Input
+    abstract val skip: Property<Boolean>
+
     @TaskAction
     fun increment() {
-        val file = versionFile.get().asFile
-tasks.register("incrementBuildNumber") {
-    val versionFile = layout.projectDirectory.file("../version.properties").asFile
-    val buildOverride = versionBuildOverride
-    outputs.upToDateWhen { false }
-    doFirst {
         // CI supplies the build component via -PversionBuild (commit count); leave
         // version.properties untouched in that case so the checkout stays clean.
-        if (buildOverride != null) return@doFirst
+        if (skip.get()) return
+        val file = versionFile.get().asFile
         val props = Properties()
         if (file.exists()) {
             file.inputStream().use { props.load(it) }
@@ -309,7 +308,8 @@ tasks.register("incrementBuildNumber") {
 }
 
 tasks.register<IncrementBuildNumberTask>("incrementBuildNumber") {
-    versionFile.set(rootProject.file("version.properties"))
+    versionFile.set(rootProject.layout.projectDirectory.file("version.properties"))
+    skip.set(versionBuildOverride != null)
     outputs.upToDateWhen { false }
 }
 

--- a/docs/build_pipeline.md
+++ b/docs/build_pipeline.md
@@ -81,11 +81,14 @@ one. To guarantee a strictly-increasing code, CI passes the git commit count:
 -PversionBuild=$(git rev-list --count HEAD)
 ```
 
-When `-PversionBuild=<n>` is supplied it becomes **both** the `versionCode` (verbatim,
-monotonic) **and** the build component (`d`) of the `a.b.c.d` `versionName`. When it is
-absent, the historic file-driven formula
-(`major·1e6 + minor·1e4 + patch·100 + build`) is used and `version.properties` is left
-untouched. See [`app/build.gradle.kts`](../app/build.gradle.kts).
+When `-PversionBuild=<n>` is supplied it becomes the build component (`d`) of the
+`a.b.c.d` `versionName` **and** the `build` term of the **same packed formula** used
+locally — `major·1e6 + minor·1e4 + patch·100 + build`. Using one formula everywhere
+keeps the `versionCode` monotonic *and* always `>= 1_000_000`, so it never drops below
+a previously-installed local/GitHub-Release build (which would trigger
+`INSTALL_FAILED_VERSION_DOWNGRADE`) and is never lower than a code Play has already
+seen. When the override is absent, the file-driven `build` number is used and
+`version.properties` is left untouched. See [`app/build.gradle.kts`](../app/build.gradle.kts).
 
 ### 6.3 Modular delivery & size
 

--- a/webruntime/build.gradle.kts
+++ b/webruntime/build.gradle.kts
@@ -4,10 +4,16 @@ plugins {
 
 // Assets-only dynamic feature module: it carries the bundled in-browser web
 // runtime (assets/ideaz-runtime/*) and nothing else — no Kotlin, no resources.
-// minSdk / versionCode / signing are all inherited from the base :app module.
+// versionCode / signing are inherited from the base :app module. minSdk must be
+// declared explicitly and match the base (30): bundletool rejects the bundle if a
+// feature module's minSdkVersion is lower than the base module's.
 android {
     namespace = "com.hereliesaz.ideaz.webruntime"
     compileSdk = 37
+
+    defaultConfig {
+        minSdk = 30
+    }
 }
 
 dependencies {


### PR DESCRIPTION
## Why

`master` is currently **red** (`build-and-release` failing on `8e2eb61`). The merge of two automated follow-up PRs (#722, #723) on top of #719 collided and left `app/build.gradle.kts` invalid, and also reverted an earlier fix. A separate bundle-only bug surfaced too.

## Fixes

1. **`incrementBuildNumber` (compile failure).** The merge spliced an unclosed `IncrementBuildNumberTask` class together with a second, old-style `tasks.register("incrementBuildNumber")` — duplicate task name, unbalanced braces, a dangling `file` reference. Collapsed to a **single typed task** that is configuration-cache safe (a `Property<Boolean> skip` captured at configuration time) and skips the `version.properties` bump when `-PversionBuild` is supplied.

2. **`versionCode` regression.** The merge reverted the code back to the **verbatim** override form (`versionCode = versionBuildOverride ?: …`). With CI passing the commit count (~720) that sinks *below* the existing packed code (~1,151,773), causing `INSTALL_FAILED_VERSION_DOWNGRADE` for installed users and Play rejection. Restored the single **packed formula** (`major*1e6 + minor*1e4 + patch*100 + buildNumber`) for both local and CI — monotonic and always `≥ 1_000_000`.

3. **AAB `minSdk` (bundle failure).** `:app:packageReleaseBundle` failed with *"Modules cannot have a minSdkVersion attribute with a value lower than the one from the base module."* The `:webruntime` dynamic feature module didn't declare a `minSdk`; set it explicitly to **30** to match the base. This only shows up in `bundleRelease` — the existing `build-and-release.yml` runs `assembleRelease` only, which is why #719 didn't catch it.

4. **Docs.** Re-aligned `docs/build_pipeline.md` §6.2 with the packed-formula behavior.

## Verification

No Android SDK in this environment, so not built locally — relies on CI. Note the CI log that revealed fix #3 already showed the project **configuring and reaching `packageReleaseBundle`** with the typed-task pattern, so #1's structure is sound; this PR removes the duplicate and adds the `minSdk`. The `publish-play.yml` workflow (which runs `bundleRelease`) is the one that exercises fix #3 end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxcaHy3fp62Yw329xWWLhB)_

## Summary by Sourcery

Restore a consistent, monotonic Android versionCode scheme, fix the incremental build number task, and align dynamic feature and documentation behavior with the base app configuration.

Bug Fixes:
- Ensure versionCode always uses the packed major/minor/patch/build formula so both local and CI builds remain monotonically increasing and compatible with existing installs and Play Store requirements.
- Fix the IncrementBuildNumberTask so CI-supplied build overrides skip updating version.properties without breaking configuration-cache compatibility.
- Set an explicit minSdk of 30 for the webruntime dynamic feature module to prevent bundle packaging failures due to mismatched minSdk versions.

Documentation:
- Update build pipeline documentation to describe the unified packed versionCode formula for both local and CI builds.