### PR TITLE
fix: resolve AzNavRail dependency variant resolution build failure

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -24,6 +24,7 @@ When Phase 0 completes, this file will point to Phase 1's plan.
 - Resolved build failure caused by duplicate `protobuf` classes by excluding `protobuf-java` from `google-genai` and standardizing on `protobuf-javalite`.
 - Fixed build failure caused by the redundant `org.jetbrains.kotlin.android` plugin which is now integrated into AGP 9.0+.
 - Fixed Gradle configuration cache failure and build script syntax error by refactoring the `incrementBuildNumber` task into a proper task class.
+- Fixed build failure caused by Gradle variant selection mismatch when upgrading `aznavrail` dependency to `11.0` by using the specific published submodule coordinate `com.github.HereLiesAz.AzNavRail:aznavrail` in the Version Catalog.
 - Resolved several deprecation and code health warnings:
     - Updated `Icons.Default.NoteAdd` to its `AutoMirrored` version in `FileExplorerScreen.kt`.
     - Removed an unnecessary safe call on `SourceContext` in `AIDelegate.kt`.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -58,7 +58,7 @@ androidx-preference-ktx = { group = "androidx.preference", name = "preference-kt
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycleRuntimeKtx" }
 androidx-localbroadcastmanager = { module = "androidx.localbroadcastmanager:localbroadcastmanager", version.ref = "localbroadcastmanager" }
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
-aznavrail = { module = "com.github.HereLiesAz:AzNavRail", version.ref = "aznavrail" }
+aznavrail = { module = "com.github.HereLiesAz.AzNavRail:aznavrail", version.ref = "aznavrail" }
 google-genai = { module = "com.google.genai:google-genai", version.ref = "googleGenai" }
 google-ai-edge-aicore = { module = "com.google.ai.edge.aicore:aicore", version.ref = "aicore" }
 mediapipe-tasks-genai = { module = "com.google.mediapipe:tasks-genai", version.ref = "mediapipeGenai" }

--- a/version.properties
+++ b/version.properties
@@ -1,5 +1,5 @@
-#Sat Jun 20 14:46:35 UTC 2026
-build=86
+#Tue Jul 21 20:04:10 UTC 2026
+build=90
 major=1
 minor=15
-patch=19
+patch=20


### PR DESCRIPTION
Resolve Gradle variant matching failures for AzNavRail in gradle/libs.versions.toml when upgraded to 11.0.

Fixes #753

---
*PR created automatically by Jules for task [16063203517751606405](https://jules.google.com/task/16063203517751606405) started by @HereLiesAz*

## Summary by Sourcery

Clarify AzNavRail Gradle variant selection handling and bump the build number metadata.

Documentation:
- Document the fix for Gradle variant selection mismatch when upgrading the AzNavRail dependency to version 11.0 in the Phase 0 TODO plan.

Chores:
- Update version properties metadata for build 90 by removing the autogenerated timestamp comment.