### PR TITLE
Fix all workflows broken by nonexistent run-antigravity-cli action

### DIFF
--- a/.github/workflows/antigravity-branch-manager.yml
+++ b/.github/workflows/antigravity-branch-manager.yml
@@ -19,7 +19,7 @@ name: Antigravity Branch Manager
 #   4. Removed the auto-merge and auto-delete-branch behaviour. The agent now
 #      proposes; humans dispose. Auto-merging on a `pull_request_review` event
 #      where the review can come from outside is too dangerous.
-#   5. TODO: pin run-antigravity-cli to a commit SHA before relying on this in CI.
+#   5. TODO: pin run-gemini-cli to a commit SHA before relying on this in CI.
 
 on:
   push:
@@ -49,7 +49,7 @@ jobs:
           fetch-depth: 0
 
       - name: 'Run Antigravity CLI'
-        uses: 'google-github-actions/run-antigravity-cli@v0'
+        uses: 'google-github-actions/run-gemini-cli@v0'
         env:
           BRANCH: ${{ github.ref_name }}
           REPOSITORY: ${{ github.repository }}
@@ -60,12 +60,12 @@ jobs:
           REVIEW_BODY: ${{ github.event.review.body }}
           REVIEWER: ${{ github.event.review.user.login }}
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
-          ANTIGRAVITY_CLI_TRUST_WORKSPACE: true
+          GEMINI_TRUST_WORKSPACE: true
         with:
           gcp_project_id: ""
-          antigravity_api_key: '${{ secrets.ANTIGRAVITY_API_KEY }}'
+          gemini_api_key: '${{ secrets.ANTIGRAVITY_API_KEY }}'
           google_api_key: '${{ secrets.ANTIGRAVITY_API_KEY }}'
-          antigravity_cli_version: '0.24.0'
+          gemini_cli_version: '0.24.0'
           workflow_name: 'antigravity-branch-manager'
           use_gemini_code_assist: false
           use_vertex_ai: false

--- a/.github/workflows/antigravity-invoke.yml
+++ b/.github/workflows/antigravity-invoke.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: 'Run Antigravity CLI'
         id: 'run_antigravity'
-        uses: 'google-github-actions/run-antigravity-cli@v0' # ratchet:exclude
+        uses: 'google-github-actions/run-gemini-cli@v0' # ratchet:exclude
         env:
           TITLE: '${{ github.event.pull_request.title || github.event.issue.title }}'
           DESCRIPTION: '${{ github.event.pull_request.body || github.event.issue.body }}'
@@ -55,16 +55,16 @@ jobs:
           ISSUE_NUMBER: '${{ github.event.pull_request.number || github.event.issue.number }}'
           REPOSITORY: '${{ github.repository }}'
           ADDITIONAL_CONTEXT: '${{ inputs.additional_context }}'
-          ANTIGRAVITY_CLI_TRUST_WORKSPACE: true
+          GEMINI_TRUST_WORKSPACE: true
         with:
           google_api_key: '${{ secrets.ANTIGRAVITY_API_KEY }}'
           gcp_project_id: ""
           gcp_location: '${{ vars.GOOGLE_CLOUD_LOCATION }}'
           gcp_service_account: '${{ vars.SERVICE_ACCOUNT_EMAIL }}'
-          antigravity_api_key: '${{ secrets.ANTIGRAVITY_API_KEY }}'
-          antigravity_cli_version: '0.24.0'
-          antigravity_debug: '${{ fromJSON(vars.DEBUG || vars.ACTIONS_STEP_DEBUG || false) }}'
-          antigravity_model: '${{ vars.ANTIGRAVITY_MODEL }}'
+          gemini_api_key: '${{ secrets.ANTIGRAVITY_API_KEY }}'
+          gemini_cli_version: '0.24.0'
+          gemini_debug: '${{ fromJSON(vars.DEBUG || vars.ACTIONS_STEP_DEBUG || false) }}'
+          gemini_model: '${{ vars.ANTIGRAVITY_MODEL }}'
           use_gemini_code_assist: false
           use_vertex_ai: false
           upload_artifacts: '${{ vars.UPLOAD_ARTIFACTS }}'

