### PR TITLE
feat(android): pivot Android pipeline to Compose Multiplatform (Wasm preview + CI APK)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -116,6 +116,22 @@ extensions.configure<com.android.build.api.dsl.ApplicationExtension> {
         aidl = true
     }
 
+    androidResources {
+        // The bundled Android template ships .github/workflows/build-apk.yml
+        // (assets/templates/android). aapt's default asset filter contains ".*",
+        // which drops every dot-prefixed entry — the workflow would never reach
+        // the APK and scaffolded projects would have no CI. This is the default
+        // list minus ".*"; .git and friends stay excluded by their own entries.
+        ignoreAssetsPatterns.clear()
+        ignoreAssetsPatterns.addAll(
+            listOf(
+                "!.svn", "!.git", "!.gitattributes", "!.gitignore", "!.gitkeep",
+                "!.ds_store", "!*.scc", "<dir>_*", "!CVS", "!thumbs.db",
+                "!picasa.ini", "!*~",
+            )
+        )
+    }
+
     packaging {
         jniLibs.useLegacyPackaging = true
         resources {

--- a/app/src/main/assets/templates/android/.github/workflows/build-apk.yml
+++ b/app/src/main/assets/templates/android/.github/workflows/build-apk.yml
@@ -1,0 +1,30 @@
+name: Build APK
+
+on: push
+
+jobs:
+  build-apk:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Assemble debug APK
+        run: ./gradlew assembleDebug
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-debug
+          path: app/build/outputs/apk/debug/*.apk
+          if-no-files-found: error

--- a/app/src/main/assets/templates/android/app/build.gradle.kts
+++ b/app/src/main/assets/templates/android/app/build.gradle.kts
@@ -1,0 +1,68 @@
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    id("org.jetbrains.kotlin.multiplatform")
+    id("com.android.application")
+    id("org.jetbrains.kotlin.plugin.compose")
+    id("org.jetbrains.compose")
+}
+
+kotlin {
+    // Local preview target. IDEaz compiles commonMain + wasmJsMain to a .wasm
+    // binary on-device and hot-reloads it in the preview WebView; this target
+    // exists so the same sources also build a browser distribution via Gradle.
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs {
+        moduleName = "helloworld"
+        browser()
+        binaries.executable()
+    }
+
+    // Final output target. Compiled remotely by .github/workflows/build-apk.yml.
+    androidTarget {
+        compilations.all {
+            compileTaskProvider.configure {
+                compilerOptions {
+                    jvmTarget.set(JvmTarget.JVM_17)
+                }
+            }
+        }
+    }
+
+    sourceSets {
+        // All UI and logic lives here. Both targets consume it unchanged.
+        commonMain.dependencies {
+            implementation(compose.runtime)
+            implementation(compose.foundation)
+            implementation(compose.material3)
+            implementation(compose.ui)
+        }
+
+        // Platform source sets hold nothing but their entry point.
+        androidMain.dependencies {
+            implementation("androidx.activity:activity-compose:1.13.0")
+        }
+    }
+}
+
+android {
+    namespace = "com.example.helloworld"
+    compileSdk = 37
+
+    sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
+    sourceSets["main"].res.srcDirs("src/androidMain/res")
+
+    defaultConfig {
+        applicationId = "com.example.helloworld"
+        minSdk = 24
+        targetSdk = 37
+        versionCode = 1
+        versionName = "1.0"
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+}

--- a/app/src/main/assets/templates/android/app/src/androidMain/AndroidManifest.xml
+++ b/app/src/main/assets/templates/android/app/src/androidMain/AndroidManifest.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application
+        android:allowBackup="true"
+        android:label="helloworld"
+        android:supportsRtl="true"
+        android:theme="@android:style/Theme.Material.Light.NoActionBar">
+
+        <activity
+            android:name=".MainActivity"
+            android:exported="true"
+            android:configChanges="orientation|screenSize|screenLayout|keyboardHidden|uiMode">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/app/src/main/assets/templates/android/app/src/androidMain/kotlin/MainActivity.kt
+++ b/app/src/main/assets/templates/android/app/src/androidMain/kotlin/MainActivity.kt
@@ -1,0 +1,18 @@
+package com.example.helloworld
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+
+/**
+ * Native Android entry point: sets the content for the APK assembled by
+ * GitHub Actions. The UI itself lives in commonMain.
+ */
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            App()
+        }
+    }
+}

--- a/app/src/main/assets/templates/android/app/src/commonMain/kotlin/App.kt
+++ b/app/src/main/assets/templates/android/app/src/commonMain/kotlin/App.kt
@@ -1,0 +1,26 @@
+package com.example.helloworld
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+/**
+ * The application. Everything you write goes here (or in another commonMain
+ * file) — both the Wasm preview and the native Android APK render this exact
+ * composable.
+ */
+@Composable
+fun App() {
+    MaterialTheme {
+        Surface(modifier = Modifier.fillMaxSize()) {
+            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text("Hello, helloworld", style = MaterialTheme.typography.headlineMedium)
+            }
+        }
+    }
+}

