### PR TITLE
Bump pinned Jackson family to 2.18.10 (9 Dependabot alerts)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -191,21 +191,28 @@ configurations.all {
         eachDependency {
             when {
                 // Jackson arrives as core/databind/annotations + datatype modules and a
-                // BOM; pin the whole family to a patched 2.18.x. Use 2.18.7 — the java8
-                // datatype modules (jackson-datatype-jdk8/jsr310) stop there, while
-                // core/databind go to 2.18.8, so 2.18.7 is the latest version every
-                // module publishes (and still > the 2.18.6 fix).
+                // BOM; pin the whole family to a patched 2.18.x.
                 //
                 // 2026-08-16: tried bumping core/databind/annotations to 2.18.9 and Netty
-                // (below) to 4.1.137.Final to close out newer CVEs. The very first CI build
-                // against that combination hung indefinitely on `Build with Gradle` (30+ min
-                // against a ~7 min baseline, no error, no completion) and had to be reverted
-                // sight-unseen — no log access to an in-progress job to pin down whether it
-                // was dependency-resolution backtracking or an R8 pathological case. Re-attempt
-                // in isolation (one version bump at a time, watched locally first) rather than
-                // both at once.
+                // (below) to 4.1.137.Final together, on the mistaken belief that the java8
+                // datatype modules (jackson-datatype-jdk8/jsr310) didn't publish past 2.18.7
+                // (they do - verified directly against Maven Central, every Jackson module
+                // this project uses publishes through 2.18.10). The CI build against that
+                // combination hung indefinitely on `Build with Gradle` (30+ min against a
+                // ~7 min baseline, no error, no completion) and had to be reverted
+                // sight-unseen - no log access to an in-progress job to pin down whether it
+                // was the Jackson bump, the simultaneous Netty bump, or dependency-resolution
+                // backtracking.
+                //
+                // 2026-08-17: re-attempting with only Jackson moving (Netty below is
+                // untouched), bumped straight to 2.18.10 - the current newest 2.18.x patch,
+                // confirmed to exist for every module this project resolves. If this hangs
+                // CI again, the `Build with Gradle` step's own 12-minute JVM thread-dump
+                // watchdog (added since the last incident) should actually show what's
+                // blocked this time, instead of the silent 30-min timeout the prior attempt
+                // burned blind.
                 requested.group.startsWith("com.fasterxml.jackson") ->
-                    useVersion("2.18.7")
+                    useVersion("2.18.10")
                 // Netty arrives as ~11 modules via grpc-netty (unit-test only). Pin the
                 // io.netty group to the latest patched 4.1.x — staying off 4.2.x, which
                 // grpc-netty does not support. (netty-tcnative tracks a separate scheme.)


### PR DESCRIPTION
## Summary
Closes 9 open Dependabot alerts (#56, #57, #58, #59, #81, #82, #83, #84, #95), all against the transitive Jackson pin in `app/build.gradle.kts`'s `resolutionStrategy`.

- **#56/#57** (High) — databind `PolymorphicTypeValidator` bypass via generic type parameters (CVE-2026-54512): fixed in 2.18.8.
- **#83** (High) — core async-parser `maxNumberLength` bypass via chunked digit accumulation, an incomplete-fix follow-up to an earlier CVE (GHSA-72hv-8253-57qq): fixed in 2.18.8.
- **#58, #59, #81, #82, #84, #95** (Moderate) — batched into the same 2.18.x-line fixes carried through to 2.18.10.

The prior pin (2.18.7) rested on a belief that `jackson-datatype-jdk8`/`jackson-datatype-jsr310` stopped publishing at 2.18.7 while core/databind moved on. Verified directly against Maven Central (`curl` against `repo1.maven.org`, not the flaky search UIs) that this was wrong — every Jackson module this project resolves publishes through **2.18.10**, the current newest 2.18.x patch (released 2 days ago).

## ⚠️ Known risk — please watch this build
A prior attempt (2026-08-16, documented in the code comment this PR touches) to bump Jackson to 2.18.9 *together with* a Netty bump hung CI indefinitely on the `Build with Gradle` step and had to be reverted sight-unseen, with no way to tell which change caused it. This PR moves **only** Jackson — Netty is untouched — specifically to isolate the variable this time. If it hangs again, the 12-minute JVM thread-dump watchdog already in that step (added since the last incident) should show what's actually blocked, rather than the silent 30-minute timeout the prior attempt burned blind.

## Test plan
- [ ] Confirm `pr-check.yml`'s `check` job passes without a repeat of the prior hang.
- [ ] Confirm the 9 listed Dependabot alerts auto-dismiss once this merges to master and the next dependency-submission run reflects the new pinned version.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdR1Kn5HNmKjEwrv82RZ31)_

## Summary by Sourcery

Upgrade the pinned Jackson family to 2.18.10 and clarify the rationale and risk-management approach for the dependency update.

Bug Fixes:
- Update the pinned Jackson dependency family to 2.18.10 to address nine reported security vulnerabilities.

Enhancements:
- Correct the documented Jackson module version assumption and isolate the Jackson upgrade from the separate Netty change to make CI failures easier to diagnose.