### PR TITLE
Fix Kotlin compile errors in worker and settings dialog

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ai/local/LocalModelDownloadWorker.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ai/local/LocalModelDownloadWorker.kt
@@ -1,5 +1,6 @@
 package com.hereliesaz.ideaz.ai.local
 
+import android.app.Application
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
@@ -50,7 +51,7 @@ class LocalModelDownloadWorker(
         if (model.systemManaged) return failure("System-managed models are not downloadable")
 
         setForeground(foregroundInfo(model.name, downloaded = 0L, total = model.approxSizeBytes))
-        val settings = SettingsViewModel(applicationContext)
+        val settings = SettingsViewModel(applicationContext as Application)
         val token = settings.getApiKey(SettingsViewModel.KEY_HF_API_KEY)?.takeIf { it.isNotBlank() }
 
         return try {

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/SettingsScreen.kt
@@ -1098,7 +1098,7 @@ fun PasswordDialog(
                 },
                 hint = "Enter Password",
                 secret = true,
-                onSubmit = submit,
+                onSubmit = { submit() },
             )
             error?.let { Text(it, color = MaterialTheme.colorScheme.error) }
         },


### PR DESCRIPTION
## Summary
- Fix `LocalModelDownloadWorker.kt:53` — cast `applicationContext` (`Context`) to `Application` when constructing `SettingsViewModel`, which requires an `Application`.
- Fix `SettingsScreen.kt:1101` — `PasswordDialog`'s `AzTextBox` expects `onSubmit: (String) -> Unit`, but was passed the local `submit: () -> Unit` lambda directly; wrap it in `{ submit() }`.

Both errors were failing `:app:compileDebugKotlin` and `:app:compileReleaseKotlin` in CI.

## Test plan
- [ ] CI Kotlin compile (`compileDebugKotlin` / `compileReleaseKotlin`) passes
- [x] Manually verified fixes match existing patterns in the codebase (`MainApplication.kt` constructs `SettingsViewModel` from an `Application`; other `AzTextBox` call sites use `onSubmit = { text -> ... }`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdR1Kn5HNmKjEwrv82RZ31)_

## Summary by Sourcery

Resolve Kotlin compilation issues in the local model download worker and settings password dialog.

Bug Fixes:
- Correct SettingsViewModel initialization in LocalModelDownloadWorker by providing an Application context.
- Align PasswordDialog text field onSubmit handler with the expected String-parameter callback to prevent type mismatches.