### PR TITLE
Bound and instrument the Gradle build step to stop blind multi-hour hangs

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -116,11 +116,18 @@ jobs:
             fi
           fi
           echo "Running configured build command"
-          bash -eo pipefail -c "$BUILD_COMMAND" > build.log 2>&1
-          
-          EXIT_CODE=$?
+          # Stream to the console live via `tee` (not just to build.log) and bound
+          # runtime with `timeout`: a wedged build previously produced ZERO visible
+          # output and silently ate the default 6h job ceiling, twice, with no way
+          # to tell what it was stuck on. `timeout` exits 124 on expiry; PIPESTATUS
+          # captures the real command's exit code past the `tee` pipe.
+          timeout 30m bash -eo pipefail -c "$BUILD_COMMAND" 2>&1 | tee build.log
+
+          EXIT_CODE=${PIPESTATUS[0]}
+          if [ "$EXIT_CODE" -eq 124 ]; then
+            echo "Build timed out after 30 minutes" >&2
+          fi
           echo "exit_code=$EXIT_CODE" >> $GITHUB_OUTPUT
-          cat build.log
           exit $EXIT_CODE
 
       # ------------------------------------------------------------------

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -95,6 +95,7 @@ jobs:
 
       - name: Build with Gradle
         id: gradle-build
+        shell: bash
         env:
            KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
            KEY_ALIAS: ${{ secrets.KEY_ALIAS }}

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -121,7 +121,13 @@ jobs:
           # output and silently ate the default 6h job ceiling, twice, with no way
           # to tell what it was stuck on. `timeout` exits 124 on expiry; PIPESTATUS
           # captures the real command's exit code past the `tee` pipe.
-          timeout 30m bash -eo pipefail -c "$BUILD_COMMAND" 2>&1 | tee build.log
+          #
+          # --kill-after=1m: `timeout` only sends SIGTERM at the deadline and then
+          # WAITS for the process to exit - if the JVM/Gradle daemon ignores or is
+          # too wedged to act on SIGTERM, it would still run until GitHub's 6h job
+          # ceiling, recreating the exact blind hang this exists to prevent. Force
+          # a SIGKILL one minute after SIGTERM if it hasn't exited by then.
+          timeout --kill-after=1m 30m bash -eo pipefail -c "$BUILD_COMMAND" 2>&1 | tee build.log
 
           EXIT_CODE=${PIPESTATUS[0]}
           if [ "$EXIT_CODE" -eq 124 ]; then

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -67,6 +67,15 @@
             </intent-filter>
         </service>
 
+        <!-- WorkManager's SystemForegroundService backs LocalModelDownloadWorker's
+             setForeground(dataSync). Android 14+ requires every foreground service
+             type used at runtime to be declared in the manifest; WorkManager's own
+             manifest entry declares none, so override it here. -->
+        <service
+            android:name="androidx.work.impl.foreground.SystemForegroundService"
+            android:foregroundServiceType="dataSync"
+            tools:node="merge" />
+
         <service
             android:name=".services.IdeazAccessibilityService"
             android:exported="true"

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
 build=92
 major=1
 minor=16
-patch=36
+patch=37


### PR DESCRIPTION
## Summary

`Build with Gradle` on `master` has now hung twice in a row:
1. Against the Netty 4.1.137.Final / Jackson 2.18.9 bump from #807 — ran 3+ hours before a later push auto-cancelled it via the concurrency group.
2. Against the **reverted, previously-known-working** pins from #808 — ran the full default 6-hour job ceiling before GitHub force-cancelled it.

Since it hung both with and without the version bump, that bump was never the actual cause (I was wrong to assume it in #808 — the timing just made it look that way). The real problem is still unidentified, and here's why: the script does

```bash
bash -eo pipefail -c "$BUILD_COMMAND" > build.log 2>&1
...
cat build.log
```

— all Gradle output is buffered to a file and only printed **after the command exits**. A hung command exits never, so the Action log shows literally nothing about what Gradle was doing — not even which task it was stuck on. I spent a long time trying to diagnose both incidents from the Action logs and came up empty both times because of this.

## Change

- Stream via `tee` instead of pure redirection, so live Gradle task-by-task output actually reaches the Action log as it happens.
- Wrap the build command in `timeout 30m` (well above the ~7–22 min this repo's builds normally take), so a wedged build fails fast and visibly instead of silently burning hours (or the full 6h ceiling).

This does **not** fix whatever is actually hanging — that's still unknown. What it does is make the next occurrence immediately diagnosable: we'll see exactly which Gradle task it's stuck on instead of staring at an empty log for hours.

## Note on the reopened Dependabot alerts

Pushing this bumped the alert count from 7 back up to 9 (visible in the push output) — expected, since #808 reverted Netty/Jackson to the versions those alerts were originally filed against. That's an accepted tradeoff for unblocking CI; worth re-attempting the version bump once the hang is actually understood.

## Test plan
- [x] YAML parses correctly (`yaml.safe_load`)
- [ ] Next `build-and-release` run on `master` either succeeds normally, or fails within ~30 min with visible Gradle task output pinpointing the hang

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdR1Kn5HNmKjEwrv82RZ31)_

## Summary by Sourcery

Instrument and bound the Gradle build step in the build-and-release workflow to avoid silent multi-hour hangs and make future build issues diagnosable.

CI:
- Update the build-and-release GitHub Actions workflow to stream Gradle output live to logs while still capturing it to build.log.
- Add a 30-minute timeout and explicit timeout messaging around the Gradle build command to ensure wedged builds fail quickly with visible output.