### PR TITLE
Fix dependency-submission workflow and bump Netty/Jackson security pins

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -26,7 +26,6 @@ concurrency:
 
 jobs:
   dependency-submission:
-    if: ${{ hashFiles('**/gradlew') != '' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -190,20 +190,32 @@ configurations.all {
         }
         eachDependency {
             when {
-                // Jackson arrives as core/databind/annotations + datatype modules and a
-                // BOM; pin the whole family to a patched 2.18.x. Use 2.18.7 — the java8
-                // datatype modules (jackson-datatype-jdk8/jsr310) stop there, while
-                // core/databind go to 2.18.8, so 2.18.7 is the latest version every
-                // module publishes (and still > the 2.18.6 fix).
+                // jackson-core/jackson-databind/jackson-annotations all publish under this
+                // group. Pin to 2.18.9: jackson-core needs >= 2.18.8 (GHSA-r7wm-3cxj-wff9,
+                // async parser maxNumberLength bypass) and jackson-databind needs >= 2.18.9
+                // (CVE-2026-54515, case-insensitive deserialization bypass; CVE-2026-54512,
+                // PolymorphicTypeValidator bypass needs >= 2.18.8).
+                requested.group == "com.fasterxml.jackson.core" ->
+                    useVersion("2.18.9")
+                // Everything else in the family (datatype/module/dataformat modules, the
+                // BOM) — the java8 datatype modules (jackson-datatype-jdk8/jsr310) stop
+                // publishing at 2.18.7, so pin the rest of the family there. None of the
+                // open CVEs are in these modules; they're compatible with core/databind
+                // 2.18.9 since Jackson keeps API/behavior stable across a minor line.
                 requested.group.startsWith("com.fasterxml.jackson") ->
                     useVersion("2.18.7")
                 // Netty arrives as ~11 modules via grpc-netty (unit-test only). Pin the
                 // io.netty group to the latest patched 4.1.x — staying off 4.2.x, which
                 // grpc-netty does not support. (netty-tcnative tracks a separate scheme.)
+                // 4.1.137.Final (Aug 2026) rolls up the fixes from 4.1.135/.136/.137,
+                // covering the CONTINUATION flood, MadeYouReset, IPv6 subnet bypass,
+                // SNI/hostname-verification, request-smuggling, and decompression-bomb
+                // CVEs Dependabot flagged across netty-codec-http(2)/netty-handler/
+                // netty-common.
                 requested.group == "io.netty" &&
                     requested.name.startsWith("netty-") &&
                     !requested.name.startsWith("netty-tcnative") ->
-                    useVersion("4.1.134.Final")
+                    useVersion("4.1.137.Final")
             }
         }
     }


### PR DESCRIPTION
## Summary

Investigated the 53 open Dependabot alerts (pasted from the Security tab). Root cause: `.github/workflows/dependency-submission.yml` has been failing on **every single run since it was added** (100% failure rate on `master` and every branch — confirmed via workflow-run history), with:

```
Unrecognized function: 'hashFiles'. Located at position 1 within expression: hashFiles('**/gradlew') != ''
```

`hashFiles()` isn't available in a job-level `if:` — that expression is evaluated before any runner/checkout exists, so there's nothing to hash yet. The whole workflow run fails immediately with zero jobs.

Because this workflow never successfully ran, GitHub never received an up-to-date release-runtime dependency graph, so Dependabot has had no way to auto-dismiss alerts — **even for CVEs `app/build.gradle.kts` already pins a patched version for**. I confirmed the current pins for BouncyCastle (1.85), commons-lang3 (3.20.0), and Apache HttpClient (4.5.14) already satisfy their respective open alerts (#60/#26/#27, #31, #30) per each CVE's advisory. Once this workflow runs successfully, those should auto-dismiss.

## Changes

1. **`.github/workflows/dependency-submission.yml`**: drop the broken job-level `if:` guard. This repo always has a Gradle build, so the condition never did anything but break the workflow.
2. **`app/build.gradle.kts`**: bump the two pins that are genuinely stale (postdate the existing pins):
   - Netty `4.1.134.Final` → `4.1.137.Final` — rolls up the 4.1.135/.136/.137 security fixes (HTTP/2 CONTINUATION flood, MadeYouReset DDoS, IPv6 subnet bypass, SNI/hostname-verification bypass, several request-smuggling variants, decompression-bomb DoS, and more across `netty-codec-http(2)`/`netty-handler`/`netty-common`).
   - `jackson-core`/`jackson-databind`/`jackson-annotations` `2.18.7` → `2.18.9` — `jackson-core` needs ≥ 2.18.8 for GHSA-r7wm-3cxj-wff9 (async-parser number-length bypass); `jackson-databind` needs ≥ 2.18.9 for CVE-2026-54515 (case-insensitive deserialization bypass). Datatype/module/dataformat submodules (e.g. `jackson-datatype-jsr310`) stay at 2.18.7 — the newest version they publish, and none of the open CVEs are in those modules; Jackson keeps cross-module compatibility within a minor line.

## Not fixed here

The Kotlin Gradle Plugin unsafe-deserialization alert (CVE-2026-53914) has **no patched stable release yet** — the fix ships in Kotlin 2.4.20, currently only at Beta1, with stable planned for September 2026. Bumping the whole project's compiler to a beta isn't something I'll do without your explicit go-ahead given the blast radius. Worth revisiting once 2.4.20 stable ships.

## Test plan
- [x] `app/build.gradle.kts` braces/parens balanced; `dependency-submission.yml` parses as valid YAML
- [ ] `dependency-submission.yml` runs successfully on this PR / after merge to `master` (should show jobs now, not an immediate zero-job failure)
- [ ] Dependabot alerts for already-patched libraries (BouncyCastle, commons-lang3, Apache HttpClient) auto-dismiss after the graph resubmission
- [ ] Remaining Netty/Jackson alerts clear once the new pins are reflected in the graph

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdR1Kn5HNmKjEwrv82RZ31)_

## Summary by Sourcery

Fix dependency graph submission and update security-pinned libraries to patched versions.

Bug Fixes:
- Fix the dependency-submission GitHub Actions workflow so it no longer fails before running jobs and can upload the dependency graph.
- Update Jackson core/databind/annotations dependencies to 2.18.9 to address recent security advisories.
- Update Netty dependencies to 4.1.137.Final to roll in the latest 4.1.x security fixes.

Enhancements:
- Clarify Gradle dependency resolution comments around Jackson family version pinning and Netty module constraints.