### PR TITLE
Point antigravity workflows at a GEMINI_API_KEY secret

### DIFF
--- a/.github/workflows/antigravity-branch-manager.yml
+++ b/.github/workflows/antigravity-branch-manager.yml
@@ -66,8 +66,8 @@ jobs:
           GEMINI_TRUST_WORKSPACE: true
         with:
           gcp_project_id: ""
-          gemini_api_key: '${{ secrets.ANTIGRAVITY_API_KEY }}'
-          google_api_key: '${{ secrets.ANTIGRAVITY_API_KEY }}'
+          gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
+          google_api_key: '${{ secrets.GEMINI_API_KEY }}'
           gemini_cli_version: '0.24.0'
           workflow_name: 'antigravity-branch-manager'
           use_gemini_code_assist: false

--- a/.github/workflows/antigravity-invoke.yml
+++ b/.github/workflows/antigravity-invoke.yml
@@ -60,11 +60,11 @@ jobs:
           ADDITIONAL_CONTEXT: '${{ inputs.additional_context }}'
           GEMINI_TRUST_WORKSPACE: true
         with:
-          google_api_key: '${{ secrets.ANTIGRAVITY_API_KEY }}'
+          google_api_key: '${{ secrets.GEMINI_API_KEY }}'
           gcp_project_id: ""
           gcp_location: '${{ vars.GOOGLE_CLOUD_LOCATION }}'
           gcp_service_account: '${{ vars.SERVICE_ACCOUNT_EMAIL }}'
-          gemini_api_key: '${{ secrets.ANTIGRAVITY_API_KEY }}'
+          gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
           gemini_cli_version: '0.24.0'
           gemini_debug: '${{ fromJSON(vars.DEBUG || vars.ACTIONS_STEP_DEBUG || false) }}'
           gemini_model: '${{ vars.ANTIGRAVITY_MODEL }}'

--- a/.github/workflows/antigravity-issue-handler.yml
+++ b/.github/workflows/antigravity-issue-handler.yml
@@ -65,8 +65,8 @@ jobs:
           GEMINI_TRUST_WORKSPACE: true
         with:
           gcp_project_id: ""
-          gemini_api_key: '${{ secrets.ANTIGRAVITY_API_KEY }}'
-          google_api_key: '${{ secrets.ANTIGRAVITY_API_KEY }}'
+          gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
+          google_api_key: '${{ secrets.GEMINI_API_KEY }}'
           gemini_cli_version: '0.24.0'
           workflow_name: 'antigravity-issue-handler'
           use_gemini_code_assist: false

--- a/.github/workflows/antigravity-review.yml
+++ b/.github/workflows/antigravity-review.yml
@@ -56,11 +56,11 @@ jobs:
           ADDITIONAL_CONTEXT: '${{ inputs.additional_context }}'
           GEMINI_TRUST_WORKSPACE: true
         with:
-          google_api_key: '${{ secrets.ANTIGRAVITY_API_KEY }}'
+          google_api_key: '${{ secrets.GEMINI_API_KEY }}'
           gcp_project_id: ""
           gcp_location: '${{ vars.GOOGLE_CLOUD_LOCATION }}'
           gcp_service_account: '${{ vars.SERVICE_ACCOUNT_EMAIL }}'
-          gemini_api_key: '${{ secrets.ANTIGRAVITY_API_KEY }}'
+          gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
           gemini_cli_version: '0.24.0'
           gemini_debug: '${{ fromJSON(vars.DEBUG || vars.ACTIONS_STEP_DEBUG || false) }}'
           gemini_model: '${{ vars.ANTIGRAVITY_MODEL }}'

--- a/.github/workflows/antigravity-scheduled-triage.yml
+++ b/.github/workflows/antigravity-scheduled-triage.yml
@@ -122,12 +122,12 @@ jobs:
           AVAILABLE_LABELS: '${{ steps.get_labels.outputs.available_labels }}'
           GEMINI_TRUST_WORKSPACE: true
         with:
-          google_api_key: '${{ secrets.ANTIGRAVITY_API_KEY }}'
+          google_api_key: '${{ secrets.GEMINI_API_KEY }}'
           gcp_project_id: ""
           gcp_location: '${{ vars.GOOGLE_CLOUD_LOCATION }}'
           gcp_service_account: '${{ vars.SERVICE_ACCOUNT_EMAIL }}'
           gcp_workload_identity_provider: '${{ vars.GCP_WIF_PROVIDER }}'
-          gemini_api_key: '${{ secrets.ANTIGRAVITY_API_KEY }}'
+          gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
           gemini_cli_version: '0.24.0'
           gemini_debug: '${{ fromJSON(vars.DEBUG || vars.ACTIONS_STEP_DEBUG || false) }}'
           gemini_model: '${{ vars.ANTIGRAVITY_MODEL }}'

--- a/.github/workflows/antigravity-triage.yml
+++ b/.github/workflows/antigravity-triage.yml
@@ -72,11 +72,11 @@ jobs:
           AVAILABLE_LABELS: '${{ steps.get_labels.outputs.available_labels }}'
           GEMINI_TRUST_WORKSPACE: true
         with:
