### PR TITLE
Add App Info shortcut to Settings for restricted-settings access

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/SettingsScreen.kt
@@ -328,8 +328,12 @@ fun SettingsScreen(
                     hint = "Key Password",
                     secret = true,
                     onSubmit = {
-                        settingsViewModel.saveSigningCredentials(keystorePass, keyAlias, keyPass)
-                        Toast.makeText(context, "Signing config saved", Toast.LENGTH_SHORT).show()
+                        val saved = settingsViewModel.saveSigningCredentials(keystorePass, keyAlias, keyPass)
+                        Toast.makeText(
+                            context,
+                            if (saved) "Signing config saved" else "Signing config save failed",
+                            Toast.LENGTH_SHORT,
+                        ).show()
                     },
                     submitButtonContent = { Text("Save") }
                 )
@@ -370,8 +374,12 @@ fun SettingsScreen(
                         hint = "Jules API Key",
                         secret = true,
                         onSubmit = {
-                            settingsViewModel.saveApiKey(apiKey)
-                            Toast.makeText(context, "Jules Key Saved", Toast.LENGTH_SHORT).show()
+                            val saved = settingsViewModel.saveApiKey(apiKey)
+                            Toast.makeText(
+                                context,
+                                if (saved) "Jules Key Saved" else "Jules Key Save Failed",
+                                Toast.LENGTH_SHORT,
+                            ).show()
                         },
                         submitButtonContent = { Text("Save") }
                     )
@@ -398,8 +406,15 @@ fun SettingsScreen(
                         hint = "GitHub Token",
                         secret = true,
                         onSubmit = {
-                            settingsViewModel.saveGithubToken(githubToken)
-                            Toast.makeText(context, "GitHub Token Saved", Toast.LENGTH_SHORT).show()
+                            val saved = settingsViewModel.saveGithubToken(githubToken)
+                            if (saved) {
+                                viewModel.fetchGitHubRepos()
+                            }
+                            Toast.makeText(
+                                context,
+                                if (saved) "GitHub Token Saved" else "GitHub Token Save Failed",
+                                Toast.LENGTH_SHORT,
+                            ).show()
                         },
                         submitButtonContent = { Text("Save") }
                     )