--- a/.github/workflows/antigravity-issue-handler.yml
+++ b/.github/workflows/antigravity-issue-handler.yml
@@ -49,7 +49,7 @@ jobs:
           persist-credentials: false
 
       - name: 'Run Antigravity CLI (read-only triage mode)'
-        uses: 'google-github-actions/run-antigravity-cli@v0'
+        uses: 'google-github-actions/run-gemini-cli@v0'
         env:
           # Untrusted inputs delivered out-of-band. The prompt below references
           # these by name so they cannot break out of the YAML template.
@@ -59,12 +59,12 @@ jobs:
           ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
           REPOSITORY: ${{ github.repository }}
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
-          ANTIGRAVITY_CLI_TRUST_WORKSPACE: true
+          GEMINI_TRUST_WORKSPACE: true
         with:
           gcp_project_id: ""
-          antigravity_api_key: '${{ secrets.ANTIGRAVITY_API_KEY }}'
+          gemini_api_key: '${{ secrets.ANTIGRAVITY_API_KEY }}'
           google_api_key: '${{ secrets.ANTIGRAVITY_API_KEY }}'
-          antigravity_cli_version: '0.24.0'
+          gemini_cli_version: '0.24.0'
           workflow_name: 'antigravity-issue-handler'
           use_gemini_code_assist: false
           use_vertex_ai: false

--- a/.github/workflows/antigravity-review.yml
+++ b/.github/workflows/antigravity-review.yml
@@ -42,7 +42,7 @@ jobs:
         uses: 'actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0' # ratchet:actions/checkout@v5
 
       - name: 'Run Antigravity pull request review'
-        uses: 'google-github-actions/run-antigravity-cli@v0' # ratchet:exclude
+        uses: 'google-github-actions/run-gemini-cli@v0' # ratchet:exclude
         id: 'antigravity_pr_review'
         env:
           GITHUB_TOKEN: '${{ steps.mint_identity_token.outputs.token || secrets.GH_TOKEN || github.token }}'
@@ -51,16 +51,16 @@ jobs:
           PULL_REQUEST_NUMBER: '${{ github.event.pull_request.number || github.event.issue.number }}'
           REPOSITORY: '${{ github.repository }}'
           ADDITIONAL_CONTEXT: '${{ inputs.additional_context }}'
-          ANTIGRAVITY_CLI_TRUST_WORKSPACE: true
+          GEMINI_TRUST_WORKSPACE: true
         with:
           google_api_key: '${{ secrets.ANTIGRAVITY_API_KEY }}'
           gcp_project_id: ""
           gcp_location: '${{ vars.GOOGLE_CLOUD_LOCATION }}'
           gcp_service_account: '${{ vars.SERVICE_ACCOUNT_EMAIL }}'
-          antigravity_api_key: '${{ secrets.ANTIGRAVITY_API_KEY }}'
-          antigravity_cli_version: '0.24.0'
-          antigravity_debug: '${{ fromJSON(vars.DEBUG || vars.ACTIONS_STEP_DEBUG || false) }}'
-          antigravity_model: '${{ vars.ANTIGRAVITY_MODEL }}'
+          gemini_api_key: '${{ secrets.ANTIGRAVITY_API_KEY }}'
+          gemini_cli_version: '0.24.0'
+          gemini_debug: '${{ fromJSON(vars.DEBUG || vars.ACTIONS_STEP_DEBUG || false) }}'
+          gemini_model: '${{ vars.ANTIGRAVITY_MODEL }}'
           use_gemini_code_assist: false
           use_vertex_ai: false
           upload_artifacts: '${{ vars.UPLOAD_ARTIFACTS }}'

--- a/.github/workflows/antigravity-scheduled-triage.yml
+++ b/.github/workflows/antigravity-scheduled-triage.yml
@@ -108,24 +108,24 @@ jobs:
       - name: 'Run Antigravity scheduled issue triage'
         if: |-
           fromJSON(steps.find_issues.outputs.issues_to_triage).length > 0
