### PR TITLE
Fix root cause: every credential save threw "Caller-provided IV not permitted"

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -134,9 +134,16 @@ jobs:
         run: |
           set +e
           test -f version.properties || { echo "version.properties is required" >&2; exit 1; }
-          FILE_BUILD=$(sed -n 's/^build=//p' version.properties | tail -n 1)
+          # -PversionBuild is meant to be a value that only ever grows (see
+          # the comment on `versionBuildOverride` in app/build.gradle.kts:
+          # "CI passes git rev-list --count HEAD"). This previously read the
+          # `build` field out of version.properties instead - a value that
+          # nothing in this pipeline ever increments or commits back - so
+          # every CI build baked in the exact same versionCode/versionName
+          # regardless of how many commits/builds actually happened.
+          COMMIT_COUNT=$(git rev-list --count HEAD)
           export BUILD_NUMBER=${{ vars.BUILD_NUMBER_OVERRIDE || '' }}
-          export BUILD_NUMBER=${BUILD_NUMBER:-$FILE_BUILD}
+          export BUILD_NUMBER=${BUILD_NUMBER:-$COMMIT_COUNT}
           
           BUILD_COMMAND=${BUILD_COMMAND:-${{ vars.BUILD_COMMAND }}}
           if [ -z "$BUILD_COMMAND" ]; then
@@ -263,8 +270,11 @@ jobs:
           MAJOR=$(get_version_part major)
           MINOR=$(get_version_part minor)
           PATCH=$(get_version_part patch)
-          FILE_BUILD=$(get_version_part build)
-          BUILD_NUMBER=${BUILD_NUMBER:-${FILE_BUILD}}
+          # Same derivation as the "Build with Gradle" step above, so the
+          # artifact filename/release notes match what's actually baked into
+          # the compiled APK's versionCode/versionName.
+          BUILD_NUMBER=${{ vars.BUILD_NUMBER_OVERRIDE || '' }}
+          BUILD_NUMBER=${BUILD_NUMBER:-$(git rev-list --count HEAD)}
           for value in "$MAJOR" "$MINOR" "$PATCH" "$BUILD_NUMBER"; do
             [[ "$value" =~ ^[0-9]+$ ]] || { echo "Invalid version.properties" >&2; exit 1; }
           done

--- a/.github/workflows/publish-play.yml
+++ b/.github/workflows/publish-play.yml
@@ -129,9 +129,14 @@ jobs:
         run: |
           set -e
           test -f version.properties || { echo "version.properties is required" >&2; exit 1; }
-          FILE_BUILD=$(sed -n 's/^build=//p' version.properties | tail -n 1)
+          # -PversionBuild must be a value that only ever grows - Play Store
+          # rejects any upload whose versionCode doesn't strictly increase.
+          # This previously read the static `build` field out of
+          # version.properties, which nothing in this pipeline ever
+          # increments/commits back, so every publish attempt would try to
+          # reuse the exact same versionCode as the last one.
           BUILD_NUMBER=${{ vars.BUILD_NUMBER_OVERRIDE || '' }}
-          BUILD_NUMBER=${BUILD_NUMBER:-$FILE_BUILD}
+          BUILD_NUMBER=${BUILD_NUMBER:-$(git rev-list --count HEAD)}
           [[ "$BUILD_NUMBER" =~ ^[0-9]+$ ]] || { echo "Invalid build component" >&2; exit 1; }
           ${{ vars.BUNDLE_COMMAND || './gradlew bundleRelease' }} -PversionBuild=$BUILD_NUMBER --build-cache
 

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/utils/AndroidKeystoreCredentialStore.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/utils/AndroidKeystoreCredentialStore.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyProperties
 import java.security.KeyStore
-import java.security.SecureRandom
 import java.util.Base64
 import javax.crypto.Cipher
 import javax.crypto.KeyGenerator
@@ -32,11 +31,26 @@ fun readSecureOrLegacyCredential(context: Context, key: String): String? {
     return androidx.preference.PreferenceManager.getDefaultSharedPreferences(context).getString(key, null)
 }
 
