### PR TITLE
Fix AzNavRail variant matching build error

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -234,7 +234,10 @@ dependencies {
         exclude(group = "com.google.protobuf", module = "protobuf-javalite")
     }
     implementation(libs.androidx.localbroadcastmanager)
-    implementation(libs.aznavrail)
+    implementation(libs.aznavrail) {
+        exclude(group = "com.github.HereLiesAz.AzNavRail", module = "aznavrail-cmp-wasm-js")
+        exclude(group = "com.github.HereLiesAz.AzNavRail", module = "aznavrail-cmp-desktop")
+    }
     implementation(libs.androidx.navigation.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.compose.runtime.livedata)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -237,6 +237,7 @@ dependencies {
     implementation(libs.aznavrail) {
         exclude(group = "com.github.HereLiesAz.AzNavRail", module = "aznavrail-cmp-wasm-js")
         exclude(group = "com.github.HereLiesAz.AzNavRail", module = "aznavrail-cmp-desktop")
+        exclude(group = "com.github.HereLiesAz.AzNavRail", module = "aznavrail-cmp-android")
     }
     implementation(libs.androidx.navigation.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -22,7 +22,7 @@ When Phase 0 completes, this file will point to Phase 1's plan.
 - Pinned `run-gemini-cli` to a specific SHA in CI workflows to mitigate supply chain vulnerabilities.
 - Performed full User Flow & Navigation audit, mapping PWA loops, Editor flows, and Phase 1 transitions.
 - Resolved build failure caused by duplicate `protobuf` classes by excluding `protobuf-java` from `google-genai` and standardizing on `protobuf-javalite`.
-- Fixed build failure caused by incompatible transitive dependencies (`wasm-js` and `desktop` variants) of `AzNavRail` library by adding explicit Gradle exclusions.
+- Fixed build failure and duplicate class packaging errors caused by incompatible transitive dependencies (`wasm-js`, `desktop`, and `cmp-android` variants) of the `AzNavRail` library by adding explicit Gradle exclusions.
 - Fixed build failure caused by the redundant `org.jetbrains.kotlin.android` plugin which is now integrated into AGP 9.0+.
 - Fixed Gradle configuration cache failure and build script syntax error by refactoring the `incrementBuildNumber` task into a proper task class.
 - Resolved several deprecation and code health warnings:

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -22,6 +22,7 @@ When Phase 0 completes, this file will point to Phase 1's plan.
 - Pinned `run-gemini-cli` to a specific SHA in CI workflows to mitigate supply chain vulnerabilities.
 - Performed full User Flow & Navigation audit, mapping PWA loops, Editor flows, and Phase 1 transitions.
 - Resolved build failure caused by duplicate `protobuf` classes by excluding `protobuf-java` from `google-genai` and standardizing on `protobuf-javalite`.
+- Fixed build failure caused by incompatible transitive dependencies (`wasm-js` and `desktop` variants) of `AzNavRail` library by adding explicit Gradle exclusions.
 - Fixed build failure caused by the redundant `org.jetbrains.kotlin.android` plugin which is now integrated into AGP 9.0+.
 - Fixed Gradle configuration cache failure and build script syntax error by refactoring the `incrementBuildNumber` task into a proper task class.
 - Resolved several deprecation and code health warnings:

--- a/version.properties
+++ b/version.properties
@@ -1,5 +1,5 @@
-#Sat Jun 20 14:46:35 UTC 2026
-build=86
+#Tue Jul 21 20:01:17 UTC 2026
+build=87
 major=1
 minor=15
-patch=19
+patch=20

--- a/version.properties
+++ b/version.properties
@@ -1,5 +1,5 @@
-#Tue Jul 21 20:01:17 UTC 2026
-build=87
+#Tue Jul 21 20:28:33 UTC 2026
+build=90
 major=1
 minor=15
 patch=20


### PR DESCRIPTION
Resolved Android build failures when upgrading Gradle or building with strict variant matching by adding explicit Gradle exclusions for the incompatible WASM/JS and Desktop transitive submodules of the AzNavRail library. Incremented patch version in version.properties and documented the fix in TODO.md.

Fixes #757

---
*PR created automatically by Jules for task [18259864942705260972](https://jules.google.com/task/18259864942705260972) started by @HereLiesAz*

## Summary by Sourcery

Exclude incompatible AzNavRail variants from the Android app dependency to restore successful builds and document the change.

Bug Fixes:
- Prevent Android build failures caused by incompatible WASM/JS, Desktop, and Android variants of the AzNavRail library via explicit Gradle exclusions.

Enhancements:
- Increment the app build number for a new patch release.

Documentation:
- Document the AzNavRail transitive dependency issue and its Gradle exclusion fix in the TODO change log.