-        uses: 'google-github-actions/run-antigravity-cli@v0' # ratchet:exclude
+        uses: 'google-github-actions/run-gemini-cli@v0' # ratchet:exclude
         id: 'antigravity_scheduled_triage'
         env:
           GITHUB_TOKEN: '${{ steps.mint_identity_token.outputs.token || secrets.GH_TOKEN || github.token }}'
           ISSUES_TO_TRIAGE: '${{ steps.find_issues.outputs.issues_to_triage }}'
           REPOSITORY: '${{ github.repository }}'
           AVAILABLE_LABELS: '${{ steps.get_labels.outputs.available_labels }}'
-          ANTIGRAVITY_CLI_TRUST_WORKSPACE: true
+          GEMINI_TRUST_WORKSPACE: true
         with:
           google_api_key: '${{ secrets.ANTIGRAVITY_API_KEY }}'
           gcp_project_id: ""
           gcp_location: '${{ vars.GOOGLE_CLOUD_LOCATION }}'
           gcp_service_account: '${{ vars.SERVICE_ACCOUNT_EMAIL }}'
           gcp_workload_identity_provider: '${{ vars.GCP_WIF_PROVIDER }}'
-          antigravity_api_key: '${{ secrets.ANTIGRAVITY_API_KEY }}'
-          antigravity_cli_version: '0.24.0'
-          antigravity_debug: '${{ fromJSON(vars.DEBUG || vars.ACTIONS_STEP_DEBUG || false) }}'
-          antigravity_model: '${{ vars.ANTIGRAVITY_MODEL }}'
+          gemini_api_key: '${{ secrets.ANTIGRAVITY_API_KEY }}'
+          gemini_cli_version: '0.24.0'
+          gemini_debug: '${{ fromJSON(vars.DEBUG || vars.ACTIONS_STEP_DEBUG || false) }}'
+          gemini_model: '${{ vars.ANTIGRAVITY_MODEL }}'
           # Force AI Studio (API Key) auth when using ANTIGRAVITY_API_KEY
           use_gemini_code_assist: false
           use_vertex_ai: false

--- a/.github/workflows/antigravity-triage.yml
+++ b/.github/workflows/antigravity-triage.yml
@@ -60,23 +60,23 @@ jobs:
             core.setOutput('available_labels', labels.join(', '));
 
       - name: 'Run Antigravity issue triage'
-        uses: 'google-github-actions/run-antigravity-cli@v0' # ratchet:exclude
+        uses: 'google-github-actions/run-gemini-cli@v0' # ratchet:exclude
         id: 'antigravity_triage'
         env:
           GITHUB_TOKEN: '${{ steps.mint_identity_token.outputs.token || secrets.GH_TOKEN || github.token }}'
           ISSUE_TITLE: '${{ github.event.issue.title }}'
           ISSUE_BODY: '${{ github.event.issue.body }}'
           AVAILABLE_LABELS: '${{ steps.get_labels.outputs.available_labels }}'
-          ANTIGRAVITY_CLI_TRUST_WORKSPACE: true
+          GEMINI_TRUST_WORKSPACE: true
         with:
           google_api_key: '${{ secrets.ANTIGRAVITY_API_KEY }}'
           gcp_project_id: ""
           gcp_location: '${{ vars.GOOGLE_CLOUD_LOCATION }}'
           gcp_service_account: '${{ vars.SERVICE_ACCOUNT_EMAIL }}'
-          antigravity_api_key: '${{ secrets.ANTIGRAVITY_API_KEY }}'
-          antigravity_cli_version: '0.24.0'
-          antigravity_debug: '${{ fromJSON(vars.DEBUG || vars.ACTIONS_STEP_DEBUG || false) }}'
-          antigravity_model: '${{ vars.ANTIGRAVITY_MODEL }}'
+          gemini_api_key: '${{ secrets.ANTIGRAVITY_API_KEY }}'
+          gemini_cli_version: '0.24.0'
+          gemini_debug: '${{ fromJSON(vars.DEBUG || vars.ACTIONS_STEP_DEBUG || false) }}'
+          gemini_model: '${{ vars.ANTIGRAVITY_MODEL }}'
           use_gemini_code_assist: false
           use_vertex_ai: false
           upload_artifacts: '${{ vars.UPLOAD_ARTIFACTS }}'

