### PR TITLE
Add JVM thread-dump watchdog to Build with Gradle

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -130,22 +130,53 @@ jobs:
           # Stream to the console live via `tee` (not just to build.log) and bound
           # runtime with `timeout`: a wedged build previously produced ZERO visible
           # output and silently ate the default 6h job ceiling, twice, with no way
-          # to tell what it was stuck on. `timeout` exits 124 on expiry; PIPESTATUS
-          # captures the real command's exit code past the `tee` pipe.
+          # to tell what it was stuck on. `timeout` exits 124 on expiry.
           #
           # --kill-after=1m: `timeout` only sends SIGTERM at the deadline and then
           # WAITS for the process to exit - if the JVM/Gradle daemon ignores or is
           # too wedged to act on SIGTERM, it would still run until GitHub's 6h job
           # ceiling, recreating the exact blind hang this exists to prevent. Force
           # a SIGKILL one minute after SIGTERM if it hasn't exited by then.
-          timeout --kill-after=1m 30m bash -eo pipefail -c "$BUILD_COMMAND" 2>&1 | tee build.log
+          #
+          # Run it in a subshell backgrounded so a watchdog can dump JVM thread
+          # stacks partway through: two runs have now hung for 20-30+ min with
+          # zero output right after all Gradle tasks finish (once on a lint
+          # failure, once on test failures - both times losing 3h/6h/30m/30m to a
+          # silent freeze), and switching off Gradle's Enhanced Caching provider
+          # didn't fix it either. This repo's tasks normally finish inside ~7-8
+          # min, so at 12 min (comfortably past that, comfortably before the 30
+          # min ceiling) dump every JVM's threads to find out what's actually
+          # blocked instead of guessing again.
+          (
+            timeout --kill-after=1m 30m bash -eo pipefail -c "$BUILD_COMMAND" 2>&1 | tee build.log
+            echo "${PIPESTATUS[0]}" > /tmp/build_exit_code
+          ) &
+          BUILD_PID=$!
 
-          EXIT_CODE=${PIPESTATUS[0]}
+          (
+            sleep 720
+            if kill -0 "$BUILD_PID" 2>/dev/null; then
+              echo "::warning::Build still running after 12 min - dumping JVM thread stacks"
+              JCMD="${JAVA_HOME:+$JAVA_HOME/bin/jcmd}"
+              JCMD="${JCMD:-jcmd}"
+              for pid in $("$JCMD" -l 2>/dev/null | awk '{print $1}'); do
+                echo "===== $JCMD $pid Thread.print ====="
+                "$JCMD" "$pid" Thread.print 2>&1 || true
+              done
+            fi
+          ) &
+          WATCHDOG_PID=$!
+
+          wait "$BUILD_PID"
+          kill "$WATCHDOG_PID" 2>/dev/null || true
+          wait "$WATCHDOG_PID" 2>/dev/null || true
+
+          EXIT_CODE=$(cat /tmp/build_exit_code 2>/dev/null || echo 1)
           if [ "$EXIT_CODE" -eq 124 ]; then
             echo "Build timed out after 30 minutes" >&2
           fi
           echo "exit_code=$EXIT_CODE" >> $GITHUB_OUTPUT
-          exit $EXIT_CODE
+          exit "$EXIT_CODE"
 
       # ------------------------------------------------------------------
       # FAILURE HANDLING

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
 build=92
 major=1
 minor=16
-patch=38
+patch=39


### PR DESCRIPTION
## Summary

Continuing the hang investigation from #810/#816. Switching `gradle/actions/setup-gradle` off the proprietary Enhanced Caching provider (`cache-provider: basic`, #816) did **not** fix it — the `master` merge build still hung for the full ~30 minute window. That rules out Enhanced Caching's in-process network hooks as the cause.

Two configuration-toggle guesses in a row without narrowing anything down. Rather than guess a third time, get direct evidence.

## Change

Background the build command and add a watchdog: if it's still running 12 minutes in (comfortably past this repo's normal ~7-8 min task-completion window, comfortably before the 30-min `timeout` ceiling), dump every local JVM's thread stacks via `jcmd <pid> Thread.print`. Whatever's actually blocked — the Gradle daemon, a Kotlin compile daemon, R8, whatever spawned process — should show up with its exact stack trace in the live-streamed log.

## Test plan
- [x] `bash -n` syntax-checks clean
- [x] YAML parses correctly
- [ ] Next build-and-release run either completes/fails promptly, or hangs again — and if it hangs, the thread dump should finally show what's blocked

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdR1Kn5HNmKjEwrv82RZ31)_

## Summary by Sourcery

Add a watchdog around the Gradle build step to capture JVM thread dumps when the build appears hung, and bump the patch version.

Enhancements:
- Introduce a backgrounded build execution with a 12-minute watchdog that emits JVM thread dumps for all local JVM processes when the build is still running.
- Record the build command exit code via a temporary file to preserve accurate status reporting through the modified execution flow.

CI:
- Update the build-and-release GitHub Actions workflow to run the Gradle build under a monitored timeout with live logging and a JVM thread-dump watchdog to aid hang diagnosis.

Chores:
- Increment the patch version in version.properties from 1.16.38 to 1.16.39.