### PR TITLE
Release tag uses major.minor only

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -269,7 +269,7 @@ jobs:
             [[ "$value" =~ ^[0-9]+$ ]] || { echo "Invalid version.properties" >&2; exit 1; }
           done
           VERSION_NAME="$MAJOR.$MINOR.$PATCH.$BUILD_NUMBER"
-          TAG_NAME="v$VERSION_NAME"
+          TAG_NAME="v$MAJOR.$MINOR"
           REPOSITORY_NAME="${GITHUB_REPOSITORY##*/}"
           ARTIFACT_GLOB=${{ vars.RELEASE_ARTIFACT_PATH || '' }}
           if [ -n "$ARTIFACT_GLOB" ]; then


### PR DESCRIPTION
## Summary
- `build-and-release.yml`'s release tag was `v$major.$minor.$patch.$build`. Since `build` auto-increments on every push, the tag was effectively unique per push, so the step's existing "force update tag" / "update existing release" logic almost never actually found an existing tag to reuse.
- Changed the tag to `v$major.$minor` only, so it rolls within a minor version as that existing force-push/edit-existing-release logic already intended.
- The artifact filename and release notes are untouched — they still use the full `major.minor.patch.build` version for precision.

## Test plan
- [ ] Confirm `build-and-release.yml` still runs successfully on push to master and produces a release tagged `vMAJOR.MINOR` (currently `v1.17`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdR1Kn5HNmKjEwrv82RZ31)_

## Summary by Sourcery

Bug Fixes:
- Update release tags to use only the major and minor version so releases can be reused and updated within a minor version.