--- a/.github/workflows/pr-contribution-guidelines-review.yml
+++ b/.github/workflows/pr-contribution-guidelines-review.yml
@@ -103,19 +103,19 @@ jobs:
 
       - name: Validate PR against CONTRIBUTING.md
         id: antigravity
-        uses: google-github-actions/run-antigravity-cli@v0
+        uses: google-github-actions/run-gemini-cli@v0
         env:
           # gh CLI inside Antigravity
           GH_TOKEN: ${{ steps.generate_token.outputs.token || secrets.GH_TOKEN }}
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token || secrets.GH_TOKEN }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           REPOSITORY: ${{ github.repository }}
-          ANTIGRAVITY_CLI_TRUST_WORKSPACE: true
+          GEMINI_TRUST_WORKSPACE: true
         with:
-          antigravity_api_key: ${{ secrets.ANTIGRAVITY_API_KEY }}
+          gemini_api_key: ${{ secrets.ANTIGRAVITY_API_KEY }}
           google_api_key: ${{ secrets.ANTIGRAVITY_API_KEY }}
           gcp_project_id: ""
-          antigravity_cli_version: '0.24.0'
+          gemini_cli_version: '0.24.0'
           use_gemini_code_assist: false
           use_vertex_ai: false
           settings: |

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/utils/ProjectConfigManager.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/utils/ProjectConfigManager.kt
@@ -174,7 +174,7 @@ name: Antigravity Issue Handler
 #   2. Issue title/body delivered as ENV VARS, never interpolated into prompt.
 #   3. MCP write tools removed. Read + comment only.
 #   4. Permissions: contents:read + issues:write only.
-#   5. run-antigravity-cli upgrades require explicit review to reduce supply-chain risk.
+#   5. run-gemini-cli upgrades require explicit review to reduce supply-chain risk.
 
 on:
   issues:
@@ -201,7 +201,7 @@ jobs:
           persist-credentials: false
 
       - name: 'Run Antigravity CLI (read-only triage mode)'
-        uses: 'google-github-actions/run-antigravity-cli@v0'
+        uses: 'google-github-actions/run-gemini-cli@v0'
         env:
           ISSUE_TITLE: ${'$'}{{ github.event.issue.title }}
           ISSUE_BODY: ${'$'}{{ github.event.issue.body }}
@@ -209,12 +209,12 @@ jobs:
           ISSUE_AUTHOR: ${'$'}{{ github.event.issue.user.login }}
           REPOSITORY: ${'$'}{{ github.repository }}
           GITHUB_TOKEN: ${'$'}{{ secrets.GH_TOKEN || github.token }}
-          ANTIGRAVITY_CLI_TRUST_WORKSPACE: true
+          GEMINI_TRUST_WORKSPACE: true
         with:
-          antigravity_api_key: '${'$'}{{ secrets.ANTIGRAVITY_API_KEY }}'
+          gemini_api_key: '${'$'}{{ secrets.ANTIGRAVITY_API_KEY }}'
           google_api_key: '${'$'}{{ secrets.ANTIGRAVITY_API_KEY }}'
           gcp_project_id: ""
-          antigravity_cli_version: '0.24.0'
+          gemini_cli_version: '0.24.0'
           workflow_name: 'antigravity-issue-handler'
           use_gemini_code_assist: false
           use_vertex_ai: false
@@ -309,7 +309,7 @@ jobs:
           fetch-depth: 0
 
       - name: 'Run Antigravity CLI'
-        uses: 'google-github-actions/run-antigravity-cli@v0'
+        uses: 'google-github-actions/run-gemini-cli@v0'
         env:
           BRANCH: ${'$'}{{ github.ref_name }}
           REPOSITORY: ${'$'}{{ github.repository }}
@@ -320,12 +320,12 @@ jobs:
           REVIEW_BODY: ${'$'}{{ github.event.review.body }}
           REVIEWER: ${'$'}{{ github.event.review.user.login }}
           GITHUB_TOKEN: ${'$'}{{ secrets.GH_TOKEN || github.token }}
-          ANTIGRAVITY_CLI_TRUST_WORKSPACE: true
+          GEMINI_TRUST_WORKSPACE: true
         with:
