### PR TITLE
Fix telemetry ENOENT crash and stray YAML key in antigravity workflows

### DIFF
--- a/.github/workflows/antigravity-branch-manager.yml
+++ b/.github/workflows/antigravity-branch-manager.yml
@@ -48,6 +48,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: 'Ensure telemetry directory exists'
+        run: 'mkdir -p .antigravity'
+
       - name: 'Run Antigravity CLI'
         uses: 'google-github-actions/run-gemini-cli@v0'
         env:
@@ -133,4 +136,4 @@ jobs:
                  instead.
               4. Stop. Do not merge. Do not close. Do not delete branches.
 
-          IMPORTANT: Do not include the string 'EOF' in your output.
+            IMPORTANT: Do not include the string 'EOF' in your output.

--- a/.github/workflows/antigravity-invoke.yml
+++ b/.github/workflows/antigravity-invoke.yml
@@ -43,6 +43,9 @@ jobs:
           token: '${{ steps.mint_identity_token.outputs.token || secrets.GH_TOKEN || github.token }}'
           fetch-depth: 0
 
+      - name: 'Ensure telemetry directory exists'
+        run: 'mkdir -p .antigravity'
+
       - name: 'Run Antigravity CLI'
         id: 'run_antigravity'
         uses: 'google-github-actions/run-gemini-cli@v0' # ratchet:exclude

--- a/.github/workflows/antigravity-issue-handler.yml
+++ b/.github/workflows/antigravity-issue-handler.yml
@@ -48,6 +48,9 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: 'Ensure telemetry directory exists'
+        run: 'mkdir -p .antigravity'
+
       - name: 'Run Antigravity CLI (read-only triage mode)'
         uses: 'google-github-actions/run-gemini-cli@v0'
         env:

--- a/.github/workflows/antigravity-review.yml
+++ b/.github/workflows/antigravity-review.yml
@@ -41,6 +41,9 @@ jobs:
       - name: 'Checkout repository'
         uses: 'actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0' # ratchet:actions/checkout@v5
 
+      - name: 'Ensure telemetry directory exists'
+        run: 'mkdir -p .antigravity'
+
       - name: 'Run Antigravity pull request review'
         uses: 'google-github-actions/run-gemini-cli@v0' # ratchet:exclude
         id: 'antigravity_pr_review'

--- a/.github/workflows/antigravity-scheduled-triage.yml
+++ b/.github/workflows/antigravity-scheduled-triage.yml
@@ -105,6 +105,11 @@ jobs:
             }
             core.setOutput('issues_to_triage', JSON.stringify(issues));
 
+      - name: 'Ensure telemetry directory exists'
+        if: |-
+          fromJSON(steps.find_issues.outputs.issues_to_triage).length > 0
+        run: 'mkdir -p .antigravity'
+
       - name: 'Run Antigravity scheduled issue triage'
         if: |-
           fromJSON(steps.find_issues.outputs.issues_to_triage).length > 0

--- a/.github/workflows/antigravity-triage.yml
+++ b/.github/workflows/antigravity-triage.yml
@@ -59,6 +59,9 @@ jobs:
             }
             core.setOutput('available_labels', labels.join(', '));
 
+      - name: 'Ensure telemetry directory exists'
+        run: 'mkdir -p .antigravity'
+
       - name: 'Run Antigravity issue triage'
         uses: 'google-github-actions/run-gemini-cli@v0' # ratchet:exclude
         id: 'antigravity_triage'

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/utils/ProjectConfigManager.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/utils/ProjectConfigManager.kt
@@ -200,6 +200,9 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: 'Ensure telemetry directory exists'
+        run: 'mkdir -p .antigravity'
+
       - name: 'Run Antigravity CLI (read-only triage mode)'
         uses: 'google-github-actions/run-gemini-cli@v0'
         env:
@@ -307,6 +310,9 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+
+      - name: 'Ensure telemetry directory exists'
+        run: 'mkdir -p .antigravity'
 
       - name: 'Run Antigravity CLI'
         uses: 'google-github-actions/run-gemini-cli@v0'


### PR DESCRIPTION
## Summary

Follow-up to #803. Once the action reference actually resolved, two more bugs surfaced from the real `run-gemini-cli` execution logs on that PR:

1. **Telemetry ENOENT crash.** Every workflow whose `settings` JSON points local telemetry at `.antigravity/telemetry.log` crashed the CLI step with:
   ```
   Error: ENOENT: no such file or directory, open '.antigravity/telemetry.log'
   ```
   because nothing ever creates that directory. Confirmed in the `manage_branch` and `invoke` job logs on #803 — both exited 1 immediately after the `## Run Antigravity CLI` step started. Fix: add a `mkdir -p .antigravity` step right before every such CLI invocation, in the workflow YAML and in the matching embedded templates in `ProjectConfigManager.kt` (which writes these same workflows into every project the app scaffolds).

2. **Stray YAML key from bad indentation.** In `antigravity-branch-manager.yml`, the trailing prompt line:
   ```yaml
             4. Stop. Do not merge. Do not close. Do not delete branches.

         IMPORTANT: Do not include the string 'EOF' in your output.
   ```
   was indented one level short of the rest of the `prompt: |` block, so YAML parsed `IMPORTANT` as a sibling key under `with:` instead of trailing prompt text. Visible in the Action logs as:
   ```
   ##[warning]Unexpected input(s) 'IMPORTANT', valid inputs are [...]
   ```
   Fixed the indentation so it stays part of the prompt. (Checked all other workflow files and the embedded Kotlin templates for the same pattern — none of the others had this bug.)

## Not fixed here — needs repo owner action

`validate-pr` (in `pr-contribution-guidelines-review.yml`) failed on #803 with a Gemini auth error:
```
Please set an Auth method in your /home/runner/.gemini/settings.json or specify one of the
following environment variables before running: GEMINI_API_KEY, GOOGLE_GENAI_USE_VERTEXAI, GOOGLE_GENAI_USE_GCA
```
The job logs show `GEMINI_API_KEY` and `GOOGLE_API_KEY` both empty at run time, even though the workflow correctly wires `secrets.ANTIGRAVITY_API_KEY` into those inputs. This means the `ANTIGRAVITY_API_KEY` repository secret itself is empty or unset in GitHub — not something fixable from a code change. Someone with repo admin access needs to set it under **Settings → Secrets and variables → Actions**.

## Test plan
- [x] All edited `.yml` files parse as valid YAML with no stray keys under any `with:` block
- [ ] CI runs the `antigravity-*` workflows against this PR and gets past the telemetry step (will still fail on auth until the secret above is set)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdR1Kn5HNmKjEwrv82RZ31)_

## Summary by Sourcery

Ensure Antigravity GitHub workflows create the telemetry directory before running the CLI and fix a mis-indented prompt line that was being parsed as a stray YAML key.

Bug Fixes:
- Prevent ENOENT crashes in Antigravity workflows by creating the .antigravity telemetry directory before CLI execution.
- Correct YAML indentation in the branch manager workflow so the IMPORTANT line remains part of the prompt instead of a separate input key.

Enhancements:
- Keep embedded Antigravity workflow templates in ProjectConfigManager.kt consistent with the fixed telemetry setup used in the repo workflows.

Build:
- Adjust multiple Antigravity workflow YAMLs to add pre-CLI telemetry directory creation, including conditional handling in the scheduled triage workflow.