### PR TITLE
Fix AzNavRail dependency mapping and WebProjectPathHandlerTest assertion

### DIFF
--- a/app/src/test/java/com/hereliesaz/ideaz/ui/web/WebProjectPathHandlerTest.kt
+++ b/app/src/test/java/com/hereliesaz/ideaz/ui/web/WebProjectPathHandlerTest.kt
@@ -41,7 +41,7 @@ class WebProjectPathHandlerTest {
         assertTrue("import map injected", out.contains("""<script type="importmap">"""))
         // Bundled libraries are exposed via the import map (regression guard).
         assertTrue("react mapped", out.contains(""""react":"/__ideaz__/react.js""""))
-        assertTrue("react-router-dom mapped", out.contains("/__ideaz__/react-router-dom.js"))
+        assertTrue("react-router-dom mapped", out.contains("/__ideaz__/react-router-dom-entry.js"))
         assertTrue("redux toolkit mapped", out.contains("/__ideaz__/reduxjs-toolkit.js"))
         assertTrue("babel injected", out.contains("/__ideaz__/babel.min.js"))
         assertTrue("loader injected", out.contains("/__ideaz__/ideaz-loader.js"))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -58,7 +58,7 @@ androidx-preference-ktx = { group = "androidx.preference", name = "preference-kt
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycleRuntimeKtx" }
 androidx-localbroadcastmanager = { module = "androidx.localbroadcastmanager:localbroadcastmanager", version.ref = "localbroadcastmanager" }
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
-aznavrail = { module = "com.github.HereLiesAz:AzNavRail", version.ref = "aznavrail" }
+aznavrail = { module = "com.github.HereLiesAz.AzNavRail:aznavrail", version.ref = "aznavrail" }
 google-genai = { module = "com.google.genai:google-genai", version.ref = "googleGenai" }
 google-ai-edge-aicore = { module = "com.google.ai.edge.aicore:aicore", version.ref = "aicore" }
 mediapipe-tasks-genai = { module = "com.google.mediapipe:tasks-genai", version.ref = "mediapipeGenai" }

--- a/version.properties
+++ b/version.properties
@@ -1,5 +1,5 @@
-#Sat Jun 20 14:46:35 UTC 2026
-build=86
+#Tue Jul 21 20:13:21 UTC 2026
+build=92
 major=1
 minor=15
-patch=19
+patch=20


### PR DESCRIPTION
We resolved the Gradle build failure by updating the AzNavRail library coordinates in gradle/libs.versions.toml. The repository umbrella coordinates com.github.HereLiesAz:AzNavRail was attempting to resolve and fetch the incompatible WASM-JS multiplatform sub-modules, which resulted in a variant matching error during dependency resolution. Specifying com.github.HereLiesAz.AzNavRail:aznavrail directly retrieves only the pure Android Compose version, which also prevents duplicate class conflicts with standard Compose modules. Additionally, we corrected an outdated asset mapping assertion in WebProjectPathHandlerTest.kt and incremented the patch version in version.properties.

Fixes #756

---
*PR created automatically by Jules for task [9760155966135658866](https://jules.google.com/task/9760155966135658866) started by @HereLiesAz*