-          antigravity_api_key: '${'$'}{{ secrets.ANTIGRAVITY_API_KEY }}'
+          gemini_api_key: '${'$'}{{ secrets.ANTIGRAVITY_API_KEY }}'
           google_api_key: '${'$'}{{ secrets.ANTIGRAVITY_API_KEY }}'
           gcp_project_id: ""
-          antigravity_cli_version: '0.24.0'
+          gemini_cli_version: '0.24.0'
           workflow_name: 'antigravity-branch-manager'
           use_gemini_code_assist: false
           use_vertex_ai: false


### PR DESCRIPTION
## Summary

Every `antigravity-*` automation workflow (and `pr-contribution-guidelines-review.yml`'s `validate-pr` job) has been failing since the `Generalize repository workflows` commit (`c1ccce4`) on Aug 14, with:

```
##[error]Unable to resolve action google-github-actions/run-antigravity-cli, repository not found
```

**Root cause:** that commit bulk-renamed `gemini-*` workflows to `antigravity-*`, and in the process swapped the real, working action `google-github-actions/run-gemini-cli@v0` for `google-github-actions/run-antigravity-cli@v0` — an action that was never published. (Confirmed via web search: no such repo exists under `google-github-actions`; Google's Gemini CLI → Antigravity CLI rebrand didn't carry the GitHub Action along with it.)

**Fix:**
- Revert `uses:` back to `google-github-actions/run-gemini-cli@v0` in all 7 affected workflow files.
- Revert the action's `with:` input keys to its real schema: `gemini_api_key` / `gemini_cli_version` / `gemini_debug` / `gemini_model` (the nonexistent `antigravity_*` keys were silently ignored even when the action did resolve). Repo secrets/vars (`ANTIGRAVITY_API_KEY`, `ANTIGRAVITY_MODEL`) are left as-is since those are presumably already configured under the new names.
- Fix the workspace-trust env var to `GEMINI_TRUST_WORKSPACE` — per `run-gemini-cli`'s security-advisory trust-model update, this is the only variable name the action currently honors; both the old `GEMINI_CLI_TRUST_WORKSPACE` and the renamed `ANTIGRAVITY_CLI_TRUST_WORKSPACE` are no-ops.

**Files:**
- `.github/workflows/antigravity-invoke.yml`
- `.github/workflows/antigravity-branch-manager.yml`
- `.github/workflows/antigravity-review.yml`
- `.github/workflows/antigravity-triage.yml`
- `.github/workflows/antigravity-scheduled-triage.yml`
- `.github/workflows/antigravity-issue-handler.yml`
- `.github/workflows/pr-contribution-guidelines-review.yml`
- `app/src/main/kotlin/com/hereliesaz/ideaz/utils/ProjectConfigManager.kt` — this file embeds two of the same workflow templates (`antigravity-issue-handler.yml`, `antigravity-branch-manager.yml`) as Kotlin string literals that get written into every project this app scaffolds, so the same bug was being baked into every generated project's CI. Fixed there too.

## Test plan
- [x] All 7 edited `.yml` files parse as valid YAML (`yaml.safe_load`)
- [ ] CI runs the `antigravity-*` / `validate-pr` workflows successfully against this PR (action resolves, no more "repository not found")
- [x] `ProjectConfigManager.kt` edits are string-literal-only; no Kotlin syntax change

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdR1Kn5HNmKjEwrv82RZ31)_

## Summary by Sourcery

Restore all antigravity GitHub workflows and embedded templates to use the published Gemini CLI GitHub Action and correct configuration so automation runs successfully.

Bug Fixes:
- Fix antigravity-* and contribution guidelines validation workflows failing due to referencing a nonexistent run-antigravity-cli GitHub Action.
- Correct CLI input parameters and workspace trust environment variable names in workflows to match the actual run-gemini-cli action schema.
- Update scaffolded project workflow templates in ProjectConfigManager to use the valid Gemini CLI action and configuration, preventing broken CI in generated projects.

Enhancements:
- Standardize comments and TODOs in workflows and templates to reference the Gemini CLI action accurately.

CI:
- Align antigravity-* GitHub workflows with the supported run-gemini-cli action, including updated trust workspace env var and Gemini-specific inputs.