-          google_api_key: '${{ secrets.ANTIGRAVITY_API_KEY }}'
+          google_api_key: '${{ secrets.GEMINI_API_KEY }}'
           gcp_project_id: ""
           gcp_location: '${{ vars.GOOGLE_CLOUD_LOCATION }}'
           gcp_service_account: '${{ vars.SERVICE_ACCOUNT_EMAIL }}'
-          gemini_api_key: '${{ secrets.ANTIGRAVITY_API_KEY }}'
+          gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
           gemini_cli_version: '0.24.0'
           gemini_debug: '${{ fromJSON(vars.DEBUG || vars.ACTIONS_STEP_DEBUG || false) }}'
           gemini_model: '${{ vars.ANTIGRAVITY_MODEL }}'

--- a/.github/workflows/pr-contribution-guidelines-review.yml
+++ b/.github/workflows/pr-contribution-guidelines-review.yml
@@ -112,8 +112,8 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           GEMINI_TRUST_WORKSPACE: true
         with:
-          gemini_api_key: ${{ secrets.ANTIGRAVITY_API_KEY }}
-          google_api_key: ${{ secrets.ANTIGRAVITY_API_KEY }}
+          gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
+          google_api_key: ${{ secrets.GEMINI_API_KEY }}
           gcp_project_id: ""
           gemini_cli_version: '0.24.0'
           use_gemini_code_assist: false

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/utils/ProjectConfigManager.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/utils/ProjectConfigManager.kt
@@ -214,8 +214,8 @@ jobs:
           GITHUB_TOKEN: ${'$'}{{ secrets.GH_TOKEN || github.token }}
           GEMINI_TRUST_WORKSPACE: true
         with:
-          gemini_api_key: '${'$'}{{ secrets.ANTIGRAVITY_API_KEY }}'
-          google_api_key: '${'$'}{{ secrets.ANTIGRAVITY_API_KEY }}'
+          gemini_api_key: '${'$'}{{ secrets.GEMINI_API_KEY }}'
+          google_api_key: '${'$'}{{ secrets.GEMINI_API_KEY }}'
           gcp_project_id: ""
           gemini_cli_version: '0.24.0'
           workflow_name: 'antigravity-issue-handler'
@@ -328,8 +328,8 @@ jobs:
           GITHUB_TOKEN: ${'$'}{{ secrets.GH_TOKEN || github.token }}
           GEMINI_TRUST_WORKSPACE: true
         with:
-          gemini_api_key: '${'$'}{{ secrets.ANTIGRAVITY_API_KEY }}'
-          google_api_key: '${'$'}{{ secrets.ANTIGRAVITY_API_KEY }}'
+          gemini_api_key: '${'$'}{{ secrets.GEMINI_API_KEY }}'
+          google_api_key: '${'$'}{{ secrets.GEMINI_API_KEY }}'
           gcp_project_id: ""
           gemini_cli_version: '0.24.0'
           workflow_name: 'antigravity-branch-manager'


### PR DESCRIPTION
## Summary

Follow-up to #803/#804. CI logs on both of those PRs showed the Gemini CLI step failing auth with `GEMINI_API_KEY`/`GOOGLE_API_KEY` both empty at runtime, even though the workflow correctly wired `secrets.ANTIGRAVITY_API_KEY` into those inputs — meaning that secret is empty/unset in the repo.

Per instruction, switch the `gemini_api_key`/`google_api_key` inputs to reference `secrets.GEMINI_API_KEY` instead, across:

- `.github/workflows/antigravity-invoke.yml`
- `.github/workflows/antigravity-review.yml`
- `.github/workflows/antigravity-triage.yml`
- `.github/workflows/antigravity-scheduled-triage.yml`
- `.github/workflows/antigravity-branch-manager.yml`
- `.github/workflows/antigravity-issue-handler.yml`
- `.github/workflows/pr-contribution-guidelines-review.yml`
- `app/src/main/kotlin/com/hereliesaz/ideaz/utils/ProjectConfigManager.kt` (embedded templates written into every scaffolded project)

Left `vars.ANTIGRAVITY_MODEL` and other `ANTIGRAVITY_*` variable references untouched — only the API key changed.

**Note:** this still requires a `GEMINI_API_KEY` secret to actually be set under **Settings → Secrets and variables → Actions** for the bots to authenticate; I can't set secret values myself.

## Test plan
- [x] All edited `.yml` files parse as valid YAML
- [ ] CI's antigravity-* jobs authenticate successfully once the `GEMINI_API_KEY` secret is set

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdR1Kn5HNmKjEwrv82RZ31)_

## Summary by Sourcery

Update antigravity GitHub Actions workflows and project scaffolding templates to use the GEMINI_API_KEY secret for Gemini CLI authentication instead of ANTIGRAVITY_API_KEY.

Enhancements:
- Align scaffolded project workflow templates with the repository’s updated Gemini authentication secret configuration.

CI:
- Switch all antigravity-related workflows to reference secrets.GEMINI_API_KEY for gemini_api_key and google_api_key inputs.