--- a/app/src/main/assets/templates/android/app/src/wasmJsMain/kotlin/main.kt
+++ b/app/src/main/assets/templates/android/app/src/wasmJsMain/kotlin/main.kt
@@ -1,0 +1,16 @@
+package com.example.helloworld
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.window.ComposeViewport
+import kotlinx.browser.document
+
+/**
+ * Wasm entry point: mounts the Compose canvas into the DOM. This is the binary
+ * IDEaz compiles on-device and hot-reloads into the preview WebView.
+ */
+@OptIn(ExperimentalComposeUiApi::class)
+fun main() {
+    ComposeViewport(document.body!!) {
+        App()
+    }
+}

--- a/app/src/main/assets/templates/android/app/src/wasmJsMain/resources/index.html
+++ b/app/src/main/assets/templates/android/app/src/wasmJsMain/resources/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <title>helloworld</title>
+    <style>
+        html, body { margin: 0; padding: 0; height: 100%; overflow: hidden; }
+    </style>
+</head>
+<body>
+<script>
+    // Classic script + dynamic import: mounts the Compose canvas without a
+    // `type="module"` tag, which the IDEaz preview host rewrites.
+    import('./helloworld.js');
+</script>
+</body>
+</html>

--- a/app/src/main/assets/templates/android/build.gradle.kts
+++ b/app/src/main/assets/templates/android/build.gradle.kts
@@ -1,0 +1,6 @@
+plugins {
+    id("com.android.application") version "9.3.0" apply false
+    id("org.jetbrains.kotlin.multiplatform") version "2.4.10" apply false
+    id("org.jetbrains.kotlin.plugin.compose") version "2.4.10" apply false
+    id("org.jetbrains.compose") version "1.10.0" apply false
+}

--- a/app/src/main/assets/templates/android/gradle.properties
+++ b/app/src/main/assets/templates/android/gradle.properties
@@ -1,0 +1,8 @@
+org.gradle.jvmargs=-Xmx3072m -Dfile.encoding=UTF-8
+android.useAndroidX=true
+android.nonTransitiveRClass=true
+kotlin.code.style=official
+
+# Compose Multiplatform's Wasm target. IDEaz previews the wasmJs binary locally;
+# GitHub Actions assembles the androidTarget APK.
+org.jetbrains.compose.experimental.wasm.enabled=true

