### PR TITLE
Resolve AzNavRail Duplicate Classes Build Failure

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -234,7 +234,9 @@ dependencies {
         exclude(group = "com.google.protobuf", module = "protobuf-javalite")
     }
     implementation(libs.androidx.localbroadcastmanager)
-    implementation(libs.aznavrail)
+    implementation(libs.aznavrail) {
+        exclude(group = "com.github.HereLiesAz.AzNavRail", module = "aznavrail-cmp-wasm-js")
+    }
     implementation(libs.androidx.navigation.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.compose.runtime.livedata)

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -28,3 +28,4 @@ When Phase 0 completes, this file will point to Phase 1's plan.
     - Updated `Icons.Default.NoteAdd` to its `AutoMirrored` version in `FileExplorerScreen.kt`.
     - Removed an unnecessary safe call on `SourceContext` in `AIDelegate.kt`.
     - Suppressed `LlmInference` deprecation warning in `LocalModelRuntime.kt`.
+- Fixed build failure caused by duplicate AzNavRail classes by specifying the correct submodule coordinate (`com.github.HereLiesAz.AzNavRail:aznavrail`) and excluding the incompatible `aznavrail-cmp-wasm-js` variant.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -58,7 +58,7 @@ androidx-preference-ktx = { group = "androidx.preference", name = "preference-kt
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycleRuntimeKtx" }
 androidx-localbroadcastmanager = { module = "androidx.localbroadcastmanager:localbroadcastmanager", version.ref = "localbroadcastmanager" }
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
-aznavrail = { module = "com.github.HereLiesAz:AzNavRail", version.ref = "aznavrail" }
+aznavrail = { module = "com.github.HereLiesAz.AzNavRail:aznavrail", version.ref = "aznavrail" }
 google-genai = { module = "com.google.genai:google-genai", version.ref = "googleGenai" }
 google-ai-edge-aicore = { module = "com.google.ai.edge.aicore:aicore", version.ref = "aicore" }
 mediapipe-tasks-genai = { module = "com.google.mediapipe:tasks-genai", version.ref = "mediapipeGenai" }

--- a/version.properties
+++ b/version.properties
@@ -1,5 +1,5 @@
-#Sat Jun 20 14:46:35 UTC 2026
-build=86
+#Tue Jul 21 20:40:27 UTC 2026
+build=89
 major=1
 minor=15
-patch=19
+patch=20


### PR DESCRIPTION
The build was failing because referencing the repository root coordinate of `AzNavRail` pulled in multiple target platforms (like desktop, android, and wasm-js) transitively, creating duplicate class conflicts on the classpath. By specifying the concrete submodule coordinate `com.github.HereLiesAz.AzNavRail:aznavrail` and excluding the wasm-js target in `app/build.gradle.kts`, the build succeeds cleanly.

Fixes #768

---
*PR created automatically by Jules for task [13670023499106351365](https://jules.google.com/task/13670023499106351365) started by @HereLiesAz*