### PR TITLE
Restrict selectable project types to PWA; gate unsupported targets in UI, docs, and tests

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/ideaz/models/ProjectType.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/models/ProjectType.kt
@@ -18,11 +18,15 @@ enum class ProjectType(val displayName: String) {
 
     companion object {
         /**
-         * The project types a user can actually create or select. OTHER and
-         * UNKNOWN are internal-only sentinels (an unsupported or not-yet-detected
-         * folder) and are never offered as a choice in the UI.
+         * Project types that have a complete, production-usable edit loop.
+         *
+         * Other types remain recognized so existing repositories can be detected
+         * without corrupting their metadata. They are deliberately not selectable
+         * until their target loops work end to end. Offering a project type whose
+         * App View ends in a placeholder is not a feature; it is a trap with
+         * branding.
          */
-        val selectable: List<ProjectType> = listOf(ANDROID, WEB, PWA, REACT)
+        val selectable: List<ProjectType> = listOf(PWA)
 
         fun fromString(value: String?): ProjectType {
             return values().find { it.name == value } ?: UNKNOWN

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/MainViewModel.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/MainViewModel.kt
@@ -913,6 +913,16 @@ class MainViewModel(
                 ProjectAnalyzer.detectProjectType(projectDir)
             }
             settingsViewModel.setProjectType(detectedType.name)
+            if (detectedType !in ProjectType.selectable) {
+                stateDelegate.setCurrentWebUrl(null)
+                stateDelegate.setTargetAppVisible(false)
+                logHandler.onOverlayLog(
+                    "${detectedType.displayName} projects are not available in this release. " +
+                        "The project was not modified."
+                )
+                onSuccess()
+                return@launch
+            }
             if (!detectedType.isWebLike()) {
                 withContext(Dispatchers.IO) { ProjectAnalyzer.detectPackageName(projectDir) }
                     ?.let { settingsViewModel.saveTargetPackageName(it) }
@@ -927,8 +937,8 @@ class MainViewModel(
                 aiDelegate.fetchSessionsForRepo("$user/$name")
             }
 
-            // Re-mount: clear any prior preview so launchTargetApp mounts THIS
-            // project, then actually show it (web → live preview, Android → host).
+            // Re-mount only after the release-scope gate above has accepted the
+            // detected project type.
             stateDelegate.setCurrentWebUrl(null)
             launchTargetApp(context)
             onSuccess()

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/ProjectScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/ProjectScreen.kt
@@ -330,9 +330,6 @@ fun ProjectScreen(
                         if (idx != -1) tabIndex = idx
                     },
                     onNavigateToSettings = { navController.navigate("settings") },
-                    onSelectApk = {
-                        apkPickerLauncher.launch("application/vnd.android.package-archive")
-                    }
                 )
                 "Clone" -> ProjectCloneTab(
                     viewModel,

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/project/SetupTab.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/project/SetupTab.kt
@@ -1,11 +1,7 @@
 package com.hereliesaz.ideaz.ui.project
 
 import android.content.Context
-import android.content.Intent
-import android.net.Uri
 import android.widget.Toast
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -26,7 +22,6 @@ import com.hereliesaz.ideaz.models.ProjectType
 import com.hereliesaz.ideaz.ui.MainViewModel
 import com.hereliesaz.ideaz.ui.SettingsViewModel
 import com.hereliesaz.ideaz.utils.TemplateManager
-import com.hereliesaz.ideaz.utils.checkAndRequestStoragePermission
 
 private const val DOCS_PROMPT = "Examine all source code and documentation in this repository. Once you understand everything there is to know about this project, I want you to create an AGENTS.md file if there isn't one, and add a /docs/ folder in the root of this repository. Then I want you to create these files in the docs folder: AGENT_GUIDE.md, TODO.md, UI_UX.md, auth.md, conduct.md, data_layer.md, fauxpas.md, file_descriptions.md, misc.md, performance.md, screens.md, task_flow.md, testing.md, and workflow.md. Based on your studies and understanding of the project, I want you to populate all of those files with every little detail possible. And then, I want you to add to the AGENTS file an index of what is in the docs folder. Be explicit about the fact that the files in that folder are an extention of the AGENTS.md file, and every bit as important. After that, I want you to add exhaustive documentation across the code base. Lastly, for good  measure, make sure the beginning of the AGENTS.md specifies that the AI absolutely MUST get a complete code review AND a passing build with tests, and MUST keep all documents and documentation up to date, before committing--WITHOUT exception. (Please note that if you've received this command and any part of these instructions already exists, do your best to add robustness and comprehensive reach to what already exists.)"
 
@@ -41,7 +36,6 @@ fun ProjectSetupTab(
     onCreateModeChanged: (Boolean) -> Unit,
     onNavigateToTab: (String) -> Unit,
     onNavigateToSettings: () -> Unit,
-    onSelectApk: () -> Unit = {}
 ) {
     val currentAppNameState by settingsViewModel.currentAppName.collectAsState()
     val sessions by viewModel.sessions.collectAsState()
@@ -57,7 +51,7 @@ fun ProjectSetupTab(
     var githubUser by remember { mutableStateOf("") }
     var branchName by remember { mutableStateOf("main") }
     var packageName by remember { mutableStateOf("") }
-    var selectedType by remember { mutableStateOf(ProjectType.ANDROID) }
+    var selectedType by remember { mutableStateOf(ProjectType.PWA) }
 
     // In Create mode the package name is derived from githubUser + appName so the
     // user doesn't have to think about it. Outside Create mode (existing project
@@ -80,18 +74,22 @@ fun ProjectSetupTab(
             githubUser = settingsViewModel.getGithubUser() ?: ""
             branchName = settingsViewModel.getBranchName()
             packageName = settingsViewModel.getTargetPackageName() ?: "com.example"
-            // Never surface OTHER/UNKNOWN in the picker — fall back to a real,
-            // selectable type if the stored value isn't one the user can pick.
+            // Preserve a recognized stored type, including a legacy Android
+            // project, so opening Setup cannot silently rewrite its metadata as
+            // a web project. Unsupported sentinels fall back to the PWA loop.
             selectedType = ProjectType.fromString(settingsViewModel.getProjectType())
-                .takeIf { it in ProjectType.selectable } ?: ProjectType.ANDROID
+                .takeUnless { it == ProjectType.OTHER || it == ProjectType.UNKNOWN }
+                ?: ProjectType.PWA
             if (appName.isNotBlank()) viewModel.fetchSessionsForRepo(appName)
         } else {
             if (appName == "IDEazProject") appName = ""
+            selectedType = ProjectType.PWA
         }
     }
 
     // Derived state for button enablement
-    val isReadyToCreate = initialPrompt.isNotBlank() && appName.isNotBlank()
+    val isReleaseSupportedType = selectedType in ProjectType.selectable
+    val isReadyToCreate = initialPrompt.isNotBlank() && appName.isNotBlank() && isReleaseSupportedType
 
     if (showTokenRequiredDialog) {
         AlertDialog(
@@ -113,21 +111,6 @@ fun ProjectSetupTab(
         )
     }
 
-    val apkPickerLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.OpenDocument()
-    ) { uri: Uri? ->
-        if (uri != null) {
-            val intent = Intent(Intent.ACTION_VIEW)
-            intent.setDataAndType(uri, "application/vnd.android.package-archive")
-            intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_GRANT_READ_URI_PERMISSION
-            try {
-                context.startActivity(intent)
-            } catch (e: Exception) {
-                Toast.makeText(context, "Could not open APK: ${e.message}", Toast.LENGTH_SHORT).show()
-            }
-        }
-    }
-
     LazyColumn(modifier = Modifier.fillMaxSize().padding(16.dp)) {
         item {
             Text("Project Actions", style = MaterialTheme.typography.headlineSmall, color = MaterialTheme.colorScheme.onBackground)
@@ -139,7 +122,10 @@ fun ProjectSetupTab(
             ) {
                 AzButton(
                     modifier = Modifier.weight(1f),
-                    onClick = { onCreateModeChanged(true) },
+                    onClick = {
+                        selectedType = ProjectType.PWA
+                        onCreateModeChanged(true)
+                    },
                     text = "Create",
                     shape = AzButtonShape.RECTANGLE,
                     enabled = !isBusy && !isCreateMode
@@ -245,6 +231,28 @@ fun ProjectSetupTab(
                 }
             }
 
+            if (!isReleaseSupportedType) {
+                Spacer(Modifier.height(8.dp))
+                Card(
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.errorContainer,
+                        contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                    ),
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        Text(
+                            text = "${selectedType.displayName} projects are not available in this release.",
+                            style = MaterialTheme.typography.titleSmall,
+                        )
+                        Text(
+                            text = "This project remains unchanged. PWA is the only production-ready target loop in this release.",
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                    }
+                }
+            }
+
             // --- CREATE MODE SPECIFIC FIELDS ---
             if (isCreateMode) {
                 Spacer(Modifier.height(8.dp))
@@ -323,7 +331,7 @@ fun ProjectSetupTab(
                     text = "Generate Project Docs (AI)",
                     shape = AzButtonShape.RECTANGLE,
                     modifier = Modifier.fillMaxWidth(),
-                    enabled = !isBusy
+                    enabled = !isBusy && isReleaseSupportedType
                 )
                 Text(
                     text = "Asks the AI to scaffold AGENTS.md and the docs/ folder for this repo. Sends a detailed prompt to the conversational chat.",
@@ -333,21 +341,6 @@ fun ProjectSetupTab(
                 )
 
                 Spacer(Modifier.height(8.dp))
-
-                if (selectedType == ProjectType.ANDROID) {
-                    AzButton(
-                        onClick = {
-                            checkAndRequestStoragePermission(context) {
-                                onSelectApk()
-                            }
-                        },
-                        text = "Pick APK",
-                        shape = AzButtonShape.RECTANGLE,
-                        modifier = Modifier.fillMaxWidth(),
-                        enabled = !isBusy
-                    )
-                    Spacer(Modifier.height(8.dp))
-                }
 
                 AzButton(
                     onClick = {
@@ -360,7 +353,8 @@ fun ProjectSetupTab(
                     text = "Save & Initialize",
                     shape = AzButtonShape.RECTANGLE,
                     modifier = Modifier.fillMaxWidth(),
-                    isLoading = isBusy
+                    enabled = !isBusy && isReleaseSupportedType,
+                    isLoading = isBusy,
                 )
             }
         }

--- a/app/src/test/java/com/hereliesaz/ideaz/models/ProjectTypeTemplateTest.kt
+++ b/app/src/test/java/com/hereliesaz/ideaz/models/ProjectTypeTemplateTest.kt
@@ -37,4 +37,15 @@ class ProjectTypeTemplateTest {
     fun fromString_roundTripsReact() {
         assertEquals(ProjectType.REACT, ProjectType.fromString("REACT"))
     }
+
+    @Test
+    fun selectable_excludesIncompleteAndInternalProjectTypes() {
+        assertEquals(
+            listOf(ProjectType.PWA),
+            ProjectType.selectable,
+        )
+        assertFalse(ProjectType.selectable.contains(ProjectType.ANDROID))
+        assertFalse(ProjectType.selectable.contains(ProjectType.WEB))
+        assertFalse(ProjectType.selectable.contains(ProjectType.REACT))
+    }
 }

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -8,6 +8,13 @@ abandoned-and-now-revived project. It has been superseded.
 
 When Phase 0 completes, this file will point to Phase 1's plan.
 
+**Production-readiness UX audit:** [`ux_userflow_audit.md`](ux_userflow_audit.md)
+
+## Production Readiness
+- Close all P0 release blockers in the UX user-flow audit before production release.
+- Execute and retain the device, accessibility, failure-injection, privacy, and store-policy evidence required by the audit.
+- Completed the first P0 mitigation: PWA is the sole selectable production target; other repository types remain detectable but creation, initialization, and unfinished App View mounting are release-gated until their loops are complete.
+
 ## Completed (Triage Phase)
 - Fixed build failure with Kotlin 2.4.10 and AGP 9.3.0 by excluding the incompatible `aznavrail-cmp-wasm-js` variant from the `libs.aznavrail` dependency.
 - Fixed build failure in `app/build.gradle.kts` caused by missing `java.util.Properties` and `java.io.FileInputStream` imports.

--- a/docs/UI_UX.md
+++ b/docs/UI_UX.md
@@ -94,3 +94,11 @@ A `fillMaxSize()` (or `fillMaxHeight()` / `fillMaxWidth()`) container is justifi
 Anything else is redundant. Do not introduce a global "rail title clearance" constant — if a screen's content collides with the rail title, that is an AzNavRail bug to file upstream, not a per-screen spacer to add.
 
 Bottom sheets mount via the `azBottomSheet` DSL on `AzNavHostScope`, never wrapped in `onscreen { }` — that gives the sheet the documented `zIndex(2f)` placement and the touch-targetable HIDDEN-detent strip at the screen bottom edge. See `docs/AZNAVRAIL_COMPLETE_GUIDE.md` §10.2.
+
+## Production Interaction Contract
+
+Every user-initiated operation must expose prerequisite validation and consequence before execution; named progress and cancellation policy during execution; a durable receipt on success; retained input, retry, and sanitized details on failure; and reconciliation after rotation, process death, connectivity loss, or upgrade. Accessibility and least-privilege disclosure apply at every stage. See [`ux_userflow_audit.md`](ux_userflow_audit.md) for the full flow inventory and release gates.
+
+### Current release scope
+
+Only PWA projects are selectable, matching the revival design's Phase 1 daily-driver scope. Other recognized repositories may be detected so their metadata is not rewritten, but their creation, initialization, and App View mounting remain disabled until their target loops pass end-to-end verification.

--- a/docs/file_descriptions.md
+++ b/docs/file_descriptions.md
@@ -51,7 +51,7 @@
 
 #### models/
 *   `Project.kt`: Project metadata model.
-*   `ProjectType.kt`: Enum for supported project types (currently `ANDROID`, `WEB`; Phase 1 adds `PWA` detection).
+*   `ProjectType.kt`: Project-type enum and production selection gate. PWA is the sole selectable target; other types remain detectable without being routed into incomplete loops.
 *   `IdeazProjectConfig.kt`: Configuration model.
 *   `ProjectHistory.kt`: History tracking model.
 
@@ -92,7 +92,7 @@
 *   `MainViewModel.kt`: Coordinator. Logic delegated to `ui/delegates/`.
 *   `SettingsViewModel.kt`: Manages user preferences.
 *   `MainScreen.kt`: The main Compose screen.
-*   `ProjectScreen.kt`: Project management UI (Setup / Load / Clone tabs).
+*   `ProjectScreen.kt`: Project management UI (Setup / Load / Clone tabs); delegates release-scope enforcement to Setup and `MainViewModel.loadProject`.
 *   `IdeBottomSheet.kt`: Console / chat bottom sheet.
 *   `IdeNavRail.kt`: Navigation component.
 *   `AiModels.kt`: AI model selection.
@@ -158,6 +158,7 @@
 *   `LogcatReader.kt`: System logcat reader.
 
 ## docs/
+*   `ux_userflow_audit.md`: Code-backed inventory and production-readiness assessment of every user-visible flow, with P0/P1/P2 findings, interaction standards, delivery order, and release evidence gates.
 See the index in `AGENTS.md`. The current source-of-truth is `docs/plans/2026-05-01-ideaz-revival-design.md`.
 
 ## website/

--- a/docs/screens.md
+++ b/docs/screens.md
@@ -37,4 +37,8 @@
 *   **Sections:** Build Configuration, Saved Settings & Credentials (PBKDF2-encrypted export/import), Signing Configuration, API Keys (Gemini, GitHub, Jules), AI Assignments, Permissions, Preferences/Theme/Logs/Updates/Debug.
 
 ## 7. Phase 2 Overlay (deferred until Phase 2)
-The original IDEaz overlay loop — `IdeazAccessibilityService` for node capture and `IdeazOverlayService` for the floating UI — remains wired but inert. It activates when Phase 2 lands the Android-target loop.
+The original IDEaz overlay loop — `IdeazAccessibilityService` for node capture and `IdeazOverlayService` for the floating UI — remains wired but inert. PWA is the sole selectable production target. Android stays detectable for existing-project metadata, but Setup does not offer Android creation or permit Android initialization, and loading an Android repository does not mount the placeholder App View. The gate remains until Phase 2 lands and verifies the Android-target loop.
+
+## 8. Production-readiness status
+
+The complete cross-screen flow inventory, risk assessment, and release gates live in [`ux_userflow_audit.md`](ux_userflow_audit.md). The PWA path is the only credible current daily-driver loop; the selectable Android path must remain release-gated until its Phase 2 placeholder is replaced by an end-to-end, tested experience.

--- a/docs/task_flow.md
+++ b/docs/task_flow.md
@@ -24,6 +24,8 @@
 
 ## 3. The Android Edit Loop (Phase 2)
 
+**Current release gate:** Android remains detectable so existing project metadata is preserved, but it is not offered for creation or initialization and loading it does not mount App View. The steps below remain the acceptance target for lifting that gate.
+
 1.  **Build target:** Tap "Build" → tagged release build via `release.yml`. `RemoteBuildManager` polls Releases. APK arrives → `PackageInstaller` sideloads → auto-launch.
 2.  **Inspect:** Target app full-screen on the device. IDEaz drops to a `TYPE_APPLICATION_OVERLAY`. User taps the floating IDEaz button → enters select mode.
 3.  **Capture:** `IdeazAccessibilityService` walks the active window's `AccessibilityNodeInfo` tree, captures the tapped node (class, resource ID, text, content description, bounds, parent chain) and a region screenshot.

--- a/docs/ux_userflow_audit.md
+++ b/docs/ux_userflow_audit.md
@@ -1,0 +1,127 @@
+# UX User-flow Production-readiness Audit
+
+**Audit date:** 2026-08-14<br>
+**Scope:** Every user-visible flow reachable from `MainActivity`, including project onboarding, PWA preview and selection, conversational editing, build/deploy, Git, files, settings, credentials, permissions, update/install, recovery, and the deferred Android-target path.<br>
+**Method:** Static walkthrough of the Compose navigation graph, rail actions, dialogs, state/delegate calls, manifest permissions, and existing automated tests. This is a code-backed heuristic assessment, not device usability research. No claim below is based only on older documentation.
+
+## 1. Verdict
+
+**Status: not production-ready.** The PWA happy path is credible and incomplete target loops are now gated, but the app still requests policy-sensitive permissions too broadly, lacks durable task recovery and consistent operation feedback, and has almost no automated UI-flow coverage. Shipping this as production software would turn users into unpaid chaos engineers.
+
+| Dimension | Score | Production bar | Assessment |
+|---|---:|---:|---|
+| Discoverability and onboarding | 2/5 | 4/5 | Setup is visible, but there is no guided readiness checklist, resumable onboarding, or clear product-mode choice. |
+| Task completion | 3/5 | 4/5 | The PWA path exists and incomplete target loops are now release-gated rather than presented as usable. |
+| Feedback and system status | 2/5 | 4/5 | Logs and progress exist, but many operations lack scoped success/failure, retry, cancellation, or final state. |
+| Error prevention and recovery | 2/5 | 4/5 | Some destructive actions confirm; Git, initialization, import, and long-running work remain inconsistent. |
+| Accessibility | 2/5 | 4/5 | Some semantics exist; decorative icons, text-only click targets, dynamic announcements, focus, and screen-reader flows are not systematically covered. |
+| Privacy, trust, and permissions | 1/5 | 5/5 | Accessibility, overlay, package visibility, installation, and all-files access need purpose-scoped disclosure and minimization. |
+| Responsive/device behavior | 2/5 | 4/5 | Landscape is passed to AzNavRail, but dense screens use fixed heights and button rows without compact-width strategy. |
+| Test confidence | 1/5 | 4/5 | Logic tests are broad; the only instrumentation test is the generated example and no end-to-end UX flow is automated. |
+
+**Overall: 1.9/5.** This is the arithmetic mean of the eight current dimension scores (15 ÷ 8 = 1.875, rounded to one decimal). Production remains blocked until all P0 items and the release evidence in §6 are complete.
+
+### Remediation status
+
+- **P0.1 mitigated:** PWA is now the only selectable production target. Other recognized types remain detectable for metadata integrity but cannot be created or initialized and are not mounted into an unfinished App View. Existing out-of-scope projects receive an explicit unavailable-release message and remain unmodified. The complete Android loop remains Phase 2 work.
+
+## 2. Flow inventory and assessment
+
+| ID | User goal and route | Entry → success | Current assessment | Readiness |
+|---|---|---|---|---|
+| F01 | First launch | Launcher → Project/Setup | A Gemini bridge dialog may appear, but no product tour, privacy primer, project-type decision, or persistent setup checklist exists. | Blocked |
+| F02 | Configure AI/GitHub | Project requirement dialog or Rail/Settings → save credentials/provider assignment | Settings contains the controls, but it is a long undifferentiated page. Save uses transient toasts; credential validity is not confirmed in place. | High risk |
+| F03 | Grant permissions | Action-time requirement → Android settings → return | Storage prompting is partly lazy, but return-state guidance is weak and permissions are not presented as a purpose/minimum-access sequence. | Blocked |
+| F04 | Create project | Setup/Create → fields → Create & Save | Mandatory prompt and GitHub token gates exist. App/user/branch/package validation, duplicate-name handling, rollback, and actionable failure recovery are not evident in the UI. | High risk |
+| F05 | Clone/fork project | Clone → repo or URL → Setup | Repo browsing and refresh exist. URL validation, progress cancellation, offline/empty/error distinctions, and retry are absent from the surface. | High risk |
+| F06 | Load local/external project | Load → project/directory → Setup | Empty state and delete confirmation exist. All-files access is requested before the system document picker despite SAF being designed for scoped access; import errors have no durable recovery surface. | Blocked |
+| F07 | Initialize project | Setup → Save & Initialize | The action can force-update and push CI files. There is no preflight summary, changed-file preview, explicit destructive-network confirmation, cancellation, or partial-success recovery. | Blocked |
+| F08 | Open PWA preview | Rail/Build or initialized project → WebProjectHost | Build opens console and validates the web target. Missing/invalid entry points need an actionable empty/error screen rather than log archaeology. | High risk |
+| F09 | Interact/select element | Rail mode toggle → tap/drag → contextual prompt | Core mechanics exist. Toggle labels and checked state are ambiguous, selection has no tutorial/escape affordance documented in the UI, and no accessibility alternative is proven. | High risk |
+| F10 | Prompt AI with context | Selection or Prompt → send → response/apply/reload | Conversation, attachments, loading, and contextual overlay exist. There is no visible cancel, retry, edit/resend, provider identity derived from the active provider, diff approval, undo, or failed-tool recovery. | Blocked |
+| F11 | Prompt without context | Console AI tab → Contextless Prompt | Same recovery gaps as F10; “Contextless” is implementation jargon, not a user goal. Draft persistence across navigation/process death is absent. | High risk |
+| F12 | Build | Rail/Build → progress/log → artifact/preview | A global progress dialog is non-dismissible and offers neither cancel nor backgrounding. Success/failure actions are scattered between dialogs, toasts, logs, and state. | Blocked |
+| F13 | Deploy PWA | Rail/Deploy → remote host | One-tap deploy has no confirmation/target/branch summary, no credential preflight, and no durable success receipt or rollback guidance. | Blocked |
+| F14 | Git commit/sync | Rail/Git → commit/fetch/pull/push/stash/switch | Basic operations and dirty-branch warning exist. Buttons are enabled without readiness state; risky pull/push/unstash and CI regeneration lack previews, conflict recovery, and operation-specific progress. | Blocked |
+| F15 | Browse/edit files | Rail/Files → directory → file → edit/save | Create/rename/delete validation and confirmations exist. Back navigation, unsaved-change protection, binary/large-file handling, search, save state, and error recovery need device validation and UI tests. | High risk |
+| F16 | Backup/import settings | Settings → encrypted export/import | Password dialogs exist. There is no strength guidance, confirm-password step, explicit contents summary, overwrite preview, recovery for wrong/corrupt files, or post-import restart/reload explanation. | High risk |
+| F17 | Configure signing | Settings → keystore import/save/reset | Controls exist, but destructive reset and invalid-keystore states need stronger confirmation, validation, and recovery. Secrets must never be echoed or logged. | Blocked |
+| F18 | Manage local models | Settings → On-device Models → download/select/delete | Availability and downloads exist. Storage/network preflight, pause/resume, checksum/integrity state, model-size consequences, and recoverable partial downloads require product evidence. | High risk |
+| F19 | Update IDEaz/install APK | Settings or artifact dialog → download/pick → Android installer → relaunch | Version comparison and downgrade warning exist. Unknown-sources denial, installer cancellation, signature mismatch, download integrity, post-install return, and launch failure need a coherent state machine. | Blocked |
+| F20 | Recover from failures | Any operation → logs/toast/dialog/reporting | Infrastructure reporting exists, but user-facing errors do not share a stable model with plain-language cause, retained details, retry, copy/export, and support route. | Blocked |
+| F21 | Android target loop | Project type Android → App View/build/install/select | Android is recognized for existing-repository integrity but release-gated from creation, initialization, and App View until Phase 2 completes the loop. | Mitigated |
+| F22 | Resume after interruption | Rotate, background, kill, reconnect → continue task | Local Compose state and transient toasts dominate several flows. Evidence of process-death restoration, durable queues, idempotency, and interrupted-operation reconciliation is absent. | Blocked |
+
+## 3. Prioritized findings
+
+### P0 — release blockers
+
+1. **Hide or complete the Android target path — mitigated.** PWA is now the sole selectable production target; Android is blocked from creation and initialization and never mounted into the unfinished App View. Keep this gate until Phase 2 passes its end-to-end acceptance tests.
+2. **Minimize privileged permissions and add just-in-time disclosure.** `MANAGE_EXTERNAL_STORAGE`, `QUERY_ALL_PACKAGES`, overlay, accessibility, package installation, media projection, and special-use foreground service declarations form a trust and store-policy minefield. Each must have a current user-facing purpose, narrow trigger, denial path, and documented necessity; remove anything not required by the shipped PWA scope.
+3. **Make initialization and CI regeneration reviewable.** Before force-pushing generated files, show repository, branch, exact affected paths, overwrite semantics, and a typed/explicit confirmation. Preserve a backup or offer rollback, and report partial completion.
+4. **Put AI edits behind inspect/approve/undo.** Show proposed file changes, tool progress, and validation result before reload/commit. Add cancel, retry, reject, and restore-to-pre-edit snapshot. AI without undo is merely automation wearing a knife.
+5. **Unify long-running operation state.** Create one durable model for queued/running/succeeded/failed/cancelled work across clone, create, initialize, AI, build, deploy, download, update, and Git. Every operation needs progress, safe cancellation where possible, retry, retained details, and process-restoration semantics.
+6. **Add production error UX.** Replace toast/log-only dead ends with an actionable error surface: plain-language summary, affected task, next step, retry, copy sanitized details, and report/support action. Never lose the failure when a screen changes.
+7. **Establish automated critical-flow coverage.** Add Compose/instrumentation journeys for first run, denied permissions, create/clone/load, PWA select/prompt/apply/undo, build success/failure, Git conflicts, file unsaved changes, credential import failure, update failure, rotation, and process recreation.
+8. **Define release accessibility gates.** Verify TalkBack traversal, keyboard/switch access, focus restoration after dialogs/navigation, 48dp targets, headings/labels, dynamic announcements, contrast, font scale to 200%, and reduced-motion behavior on supported API/device classes.
+
+### P1 — required before general availability
+
+1. Replace the monolithic Settings page with searchable grouped destinations and a “Setup status” summary.
+2. Validate project/repository URL, app name, branch, package name, token scopes, and provider credentials before beginning work; keep errors next to the field.
+3. Add explicit empty/loading/error/offline states to repo lists, project lists, branches, history, logs, preview, sessions, and model catalog.
+4. Add unsaved-draft and unsaved-file guards; persist prompt drafts and navigation-relevant task state across process death.
+5. Make Git actions state-aware. Disable impossible actions, display current branch/ahead/behind/conflict state, preview affected commits/files, and guide conflict resolution.
+6. Make deploy/build outcomes traceable: target, branch, commit SHA, start/end time, artifact/version, destination URL, and “view/copy/retry” actions.
+7. Replace fixed-height nested Git lists and rigid button rows with adaptive layouts tested at compact width, landscape, split screen, large text, and IME-visible states.
+8. Use provider-neutral chat labels. The chat currently labels every model response “Gemini” even though multiple providers can be assigned.
+9. Explain destructive and privacy-sensitive actions in user language, not implementation names such as “Contextless,” “Regenerate CI Files,” or raw service names.
+10. Add analytics that measure funnel completion and failure categories without collecting prompt, code, credential, file-path, or accessibility content.
+
+### P2 — hardening and polish
+
+1. Add first-run sample project and a replayable selection tutorial.
+2. Add recent projects, recent tasks, searchable logs, and clear notification deep links.
+3. Support comparison/rollback history for AI edit rounds.
+4. Add localization and RTL verification; do not ship user-facing strings embedded only in Kotlin.
+5. Run moderated usability sessions with novice and expert cohorts, followed by accessibility testing with disabled users.
+
+## 4. Cross-flow interaction standards
+
+Every production action must satisfy this contract:
+
+1. **Before:** explain consequence; validate prerequisites; identify target; confirm destructive/remote effects.
+2. **During:** show named task, determinate progress when measurable, current step, elapsed state, background behavior, and cancel policy.
+3. **Success:** state exactly what changed and where; expose the primary next action and a durable receipt.
+4. **Failure:** retain input; state cause without blame; expose retry/recovery; preserve sanitized diagnostics.
+5. **Interruption:** restore or reconcile state after rotation, process death, connectivity loss, provider timeout, and app upgrade.
+6. **Accessibility:** move focus predictably, announce state changes, support non-touch operation, preserve semantic order, and never encode status by color alone.
+7. **Privacy:** request the least privilege at the latest responsible moment and explain what is read, written, transmitted, retained, and revocable.
+
+## 5. Recommended delivery sequence
+
+1. **Scope the release:** ship PWA-only or complete Android; remove/gate every unreachable promise.
+2. **Trust pass:** permission minimization, disclosure, credentials, signing, data handling, and store-policy review.
+3. **Task-state foundation:** durable operation model and standardized progress/result/error components.
+4. **Core loop safety:** AI diff approval/undo, initialization preview/rollback, deploy/build receipts.
+5. **Recovery pass:** offline, denial, conflict, timeout, cancellation, process death, and update/install failures.
+6. **Accessibility/adaptive pass:** semantics, focus, announcements, large text, compact/landscape, keyboard/IME.
+7. **Evidence pass:** automated journeys, physical-device matrix, usability research, accessibility audit, dogfood telemetry review.
+
+## 6. Production release evidence
+
+Release approval requires artifacts, not optimism:
+
+- All P0 findings closed with linked acceptance tests.
+- `./gradlew build` passes from a clean checkout.
+- Compose/instrumentation suite passes on the minimum SDK, target SDK, current Android, phone, tablet/large screen, and at least one low-memory device profile.
+- Critical flows pass with network offline/slow/flapping, API 401/403/429/5xx, Git conflicts, disk full, permission denial/revocation, process death, and interrupted install/update.
+- TalkBack and switch/keyboard audit passes; font scale 200% and display-size extremes retain all primary actions.
+- Security/privacy review approves permission inventory, backup behavior, credential storage/export, logs, crash reports, WebView bridge, downloads, APK verification, and external intents.
+- Google Play policy review approves or eliminates restricted permissions before store submission.
+- No Sev-0/Sev-1 defects; every accepted lower-severity defect has owner, rationale, and expiry.
+- Funnel metrics meet targets defined before beta: onboarding completion, project activation, first successful prompt, edit acceptance/undo, build/deploy completion, crash-free users, and task-recovery success.
+
+## 7. Audit limitations
+
+This audit did not claim pixel-perfect, TalkBack, performance, network, or physical-device behavior because static code cannot prove those properties. The next audit must execute the journeys in §6, capture screen/video evidence, include accessibility tooling plus manual assistive-technology review, and record defect IDs against this flow inventory.

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
 build=92
 major=1
 minor=15
-patch=22
+patch=24


### PR DESCRIPTION
### Motivation
- Limit the shipped product scope to a single production-ready edit loop (PWA) and avoid exposing incomplete Android/Web/React target flows that would lead to dead-end UX or broken App View behavior.
- Preserve detection of other project types for existing-repository metadata integrity while preventing creation/initialization/mounting of unfinished target loops.

### Description
- Change `ProjectType.selectable` to only include `PWA` and update `ProjectType` documentation to explain the release gate.
- In `MainViewModel.loadProject` short-circuit loading when the detected type is not in `ProjectType.selectable` by clearing preview state, logging a user-visible message, and returning early to avoid routing into incomplete loops.
- Update `ProjectSetupTab` to default to `PWA`, change stored-type fallback logic so stored `OTHER`/`UNKNOWN` map to `PWA`, add a release-gate banner card for unsupported selected types, remove the APK picker and related storage/intent code, and disable create/generate/save actions when the selected type is not release-supported.
- Remove `onSelectApk` usage from `ProjectScreen`, add/adjust docs (`docs/*`) to record the PWA-only production scope and UX audit, and increment `version.properties` patch version.
- Add a unit test `selectable_excludesIncompleteAndInternalProjectTypes` to assert the new selectable list and update `ProjectTypeTemplateTest` accordingly.

### Testing
- Ran unit tests with `./gradlew test`, including the updated `ProjectTypeTemplateTest`, and they passed.
- Performed a full build with `./gradlew build` to verify compilation and the version bump, and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7f0677d9b0832fa4be2de9bfa44289)

## Summary by Sourcery

Restrict project creation and initialization to PWA as the sole production-supported target and gate other detected project types from mounting incomplete edit loops.

New Features:
- Add a release-scope gate that prevents loading and previewing projects whose detected type is not in the selectable production set.
- Show a banner in the project setup UI when an unsupported project type is selected, clarifying that only PWA is available in this release.

Enhancements:
- Default new and existing project setup flows to PWA and remap unsupported stored project-type sentinels to the PWA loop while preserving metadata for legacy Android projects.
- Disable create, AI doc generation, and Save & Initialize actions in the setup screen when the selected project type is not release-supported.
- Document the PWA-only production scope, UX user-flow audit, and release gates across UI/UX, TODO, screens, task_flow, and file description docs, including a new ux_userflow_audit.md audit file.

Tests:
- Add a unit test to assert that only PWA is included in the selectable project types and that incomplete or internal types are excluded.
- Update ProjectTypeTemplateTest to cover the new selectable project-type constraints.

Chores:
- Increment the patch version in version.properties to reflect the release-gated PWA-only scope.