@@ -478,8 +493,12 @@ fun SettingsScreen(
                     storedKey = settingsViewModel.getApiKey(SettingsViewModel.KEY_GROQ_API_KEY).orEmpty(),
                     signupUrl = "https://console.groq.com/keys",
                     onSave = {
-                        settingsViewModel.saveString(SettingsViewModel.KEY_GROQ_API_KEY, it)
-                        Toast.makeText(context, "Groq key saved", Toast.LENGTH_SHORT).show()
+                        val saved = settingsViewModel.saveString(SettingsViewModel.KEY_GROQ_API_KEY, it)
+                        Toast.makeText(
+                            context,
+                            if (saved) "Groq key saved" else "Groq key could not be saved",
+                            if (saved) Toast.LENGTH_SHORT else Toast.LENGTH_LONG,
+                        ).show()
                     },
                 )
                 FreeProviderKeyRow(
@@ -487,8 +506,12 @@ fun SettingsScreen(
                     storedKey = settingsViewModel.getApiKey(SettingsViewModel.KEY_CEREBRAS_API_KEY).orEmpty(),
                     signupUrl = "https://cloud.cerebras.ai/",
                     onSave = {
-                        settingsViewModel.saveString(SettingsViewModel.KEY_CEREBRAS_API_KEY, it)
-                        Toast.makeText(context, "Cerebras key saved", Toast.LENGTH_SHORT).show()
+                        val saved = settingsViewModel.saveString(SettingsViewModel.KEY_CEREBRAS_API_KEY, it)
+                        Toast.makeText(
+                            context,
+                            if (saved) "Cerebras key saved" else "Cerebras key could not be saved",
+                            if (saved) Toast.LENGTH_SHORT else Toast.LENGTH_LONG,
+                        ).show()
                     },
                 )
                 FreeProviderKeyRow(
@@ -509,8 +532,12 @@ fun SettingsScreen(
                     storedKey = settingsViewModel.getApiKey(SettingsViewModel.KEY_MISTRAL_API_KEY).orEmpty(),
                     signupUrl = "https://console.mistral.ai/api-keys/",
                     onSave = {
-                        settingsViewModel.saveString(SettingsViewModel.KEY_MISTRAL_API_KEY, it)
-                        Toast.makeText(context, "Mistral key saved", Toast.LENGTH_SHORT).show()
+                        val saved = settingsViewModel.saveString(SettingsViewModel.KEY_MISTRAL_API_KEY, it)
+                        Toast.makeText(
+                            context,
+                            if (saved) "Mistral key saved" else "Mistral key could not be saved",
+                            if (saved) Toast.LENGTH_SHORT else Toast.LENGTH_LONG,
+                        ).show()
                     },
                 )
 
@@ -528,8 +555,12 @@ fun SettingsScreen(
                     storedKey = settingsViewModel.getApiKey(SettingsViewModel.KEY_OPENAI_API_KEY).orEmpty(),
                     signupUrl = "https://platform.openai.com/api-keys",
                     onSave = {
-                        settingsViewModel.saveString(SettingsViewModel.KEY_OPENAI_API_KEY, it)
-                        Toast.makeText(context, "OpenAI key saved", Toast.LENGTH_SHORT).show()
+                        val saved = settingsViewModel.saveString(SettingsViewModel.KEY_OPENAI_API_KEY, it)
+                        Toast.makeText(
+                            context,
+                            if (saved) "OpenAI key saved" else "OpenAI key could not be saved",
+                            if (saved) Toast.LENGTH_SHORT else Toast.LENGTH_LONG,
+                        ).show()
                     },
                 )
                 FreeProviderKeyRow(
@@ -537,8 +568,12 @@ fun SettingsScreen(
                     storedKey = settingsViewModel.getApiKey(SettingsViewModel.KEY_ANTHROPIC_API_KEY).orEmpty(),
                     signupUrl = "https://console.anthropic.com/settings/keys",
                     onSave = {
-                        settingsViewModel.saveString(SettingsViewModel.KEY_ANTHROPIC_API_KEY, it)
-                        Toast.makeText(context, "Anthropic key saved", Toast.LENGTH_SHORT).show()
+                        val saved = settingsViewModel.saveString(SettingsViewModel.KEY_ANTHROPIC_API_KEY, it)
+                        Toast.makeText(
+                            context,
+                            if (saved) "Anthropic key saved" else "Anthropic key could not be saved",
+                            if (saved) Toast.LENGTH_SHORT else Toast.LENGTH_LONG,
+                        ).show()
                     },
                 )
                 FreeProviderKeyRow(
@@ -546,8 +581,12 @@ fun SettingsScreen(
                     storedKey = settingsViewModel.getApiKey(SettingsViewModel.KEY_DEEPSEEK_API_KEY).orEmpty(),
                     signupUrl = "https://platform.deepseek.com/api_keys",
                     onSave = {
-                        settingsViewModel.saveString(SettingsViewModel.KEY_DEEPSEEK_API_KEY, it)
-                        Toast.makeText(context, "DeepSeek key saved", Toast.LENGTH_SHORT).show()
+                        val saved = settingsViewModel.saveString(SettingsViewModel.KEY_DEEPSEEK_API_KEY, it)
+                        Toast.makeText(
+                            context,
+                            if (saved) "DeepSeek key saved" else "DeepSeek key could not be saved",
+                            if (saved) Toast.LENGTH_SHORT else Toast.LENGTH_LONG,
+                        ).show()
                     },
                 )
 

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/SettingsScreen.kt
@@ -200,6 +200,14 @@ fun SettingsScreen(
         }
     )
 
+    val appInfoLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.StartActivityForResult(),
+        onResult = {
+            Log.d(TAG, "Returned from app info")
+            refreshTrigger++
+        }
+    )
+
     // --- Dialogs ---
 
     if (showExportPasswordDialog) {
@@ -572,6 +580,28 @@ fun SettingsScreen(
                 OnDeviceModelsSection(settingsViewModel = settingsViewModel)
 
                 Text("Permissions", color = MaterialTheme.colorScheme.onBackground, style = MaterialTheme.typography.titleLarge, modifier = Modifier.semantics { heading() })
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    "Android may label permissions below \"Restricted\" for an app installed " +
+                        "outside the Play Store, which silently blocks granting them. If a toggle " +
+                        "below won't turn on, open App Info, tap the ⋮ menu, and choose " +
+                        "\"Allow restricted settings\".",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                AzButton(
+                    onClick = {
+                        val intent = Intent(
+                            Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                            Uri.parse("package:${context.packageName}")
+                        )
+                        appInfoLauncher.launch(intent)
+                    },
+                    text = "Open App Info",
+                    shape = AzButtonShape.RECTANGLE,
+                    modifier = Modifier.fillMaxWidth()
+                )
                 Spacer(modifier = Modifier.height(16.dp))
 
                 val hasOverlay by remember(refreshTrigger) {

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/SettingsViewModel.kt
@@ -317,24 +317,26 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
     fun getApiKey() = getApiKey(KEY_API_KEY)
     fun getApiKey(keyName: String): String? {
         if (keyName !in SECURE_CREDENTIAL_KEYS) return sharedPreferences.getString(keyName, null)
-        runCatching { credentialStore.get(keyName) }.getOrNull()?.let { secureValue ->
-            if (sharedPreferences.contains(keyName) &&
-                !sharedPreferences.edit().remove(keyName).commit()
-            ) {
-                Log.e(TAG, "Failed to remove legacy secure credential")
+        runCatching { credentialStore.get(keyName) }
+            .onFailure { Log.e(TAG, "Failed to read secure credential: $keyName", it) }
+            .getOrNull()
+            ?.let { secureValue ->
+                if (sharedPreferences.contains(keyName) &&
+                    !sharedPreferences.edit().remove(keyName).commit()
+                ) {
+                    Log.e(TAG, "Failed to remove legacy secure credential: $keyName")
+                }
+                return secureValue
             }
-            return secureValue
-        }
         val legacy = sharedPreferences.getString(keyName, null) ?: return null
-        return if (runCatching { credentialStore.put(keyName, legacy) }.isSuccess) {
-            if (!sharedPreferences.edit().remove(keyName).commit()) {
-                Log.e(TAG, "Failed to remove migrated secure credential")
+        return runCatching { credentialStore.put(keyName, legacy) }
+            .onFailure { Log.e(TAG, "Failed to migrate secure credential: $keyName", it) }
+            .onSuccess {
+                if (!sharedPreferences.edit().remove(keyName).commit()) {
+                    Log.e(TAG, "Failed to remove migrated secure credential: $keyName")
+                }
             }
-            legacy
-        } else {
-            Log.e(TAG, "Failed to migrate secure credential")
-            legacy
-        }
+            .let { legacy }
     }
 
     /**
@@ -351,7 +353,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
                     "Plaintext credential cleanup failed"
                 }
             }.onFailure {
-                Log.e(TAG, "Failed to store secure credential")
+                Log.e(TAG, "Failed to store secure credential: $keyName", it)
             }.isSuccess
         }
         sharedPreferences.edit { putString(keyName, value.trim()) }

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/SettingsViewModel.kt
@@ -93,6 +93,14 @@ object AiModels {
 
     val availableModels = listOf(NANO, BRIDGE, LOCAL, GEMINI, OPENAI, ANTHROPIC, DEEPSEEK, GROQ, CEREBRAS, HF, MISTRAL, JULES, CLI)
 
+    // Capability-ranked order for auto-selecting a default model: distinct from
+    // `availableModels` (that one's ordered for UI display). `defaultModelId()`
+    // walks this list and picks the first entry whose `requiredKey` is
+    // actually saved - the trailing no-key entries are kept here only so the
+    // list stays a complete provider ranking, but they're always skipped by
+    // that lookup (see its own `requiredKey.isNotEmpty()` guard).
+    val defaultRanking = listOf(GEMINI, ANTHROPIC, OPENAI, DEEPSEEK, GROQ, CEREBRAS, HF, MISTRAL, JULES, CLI, BRIDGE, LOCAL, NANO)
+
     fun findById(id: String?): AiModel? = availableModels.find { it.id == id }
 }
 
@@ -299,11 +307,12 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
     fun saveJulesProjectId(projectId: String) = sharedPreferences.edit { putString(KEY_JULES_PROJECT_ID, projectId.trim()) }
     fun getJulesProjectId() = sharedPreferences.getString(KEY_JULES_PROJECT_ID, null)
 
-    fun saveApiKey(apiKey: String) {
+    fun saveApiKey(apiKey: String): Boolean {
         val trimmed = apiKey.trim()
-        saveString(KEY_API_KEY, trimmed)
+        val saved = saveString(KEY_API_KEY, trimmed)
         AuthInterceptor.apiKey = trimmed
         _apiKey.value = trimmed
+        return saved
     }
     fun getApiKey() = getApiKey(KEY_API_KEY)
     fun getApiKey(keyName: String): String? {
@@ -377,12 +386,23 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
 
     fun saveAiAssignment(taskKey: String, modelId: String) = sharedPreferences.edit { putString(taskKey, modelId) }
     fun getAiAssignment(taskKey: String): String? {
-        // Phase 1 default is Gemini (AGENTS.md). Jules is Phase 2; users opt into it
-        // explicitly via the AI assignment dropdowns in Settings.
-        val defaultModelId = sharedPreferences.getString(KEY_AI_ASSIGNMENT_DEFAULT, AiModels.GEMINI_FLASH)
+        // An explicit "Default" choice from the AI Assignments dropdown always
+        // wins; absent that, fall back to the best-ranked model the user has
+        // actually entered a key for, so a freshly installed app defaults to
+        // whichever provider the user already configured rather than an
+        // always-Gemini assumption. If no key has been entered anywhere,
+        // Gemini remains the fallback - unchanged from the prior behavior.
+        val defaultModelId = sharedPreferences.getString(KEY_AI_ASSIGNMENT_DEFAULT, null) ?: defaultModelId()
         if (taskKey == KEY_AI_ASSIGNMENT_DEFAULT) return defaultModelId
         return sharedPreferences.getString(taskKey, defaultModelId)
     }
+
+    /** Highest-ranked model in [AiModels.defaultRanking] whose required key is actually saved. */
+    private fun defaultModelId(): String =
+        AiModels.defaultRanking
+            .firstOrNull { it.requiredKey.isNotEmpty() && !getApiKey(it.requiredKey).isNullOrBlank() }
+            ?.id
+            ?: AiModels.GEMINI_FLASH
 
     // --- SIGNING ---
     fun importKeystore(context: Context, uri: Uri): String? {
@@ -401,11 +421,12 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
             null
         }
     }
-    fun saveSigningCredentials(storePass: String, alias: String, keyPass: String) {
+    fun saveSigningCredentials(storePass: String, alias: String, keyPass: String): Boolean {
         // Alias is just a label, not a secret; the two passwords are.
-        saveString(KEY_KEYSTORE_PASS, storePass)
+        val storePassSaved = saveString(KEY_KEYSTORE_PASS, storePass)
         sharedPreferences.edit { putString(KEY_KEY_ALIAS, alias) }
-        saveString(KEY_KEY_PASS, keyPass)
+        val keyPassSaved = saveString(KEY_KEY_PASS, keyPass)
+        return storePassSaved && keyPassSaved
     }
     fun getKeystorePath() = sharedPreferences.getString(KEY_KEYSTORE_PATH, null)
     fun getKeystorePass() = getApiKey(KEY_KEYSTORE_PASS) ?: "android"

--- a/app/src/test/java/com/hereliesaz/ideaz/ui/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/hereliesaz/ideaz/ui/SettingsViewModelTest.kt
@@ -196,6 +196,70 @@ class SettingsViewModelTest {
     }
 
     @Test
+    fun `default AI assignment falls back to Gemini when no provider key is saved`() {
+        assertEquals(AiModels.GEMINI_FLASH, viewModel.getAiAssignment(SettingsViewModel.KEY_AI_ASSIGNMENT_DEFAULT))
+    }
+
+    @Test
+    fun `default AI assignment picks the highest-ranked provider the user has a key for`() {
+        val credentials = FakeCredentialStore()
+        viewModel = SettingsViewModel(application, credentials)
+
+        // Groq and Cerebras outrank nothing here yet - Anthropic (entered
+        // below) outranks both in AiModels.defaultRanking, so it should win.
+        viewModel.saveString(SettingsViewModel.KEY_GROQ_API_KEY, "groq_secret")
+        viewModel.saveString(SettingsViewModel.KEY_CEREBRAS_API_KEY, "cerebras_secret")
+        assertEquals(AiModels.GROQ_LLAMA, viewModel.getAiAssignment(SettingsViewModel.KEY_AI_ASSIGNMENT_DEFAULT))
+
+        viewModel.saveString(SettingsViewModel.KEY_ANTHROPIC_API_KEY, "anthropic_secret")
+        assertEquals(AiModels.ANTHROPIC_CLAUDE, viewModel.getAiAssignment(SettingsViewModel.KEY_AI_ASSIGNMENT_DEFAULT))
+    }
+
+    @Test
+    fun `an explicit Default AI assignment overrides the ranked auto-pick`() {
+        val credentials = FakeCredentialStore()
+        viewModel = SettingsViewModel(application, credentials)
+        viewModel.saveString(SettingsViewModel.KEY_ANTHROPIC_API_KEY, "anthropic_secret")
+
+        viewModel.saveAiAssignment(SettingsViewModel.KEY_AI_ASSIGNMENT_DEFAULT, AiModels.MISTRAL_SMALL)
+
+        assertEquals(AiModels.MISTRAL_SMALL, viewModel.getAiAssignment(SettingsViewModel.KEY_AI_ASSIGNMENT_DEFAULT))
+    }
+
+    @Test
+    fun `a task without its own assignment inherits the ranked default`() {
+        val credentials = FakeCredentialStore()
+        viewModel = SettingsViewModel(application, credentials)
+        viewModel.saveString(SettingsViewModel.KEY_OPENAI_API_KEY, "openai_secret")
+
+        assertEquals(AiModels.OPENAI_GPT4O, viewModel.getAiAssignment(SettingsViewModel.KEY_AI_ASSIGNMENT_OVERLAY))
+    }
+
+    @Test
+    fun `saveApiKey reports failure when the secure store rejects the write`() {
+        val credentials = object : CredentialStore {
+            override fun get(key: String): String? = null
+            override fun put(key: String, value: String) = error("keystore unavailable")
+            override fun remove(key: String) = Unit
+        }
+        viewModel = SettingsViewModel(application, credentials)
+
+        assertFalse(viewModel.saveApiKey("secret_key"))
+    }
+
+    @Test
+    fun `saveSigningCredentials reports failure when the secure store rejects the write`() {
+        val credentials = object : CredentialStore {
+            override fun get(key: String): String? = null
+            override fun put(key: String, value: String) = error("keystore unavailable")
+            override fun remove(key: String) = Unit
+        }
+        viewModel = SettingsViewModel(application, credentials)
+
+        assertFalse(viewModel.saveSigningCredentials(storePass = "storePass", alias = "myAlias", keyPass = "keyPass"))
+    }
+
+    @Test
     fun `credential envelope hides plaintext and rejects tampering`() {
         val key = KeyGenerator.getInstance("AES").apply { init(256) }.generateKey()
         val envelope = encryptCredential("hf_secret", key, "hf_api_key")

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
 build=92
 major=1
-minor=16
+minor=17
 patch=66

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
 build=92
 major=1
 minor=16
-patch=68
+patch=69

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
 build=92
 major=1
 minor=16
-patch=66
+patch=67

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
 build=92
 major=1
 minor=16
-patch=67
+patch=68

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
 build=92
 major=1
 minor=16
-patch=69
+patch=66


### PR DESCRIPTION
## Summary
- **App Info shortcut**: Android blocks Accessibility/Overlay permission grants for apps installed outside the Play Store until the user opens the app's system App Info page and taps "Allow restricted settings" from the overflow (⋮) menu. Adds a direct "Open App Info" button at the top of Settings → Permissions, with a short explanation.
- **Credential-save failures were silently swallowed**: several `onSubmit` handlers in Settings (Jules key, GitHub token, signing credentials, and all six free/paid provider keys) discarded the `Boolean` success result of `saveApiKey`/`saveString`/`saveSigningCredentials` and always showed a "Saved" toast regardless of outcome. If the underlying secure-credential write ever failed, the field would silently come back blank the next time Settings was opened, with no dots and no error shown. `saveApiKey`/`saveSigningCredentials` also had a `Unit` return type that discarded `saveString`'s result internally — both now return `Boolean` like the other `save*` functions already did, and every Settings save site now checks the result and shows an accurate success/failure toast.
- **GitHub token save now refreshes the clone list**: saving a valid GitHub token calls `viewModel.fetchGitHubRepos()` immediately, instead of the repo list only updating incidentally the next time the Clone tab happened to remount.
- **Default AI model now ranks by which keys are actually saved**: `getAiAssignment`'s fallback for an unset "Default" AI assignment was hardcoded to Gemini regardless of whether the user had a Gemini key. It now walks a new capability-ranked `AiModels.defaultRanking` list and picks the highest-ranked model whose required key is actually saved, falling back to Gemini only when no provider key has been entered anywhere (unchanged from the prior behavior in that case).

## Test plan
- [ ] Confirm `pr-check.yml`'s `check` job passes (new `SettingsViewModelTest` coverage for the ranking fallback and save-failure propagation).
- [ ] Manually verify: Settings → Permissions → "Open App Info" opens the system app-details screen for IDEaz.
- [ ] Manually verify: saving a GitHub token in Settings, then switching to the Clone tab, shows the refreshed repo list without needing a manual refresh tap.
- [ ] Manually verify: with only e.g. an Anthropic key saved (no Gemini key), the "Default" AI Assignment resolves to Claude rather than Gemini.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdR1Kn5HNmKjEwrv82RZ31)_

## Summary by Sourcery

Improve Settings permission access, credential-save feedback, GitHub synchronization, and automatic AI provider selection.

New Features:
- Add an App Info shortcut and guidance to help users enable restricted Android permissions.

Bug Fixes:
- Surface credential-save failures accurately instead of always reporting success.
- Select the default AI model from configured provider keys while preserving explicit assignments and the Gemini fallback.
- Refresh GitHub repositories immediately after successfully saving a token.

Tests:
- Add coverage for ranked AI default selection, explicit assignment precedence, inherited task assignments, and secure credential save failures.