-/** Encrypts one credential into a versioned AES-GCM envelope. */
+/**
+ * Encrypts one credential into a versioned AES-GCM envelope.
+ *
+ * Deliberately does NOT pass a caller-generated IV via GCMParameterSpec on
+ * encrypt: an AndroidKeyStore-backed key created with
+ * setRandomizedEncryptionRequired(true) (the default, and what secretKey()
+ * below sets explicitly) rejects that outright with
+ * InvalidAlgorithmParameterException("Caller-provided IV not permitted") -
+ * every single call, on every device, unconditionally. This was the actual
+ * cause of every "could not be saved" credential failure - invisible to
+ * this file's own unit test, which exercises a plain software AES key that
+ * has no such restriction, not a real AndroidKeyStore-backed one. The fix:
+ * initialize without an IV and let the provider generate one internally,
+ * then read the actual IV it used back via cipher.iv (the standard,
+ * required pattern for AndroidKeyStore-backed GCM encryption).
+ */
 internal fun encryptCredential(value: String, key: SecretKey, associatedData: String): String {
-    val iv = ByteArray(12).also(SecureRandom()::nextBytes)
     val cipher = Cipher.getInstance("AES/GCM/NoPadding")
-    cipher.init(Cipher.ENCRYPT_MODE, key, GCMParameterSpec(128, iv))
+    cipher.init(Cipher.ENCRYPT_MODE, key)
+    val iv = cipher.iv
     cipher.updateAAD(associatedData.toByteArray(Charsets.UTF_8))
     val ciphertext = cipher.doFinal(value.toByteArray(Charsets.UTF_8))
     return "v1:${Base64.getEncoder().encodeToString(iv)}:${Base64.getEncoder().encodeToString(ciphertext)}"


### PR DESCRIPTION
## Summary
- **Root cause of every credential save failing**: `encryptCredential()` generated its own IV and passed it via `Cipher.init(ENCRYPT_MODE, key, GCMParameterSpec(128, iv))`. The AndroidKeyStore-backed key is created with `setRandomizedEncryptionRequired(true)` (both explicit here and the API default), which makes the AndroidKeyStore provider's `Cipher` implementation flatly reject a caller-supplied IV on encrypt — it must generate its own internally. So the write itself always threw `InvalidAlgorithmParameterException("Caller-provided IV not permitted")` before anything ever reached disk, unconditionally, on every device, for every credential. Invisible to this file's own round-trip unit test, which uses a plain software AES key with no such restriction. Fixed by initializing without an explicit IV and reading back the IV the provider actually generated via `cipher.iv` — the standard, required pattern for AndroidKeyStore-backed GCM encryption. Decrypt is unaffected (supplying the IV there was always correct and required).
- **Build number never incrementing**: every CI-built APK/AAB showed the exact same version (e.g. `IDEaz-1.17.66.92.apk`) regardless of how many commits/builds happened, because `-PversionBuild` was computed by reading the `build` field out of `version.properties` and passing that same static value right back in — a circular no-op, since nothing in either pipeline ever increments or commits that field. `app/build.gradle.kts`'s own comment on `versionBuildOverride` already documents the intended design ("CI passes `git rev-list --count HEAD`, a value that only ever grows") — the actual CI scripts just never did that. Fixed both `build-and-release.yml` and `publish-play.yml` (where a static versionCode would eventually get every Play Store upload rejected outright) to derive `BUILD_NUMBER` from `git rev-list --count HEAD`, matching the documented intent. The manual `BUILD_NUMBER_OVERRIDE` repo-variable escape hatch is unchanged and still takes priority when set.

## Test plan
- [ ] Confirm `pr-check.yml`'s `check` job passes (existing round-trip encrypt/decrypt test still covers correctness with a software key).
- [ ] On a real device: save every credential field in Settings and confirm success (dots on revisit, no more "Caller-provided IV not permitted" toast).
- [ ] Confirm the next two CI builds produce artifacts with different `build` components in their version string.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdR1Kn5HNmKjEwrv82RZ31)_