--- a/app/src/main/assets/templates/android/settings.gradle.kts
+++ b/app/src/main/assets/templates/android/settings.gradle.kts
@@ -1,0 +1,25 @@
+pluginManagement {
+    repositories {
+        google {
+            content {
+                includeGroupByRegex("com\\.android.*")
+                includeGroupByRegex("com\\.google.*")
+                includeGroupByRegex("androidx.*")
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+        maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        google()
+        mavenCentral()
+        maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
+    }
+}
+
+rootProject.name = "helloworld"
+include(":app")

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/models/WebConstants.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/models/WebConstants.kt
@@ -2,3 +2,13 @@ package com.hereliesaz.ideaz.models
 
 const val ACTION_AI_LOG = "com.hereliesaz.ideaz.AI_LOG"
 const val EXTRA_MESSAGE = "MESSAGE"
+
+/**
+ * Broadcast by [com.hereliesaz.ideaz.services.WasmCompilerService] after a
+ * successful Kotlin/Wasm compilation of an Android project. The preview
+ * WebView listens for it, clears its cache and re-mounts the new binary.
+ */
+const val ACTION_WASM_COMPILE_SUCCESS = "com.hereliesaz.ideaz.WASM_COMPILE_SUCCESS"
+
+/** Absolute path of the `filesDir/www` directory holding the Wasm output. */
+const val EXTRA_WWW_DIR = "WWW_DIR"

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/services/WasmCompilerService.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/services/WasmCompilerService.kt
@@ -1,0 +1,343 @@
+package com.hereliesaz.ideaz.services
+
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import com.hereliesaz.ideaz.models.ACTION_WASM_COMPILE_SUCCESS
+import com.hereliesaz.ideaz.models.EXTRA_WWW_DIR
+import dalvik.system.DexClassLoader
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.PrintStream
+
+/**
+ * On-device Kotlin/Wasm compiler for **Android** (Compose Multiplatform)
+ * projects. Replaces the old Zipline-era `JsCompilerService`: instead of
+ * bundling JS for a guest runtime, it drives the embedded Kotlin compiler with
+ * its WebAssembly backend and drops the result straight into `filesDir/www/`,
+ * where [com.hereliesaz.ideaz.ui.web.WebProjectHost] mounts it.
+ *
+ * Only the local preview — "the mirage" — is produced here. The real APK is
+ * assembled remotely by the template's `.github/workflows/build-apk.yml`.
+ *
+ * Inputs are the project's `commonMain` and `wasmJsMain` source sets; outputs
+ * are `<module>.wasm` (the binary), `<module>.js` (the loader script) and
+ * `index.html` (the canvas host). Compilation is a pure function of those
+ * sources — nothing else in the project tree is read.
+ *
+ * The compiler itself is not linked into IDEaz. It is loaded at runtime, by
+ * reflection, from the dexed `kotlin-compiler-embeddable` staged out of
+ * `assets/[COMPILER_ASSET_DIR]`, so a build without those assets degrades to a
+ * clean error instead of failing to link.
+ */
+class WasmCompilerService(private val context: Context) {
+
+    /**
+     * @param success   True when the compiler exited OK and a `.wasm` binary
+     *                  plus a loader script landed in [wwwDir].
+     * @param log       Full compiler output, ready for the build console.
+     * @param wwwDir    `filesDir/www` — the directory the WebView mounts.
+     */
+    data class Result(val success: Boolean, val log: String, val wwwDir: File)
+
+    /**
+     * Compiles [projectDir]'s common + wasmJs sources into `filesDir/www/`.
+     *
+     * On success a [ACTION_WASM_COMPILE_SUCCESS] broadcast is sent so the
+     * preview WebView hot-reloads the new binary.
+     *
+     * @param projectDir Root of the user's Android (KMP) project.
+     * @param moduleName Base name for the emitted `.wasm` / `.js` pair.
+     */
+    suspend fun compile(
+        projectDir: File,
+        moduleName: String = DEFAULT_MODULE_NAME,
+    ): Result = withContext(Dispatchers.IO) {
+        val wwwDir = wwwDir()
+        val log = StringBuilder()
+
+        val sources = collectSources(projectDir)
+        if (sources.isEmpty()) {
+            return@withContext Result(
+                false,
+                "[WASM] No sources found. Expected Kotlin files under " +
+                    "app/src/commonMain/kotlin and app/src/wasmJsMain/kotlin.\n",
+                wwwDir,
+            )
+        }
+        log.append("[WASM] Compiling ${sources.size} file(s) to WebAssembly...\n")
+
+        val compiler = loadCompiler()
+        if (compiler == null) {
+            return@withContext Result(
+                false,
+                log.append(
+                    "[WASM] Embedded Kotlin compiler unavailable: no dex archives in " +
+                        "assets/$COMPILER_ASSET_DIR/.\n",
+                ).toString(),
+                wwwDir,
+            )
+        }
+
+        // Wipe only the artifacts we own; user-authored files in www/ survive.
+        wwwDir.mkdirs()
+        listOf("$moduleName.wasm", "$moduleName.js", "$moduleName.mjs").forEach {
+            File(wwwDir, it).delete()
+        }
+
+        val args = compilerArgs(sources, stageKlibs(projectDir), wwwDir, moduleName)
+        log.append("[WASM] kotlinc ${args.joinToString(" ")}\n")
+
+        val (exitOk, compilerOutput) = invoke(compiler, args)
+        log.append(compilerOutput)
+        if (!exitOk) {
+            return@withContext Result(false, log.append("[WASM] Compilation failed.\n").toString(), wwwDir)
+        }
+
+        val binary = File(wwwDir, "$moduleName.wasm")
+        if (!binary.isFile) {
+            return@withContext Result(
+                false,
+                log.append("[WASM] Compiler exited OK but produced no $moduleName.wasm.\n").toString(),
+                wwwDir,
+            )
+        }
+
+        val loader = ensureLoaderScript(wwwDir, moduleName)
+        if (loader == null) {
+            return@withContext Result(
+                false,
+                log.append("[WASM] No loader script emitted next to $moduleName.wasm.\n").toString(),
+                wwwDir,
+            )
+        }
+
+        writeHostPage(wwwDir, loader.name)
+        log.append("[WASM] ${binary.name} (${binary.length()} bytes) + ${loader.name} -> ${wwwDir.absolutePath}\n")
+
+        context.sendBroadcast(
+            Intent(ACTION_WASM_COMPILE_SUCCESS).apply {
+                putExtra(EXTRA_WWW_DIR, wwwDir.absolutePath)
+                setPackage(context.packageName)
+            },
+        )
+
+        Result(true, log.toString(), wwwDir)
+    }
+
+    /** `filesDir/www` — the single mount point for compiled previews. */
+    fun wwwDir(): File = File(context.filesDir, WWW_DIR_NAME).apply { mkdirs() }
+
+    // --- Sources ------------------------------------------------------------
+
+    /**
+     * All `.kt` files under the project's `commonMain` and `wasmJsMain` source
+     * sets. The `app/src/…` layout of the bundled template is preferred; a
+     * root-level `src/…` layout is accepted as a fallback.
+     */
+    private fun collectSources(projectDir: File): List<String> =
+        SOURCE_SET_ROOTS
+            .map { File(projectDir, it) }
+            .filter { it.isDirectory }
+            .flatMap { root -> root.walkTopDown().filter { it.isFile && it.extension == "kt" }.toList() }
+            .map { it.absolutePath }
+            .distinct()
+
+    // --- Compiler plumbing --------------------------------------------------
+
+    /**
+     * Kotlin/Wasm CLI invocation. `-Xwasm` selects the WebAssembly backend and
+     * `-Xwasm-target=wasm-js` the browser (JS-interop) flavour; `-Xir-produce-js`
+     * makes the backend emit the loader script beside the binary.
+     */
+    private fun compilerArgs(
+        sources: List<String>,
+        klibs: List<File>,
+        outDir: File,
+        moduleName: String,
+    ): List<String> = buildList {
+        addAll(sources)
+        add("-Xwasm")
+        add("-Xwasm-target=wasm-js")
+        add("-Xir-produce-js")
+        add("-Xir-module-name=$moduleName")
+        add("-ir-output-dir")
+        add(outDir.absolutePath)
+        add("-ir-output-name")
+        add(moduleName)
+        if (klibs.isNotEmpty()) {
+            add("-libraries")
+            add(klibs.joinToString(File.pathSeparator) { it.absolutePath })
+        }
+    }
+
+    /**
+     * Klib dependencies handed to the compiler: the bundled Kotlin/Wasm stdlib
+     * and Compose Multiplatform klibs from `assets/[KLIB_ASSET_DIR]`, plus any
+     * the project ships in `libs/wasm/`.
+     */
+    private fun stageKlibs(projectDir: File): List<File> {
+        val staged = stageAssets(KLIB_ASSET_DIR, File(context.filesDir, KLIB_ASSET_DIR)) { it.endsWith(".klib") }
+        val projectKlibs = File(projectDir, PROJECT_KLIB_DIR)
+            .listFiles { f -> f.isFile && f.name.endsWith(".klib") }
+            ?.toList()
+            .orEmpty()
+        return staged + projectKlibs
+    }
+
+    /**
+     * Loads the embedded compiler's entry class out of the dexed archives in
+     * `assets/[COMPILER_ASSET_DIR]`. Returns `null` when nothing is bundled.
+     */
+    private fun loadCompiler(): Class<*>? {
+        val jars = stageAssets(COMPILER_ASSET_DIR, File(context.filesDir, COMPILER_ASSET_DIR)) {
+            it.endsWith(".jar") || it.endsWith(".dex")
+        }
+        if (jars.isEmpty()) return null
+
+        return try {
+            val optimizedDir = File(context.codeCacheDir, COMPILER_ASSET_DIR).apply { mkdirs() }
+            DexClassLoader(
+                jars.joinToString(File.pathSeparator) { it.absolutePath },
+                optimizedDir.absolutePath,
+                null,
+                javaClass.classLoader,
+            ).loadClass(COMPILER_ENTRY_CLASS)
+        } catch (e: Throwable) {
+            Log.w(TAG, "Could not load $COMPILER_ENTRY_CLASS", e)
+            null
+        }
+    }
+
+    /**
+     * Runs `CLICompiler.exec(PrintStream, String...)` reflectively and captures
+     * its diagnostics. Returns exit-OK plus the captured output.
+     */
+    private fun invoke(compiler: Class<*>, args: List<String>): Pair<Boolean, String> {
+        val buffer = ByteArrayOutputStream()
+        return try {
+            val instance = compiler.getDeclaredConstructor().newInstance()
+            val exec = compiler.getMethod("exec", PrintStream::class.java, Array<String>::class.java)
+            val exitCode = PrintStream(buffer, true, Charsets.UTF_8.name()).use { stream ->
+                exec.invoke(instance, stream, args.toTypedArray())
+            }
+            val ok = (exitCode as? Enum<*>)?.name == EXIT_CODE_OK
+            ok to buffer.toString(Charsets.UTF_8.name())
+        } catch (e: Throwable) {
+            Log.w(TAG, "Wasm compilation threw", e)
+            false to (buffer.toString(Charsets.UTF_8.name()) + "[WASM] ${e.message ?: e.javaClass.simpleName}\n")
+        }
+    }
+
+    // --- Output shaping -----------------------------------------------------
+
+    /**
+     * Guarantees a `<module>.js` loader exists beside the binary. The Wasm
+     * backend emits an ES module (`.mjs`); when that is what landed, a one-line
+     * `.js` re-export is written so the host page always has a stable entry
+     * point to import.
+     */
+    private fun ensureLoaderScript(wwwDir: File, moduleName: String): File? {
+        val js = File(wwwDir, "$moduleName.js")
+        if (js.isFile) return js
+
+        val emitted = wwwDir.listFiles()
+            ?.firstOrNull { it.name == "$moduleName.mjs" }
+            ?: wwwDir.listFiles()?.firstOrNull {
+                it.isFile && it.extension == "mjs" && !it.name.endsWith(UNINSTANTIATED_SUFFIX)
+            }
+            ?: return null
+
+        js.writeText("import './${emitted.name}';\n")
+        return js
+    }
+
+    /**
+     * Writes the canvas host page. The loader is pulled in with a dynamic
+     * `import()` from a classic script deliberately: a `<script type="module">`
+     * would be rewritten by the preview host's JSX runtime injection and never
+     * execute.
+     */
+    private fun writeHostPage(wwwDir: File, loaderName: String) {
+        File(wwwDir, "index.html").writeText(
+            """
+            <!doctype html>
+            <html lang="en">
+            <head>
+                <meta charset="utf-8">
+                <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+                <title>IDEaz Preview</title>
+                <style>html,body{margin:0;padding:0;height:100%;overflow:hidden;background:#fff}</style>
+            </head>
+            <body>
+            <script>
+                import('./$loaderName').catch(function (e) {
+                    document.body.textContent = 'Wasm load failed: ' + e;
+                });
+            </script>
+            </body>
+            </html>
+            """.trimIndent() + "\n",
+        )
+    }
+
+    // --- Asset staging ------------------------------------------------------
+
+    /**
+     * Copies `assets/[assetDir]` entries matching [accept] into [destDir],
+     * skipping files already staged at the same size. Returns the staged files.
+     */
+    private fun stageAssets(assetDir: String, destDir: File, accept: (String) -> Boolean): List<File> {
+        val names = try {
+            context.assets.list(assetDir)?.filter(accept).orEmpty()
+        } catch (e: Exception) {
+            Log.w(TAG, "Could not list assets/$assetDir", e)
+            return emptyList()
+        }
+        if (names.isEmpty()) return emptyList()
+
+        destDir.mkdirs()
+        return names.mapNotNull { name ->
+            val dest = File(destDir, name)
+            try {
+                context.assets.open("$assetDir/$name").use { input ->
+                    val bytes = input.readBytes()
+                    if (!dest.isFile || dest.length() != bytes.size.toLong()) {
+                        dest.writeBytes(bytes)
+                    }
+                }
+                dest
+            } catch (e: Exception) {
+                Log.w(TAG, "Could not stage $assetDir/$name", e)
+                null
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "WasmCompilerService"
+
+        /** Output directory, served at the WebView asset-loader origin root. */
+        const val WWW_DIR_NAME = "www"
+
+        /** Default base name of the emitted binary and loader. */
+        const val DEFAULT_MODULE_NAME = "app"
+
+        /** Source sets fed to the compiler, in the order they are resolved. */
+        private val SOURCE_SET_ROOTS = listOf(
+            "app/src/commonMain/kotlin",
+            "app/src/wasmJsMain/kotlin",
+            "src/commonMain/kotlin",
+            "src/wasmJsMain/kotlin",
+        )
+
+        private const val COMPILER_ASSET_DIR = "wasm-compiler"
+        private const val KLIB_ASSET_DIR = "wasm-klibs"
+        private const val PROJECT_KLIB_DIR = "libs/wasm"
+        private const val COMPILER_ENTRY_CLASS = "org.jetbrains.kotlin.cli.js.K2JSCompiler"
+        private const val EXIT_CODE_OK = "OK"
+        private const val UNINSTANTIATED_SUFFIX = ".uninstantiated.mjs"
+    }
+}

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/MainViewModel.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/MainViewModel.kt
@@ -269,7 +269,17 @@ class MainViewModel(
             application.sendBroadcast(intent)
             launchTargetApp(application)
         },
-        gitDelegate
+        gitDelegate,
+        { wwwDir ->
+            // Wasm Preview Ready Callback. The compiled binary lives in
+            // filesDir/www and is mounted at the asset-loader root; switching to
+            // "App View" puts WebProjectHost on screen, which then hot-reloads on
+            // every subsequent compile. The editor keeps pointing at the project
+            // sources — www holds build output, not editable files.
+            stateDelegate.setCurrentWebProjectDir(wwwDir)
+            stateDelegate.setCurrentWebUrl(WebProjectUrlUtils.localProjectRootUrl())
+            stateDelegate.setTargetAppVisible(true)
+        }
     )
 
     val repoDelegate = RepoDelegate(

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/delegates/BuildDelegate.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/delegates/BuildDelegate.kt
@@ -12,6 +12,7 @@ import com.hereliesaz.ideaz.buildlogic.PullRequestCoordinator
 import com.hereliesaz.ideaz.buildlogic.RemoteBuildManager
 import com.hereliesaz.ideaz.models.ProjectType
 import com.hereliesaz.ideaz.services.BuildService
+import com.hereliesaz.ideaz.services.WasmCompilerService
 import com.hereliesaz.ideaz.ui.SettingsViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -38,6 +39,8 @@ import java.io.File
  * @param onWebBuildSuccess Callback for Web project success (URL/Path).
  * @param onAndroidBuildSuccess Callback for Android project success (Triggers app launch).
  * @param gitDelegate Reference to GitDelegate for commit/push operations required for remote builds.
+ * @param onWasmPreviewReady Callback for a successful local Compose/Wasm compile of an
+ *        Android project, carrying the `filesDir/www` directory to mount in the preview.
  */
 class BuildDelegate(
     private val application: Application,
@@ -48,7 +51,8 @@ class BuildDelegate(
     private val onBuildFailure: (String) -> Unit,
     private val onWebBuildSuccess: (String) -> Unit,
     private val onAndroidBuildSuccess: () -> Unit,
-    private val gitDelegate: GitDelegate
+    private val gitDelegate: GitDelegate,
+    private val onWasmPreviewReady: (File) -> Unit = {}
 ) {
 
     // AIDL Interface to the remote service (used only to keep the foreground
@@ -195,13 +199,34 @@ class BuildDelegate(
                 return@launch
             }
 
-            // Android: remote build only.
+            // Android: the local preview is a Compose Multiplatform / Wasm
+            // mirage compiled on-device into filesDir/www; the native APK is
+            // assembled remotely by GitHub Actions. A failed preview compile is
+            // reported but never blocks the APK build.
+            compileWasmPreview(dir)
+
             if (token.isNullOrBlank() || user.isNullOrBlank()) {
                 pushLog("Error: Remote Build requires GitHub Token and User.\n")
                 handleFailure("Remote Build requires GitHub Token and User.")
                 return@launch
             }
             startRemoteBuild(dir, user, token)
+        }
+    }
+
+    /**
+     * Compiles the project's `commonMain` + `wasmJsMain` sources to WebAssembly
+     * for the local preview. [WasmCompilerService] broadcasts its own success
+     * event (which hot-reloads the preview WebView); this only surfaces the log
+     * and hands the output directory to the host so it becomes visible.
+     */
+    private suspend fun compileWasmPreview(dir: File) {
+        val result = WasmCompilerService(application).compile(dir)
+        pushLog(result.log)
+        if (result.success) {
+            onWasmPreviewReady(result.wwwDir)
+        } else {
+            onLog("[IDE] Wasm preview unavailable; continuing with the remote APK build.\n")
         }
     }
 

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/web/WebProjectHost.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/web/WebProjectHost.kt
@@ -24,7 +24,11 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.webkit.WebViewAssetLoader
 import com.hereliesaz.ideaz.models.ACTION_AI_LOG
+import com.hereliesaz.ideaz.models.ACTION_WASM_COMPILE_SUCCESS
 import com.hereliesaz.ideaz.models.EXTRA_MESSAGE
+import com.hereliesaz.ideaz.models.EXTRA_WWW_DIR
+import com.hereliesaz.ideaz.services.WasmCompilerService
+import java.io.File
 
 class IdeazJsInterface(private val context: Context) {
     @JavascriptInterface
@@ -38,7 +42,8 @@ class IdeazJsInterface(private val context: Context) {
 }
 
 /**
- * Composable WebView host for PWA and Web projects.
+ * Composable WebView host for PWA and Web projects, and for the Compose
+ * Multiplatform (Wasm) preview of Android projects.
  *
  * Content is served via [WebViewAssetLoader] from the virtual origin
  * `https://appassets.androidplatform.net/files/` mapped to [Context.filesDir].
@@ -57,6 +62,13 @@ class IdeazJsInterface(private val context: Context) {
  * @param hardReloadTrigger  Hard-reload signal. When this Long changes (and is > 0),
  *                           the WebView clears its disk/memory cache then reloads.
  *                           Driven by [StateDelegate.webHardReloadTrigger].
+ *
+ * Android projects are previewed through this same host: when
+ * [WasmCompilerService] finishes compiling a project it broadcasts
+ * [ACTION_WASM_COMPILE_SUCCESS], and this composable then mounts `filesDir/www`,
+ * clears the WebView cache (Wasm binaries are aggressively cached and would
+ * otherwise be re-instantiated from the stale copy) and hot-reloads the HTML
+ * host page.
  */
 @Composable
 fun WebProjectHost(
@@ -92,6 +104,12 @@ fun WebProjectHost(
     // long-lived) asset loader always serves the currently-previewed project
     // without recreating the WebView when the user switches projects.
     val projectDirState = remember { mutableStateOf(projectDir) }
+
+    // Set to `filesDir/www` once a Wasm compilation succeeds. While non-null it
+    // takes precedence over [projectDir] as the mounted root, so the preview
+    // shows the compiled binary rather than the project sources. Cleared when
+    // the user switches project or URL.
+    val wasmPreviewDir = remember { mutableStateOf<File?>(null) }
 
     // AssetLoader mounts the active project at the origin root
     // (https://appassets.androidplatform.net/) via WebProjectPathHandler, so
@@ -223,9 +241,25 @@ fun WebProjectHost(
     }
 
     // INSPECT_WEB broadcast: Phase 1B tap-to-select plumbing (already present).
+    // WASM_COMPILE_SUCCESS: the Compose/Wasm hot-reload path for Android projects.
     val receiver = remember {
         object : BroadcastReceiver() {
             override fun onReceive(context: Context?, intent: Intent?) {
+                if (intent?.action == ACTION_WASM_COMPILE_SUCCESS) {
+                    if (isWebViewDestroyed.value) return
+                    val dir = intent.getStringExtra(EXTRA_WWW_DIR)
+                        ?.let { File(it) }
+                        ?: File(webView.context.filesDir, WasmCompilerService.WWW_DIR_NAME)
+                    // Mount the compiler's output directory, drop every cached
+                    // copy of the previous binary, then re-enter the host page so
+                    // the fresh .wasm is instantiated.
+                    wasmPreviewDir.value = dir
+                    projectDirState.value = dir
+                    webView.clearCache(true)
+                    webView.loadUrl(WebProjectUrlUtils.localProjectRootUrl())
+                    return
+                }
+
                 if (intent?.action == "com.hereliesaz.ideaz.INSPECT_WEB") {
                     val x = intent.getFloatExtra("X", 0f)
                     val y = intent.getFloatExtra("Y", 0f)
@@ -252,7 +286,9 @@ fun WebProjectHost(
     }
 
     DisposableEffect(context) {
-        val filter = IntentFilter("com.hereliesaz.ideaz.INSPECT_WEB")
+        val filter = IntentFilter("com.hereliesaz.ideaz.INSPECT_WEB").apply {
+            addAction(ACTION_WASM_COMPILE_SUCCESS)
+        }
         context.registerReceiver(receiver, filter, Context.RECEIVER_NOT_EXPORTED)
         onDispose {
             context.unregisterReceiver(receiver)
@@ -262,7 +298,10 @@ fun WebProjectHost(
     // Load (and reload on project / URL change). Local projects load from the
     // asset-loader root; remote URLs load as-is. Keyed so unrelated recompositions
     // (e.g. selectMode toggles) don't trigger reloads.
+    // A project/URL switch invalidates any mounted Wasm preview — the compiled
+    // binary belongs to the project we just left.
     LaunchedEffect(projectDir, url) {
+        wasmPreviewDir.value = null
         projectDirState.value = projectDir
         if (!isWebViewDestroyed.value) {
             val target = if (projectDir != null) WebProjectUrlUtils.localProjectRootUrl() else url
@@ -273,7 +312,7 @@ fun WebProjectHost(
     AndroidView(
         modifier = modifier.fillMaxSize(),
         factory = { webView },
-        update = { projectDirState.value = projectDir }
+        update = { projectDirState.value = wasmPreviewDir.value ?: projectDir }
     )
 
     DisposableEffect(lifecycleOwner) {

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/utils/TemplateManager.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/utils/TemplateManager.kt
@@ -9,7 +9,7 @@ import java.io.IOException
 
 object TemplateManager {
 
-    // Must match the actual contents of app/src/main/assets/project/.
+    // Must match the actual contents of app/src/main/assets/templates/android/.
     // If you change the bundled template's package, update these too —
     // copyAssetFile substitutes them verbatim.
     private const val PLACEHOLDER_PACKAGE = "com.example.helloworld"
@@ -72,7 +72,7 @@ object TemplateManager {
             ProjectType.WEB -> "templates/web"
             ProjectType.PWA -> "templates/pwa"
             ProjectType.REACT -> "templates/react"
-            ProjectType.ANDROID -> "project"
+            ProjectType.ANDROID -> "templates/android"
             else -> return
         }
 
@@ -127,6 +127,11 @@ object TemplateManager {
         if (srcPackagePath == destPackagePath) return
 
         val possibleRoots = listOf(
+            // Kotlin Multiplatform layout (the Compose Multiplatform Android template).
+            "app/src/commonMain/kotlin",
+            "app/src/androidMain/kotlin",
+            "app/src/wasmJsMain/kotlin",
+            // Legacy single-target layouts.
             "android/app/src/main/kotlin",
             "android/app/src/main/java",
             "app/src/main/kotlin",


### PR DESCRIPTION
Architectural pivot for the **Android** project pipeline only. Python, React Native, Flutter and Web templates are untouched.

On-device Dex/AAPT2 compilation for local previews is abandoned. Local previews are now a Kotlin/Wasm binary rendered in the preview WebView; the native APK is compiled by GitHub Actions.

## Phase 1 — Android template (`app/src/main/assets/templates/android/`)

- `app/build.gradle.kts` moves to `org.jetbrains.kotlin.multiplatform` + `org.jetbrains.compose`, with exactly two targets: `wasmJs { browser() }` (local IDEaz preview) and `androidTarget()` (final output).
- Source sets restructured: all UI and logic default to `commonMain` (`App.kt`); the platform source sets hold only their entry points.
- `app/src/wasmJsMain/kotlin/main.kt` mounts the Compose canvas to the DOM via `ComposeViewport(document.body!!)`.
- `app/src/androidMain/kotlin/MainActivity.kt` sets the content for the native build (plus `AndroidManifest.xml`).
- Root `build.gradle.kts`, `settings.gradle.kts`, `gradle.properties` for a self-contained scaffold.
- `TemplateManager` now scaffolds `ProjectType.ANDROID` from this directory (the previous `assets/project` path did not exist) and knows the KMP source roots.

## Phase 2 — local Wasm compilation

- New `services/WasmCompilerService.kt`. There was no `JsCompilerService.kt` left to replace — an earlier triage pass had already deleted it along with the Zipline path — so this lands as its successor.
- Drives the embedded Kotlin compiler with the Wasm backend (`-Xwasm`, `-Xwasm-target=wasm-js`, `-Xir-produce-js`) over the project's `commonMain` + `wasmJsMain` sources.
- Output — `.wasm` binary, `.js` loader script and the canvas host page — is written directly to `filesDir/www/`, then `ACTION_WASM_COMPILE_SUCCESS` is broadcast.
- `WebProjectHost.kt` intercepts that event, mounts `filesDir/www`, clears the WebView cache and hot-reloads the HTML host so the new binary is instantiated. The host page boots the loader with a dynamic `import()` from a classic script; a `type="module"` tag would be rewritten by the existing JSX-runtime injection and never execute.

## Phase 3 — CI/CD

`templates/android/.github/workflows/build-apk.yml`: triggers on `push`, checks out the repo, sets up JDK 17 via `actions/setup-java`, sets up Gradle, runs `./gradlew assembleDebug`, and uploads the APK from `app/build/outputs/apk/debug/`.

## Supporting changes (required for the above to function)

- `app/build.gradle.kts`: `androidResources.ignoreAssetsPatterns` no longer contains `.*`. aapt's default asset filter drops every dot-prefixed entry, which would strip the template's `.github/` directory before it reached the APK — scaffolded projects would ship with no CI. `.git` and friends stay excluded by their own entries.
- `BuildDelegate` / `MainViewModel`: the Android build path now compiles the Wasm preview and surfaces it, so the compile → broadcast → hot-reload chain is live rather than dead code. A failed preview compile is logged and never blocks the remote APK build.

## Verification

A full `:app:compileDebugKotlin` was started in this container; it was still downloading the Android SDK and dependency graph from a cold cache when the work was committed, so the Kotlin changes have **not** been confirmed to compile here. Worth watching CI on this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_014o4B8EoxMUqqYVCEmkHy6N)_

## Summary by Sourcery

Pivot Android project scaffolding and preview pipeline to a Compose Multiplatform (Kotlin/Wasm + Android) setup with CI-driven APK builds and on-device Wasm previews in the existing WebView host.

New Features:
- Introduce an Android Compose Multiplatform template with shared commonMain UI, Android and Wasm entry points, and supporting Gradle/settings/manifest configuration.
- Add a GitHub Actions workflow to the Android template that builds and uploads a debug APK on each push.
- Provide an on-device Kotlin/Wasm compilation service that produces a WebAssembly preview for Android projects and broadcasts completion to the UI.

Enhancements:
- Extend WebProjectHost to mount and hot-reload the compiled Wasm preview directory for Android projects upon successful compilation events.
- Wire the Android build flow to trigger Wasm preview compilation, surface compiler logs, and update UI state when a preview is ready.
- Update TemplateManager to scaffold Android projects from the new templates/android layout and recognize KMP source roots.
- Relax the app’s Android asset ignore patterns so dot-prefixed CI config under the template’s .github directory is packaged into generated APKs.

Build:
- Add Android template Gradle configuration for Compose Multiplatform targets and enable experimental Wasm support via gradle.properties.

CI:
- Include a CI workflow in the Android template for assembling and exporting debug APKs on GitHub Actions.