### PR TITLE
Documentation freshness pass

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -6,9 +6,10 @@ IDEaz currently operates on a **Bring Your Own Key (BYOK)** model. It does not h
 ## 2. API Key Management
 
 ### Storage Mechanism
-*   **General implementation:** Most legacy keys remain in Android's default `SharedPreferences`; completing their at-rest migration is separate security debt.
-*   **Provider credentials:** Gemini (`KEY_GOOGLE_API_KEY`) and gated Hugging Face (`KEY_HF_API_KEY`) credentials are stored as AES-GCM ciphertext in the dedicated `ideaz_secure_credentials` preferences file. Its non-exportable AES key is generated and retained by Android Keystore. Preference keys are hashed, so neither credentials nor provider names are stored in plaintext there.
-*   **Migration:** Reading a legacy plaintext Gemini or Hugging Face credential first writes it successfully to the secure store, then removes the default-preferences value. A failed secure write leaves the legacy value intact rather than converting a security migration into a credential shredder.
+*   **Secure credentials:** Every provider token/key, plus the app-signing passwords, are stored as AES-GCM ciphertext in the dedicated `ideaz_secure_credentials` preferences file (`AndroidKeystoreCredentialStore`). Its non-exportable AES key is generated and retained by Android Keystore. Preference keys are hashed (SHA-256), so neither credentials nor provider names are stored in plaintext there. The full set of secure keys (`SettingsViewModel.SECURE_CREDENTIAL_KEYS`): Jules API key, GitHub PAT, Google AI Studio (Gemini) key, and the six free/paid OpenAI-compatible provider keys (Groq, Cerebras, Hugging Face, Mistral, OpenAI, Anthropic, DeepSeek), plus the keystore and key-signing passwords. Everything else (theme, log level, AI-provider *assignment* choices, project paths, GitHub username/branch, etc.) stays in ordinary default `SharedPreferences` since none of it is a secret.
+*   **Encryption detail:** `Cipher.init(ENCRYPT_MODE, key)` is called with **no caller-supplied IV** — the AndroidKeyStore provider generates one internally and it's read back via `cipher.iv` before being stored alongside the ciphertext. An AndroidKeyStore-backed key created with `setRandomizedEncryptionRequired(true)` (the default) rejects a caller-provided IV outright (`InvalidAlgorithmParameterException`); this bit a full pass of secure-credential saves in production for a stretch before being caught and fixed. See `encryptCredential`/`decryptCredential` in `AndroidKeystoreCredentialStore.kt` for the reasoning, and don't reintroduce a caller-supplied IV on the encrypt path.
+*   **Migration:** Reading a legacy plaintext credential (from before a given key was moved into `SECURE_CREDENTIAL_KEYS`, or from an older app version) first writes it successfully to the secure store, then removes the default-preferences value. A failed secure write leaves the legacy value intact rather than converting a security migration into a credential shredder.
+*   **Failure visibility:** Every secure-credential read/write/migration failure is logged with the underlying exception (`SettingsViewModel.lastCredentialError`) and surfaced directly in the Settings screen's save-result Toast (e.g. "GitHub Token Save Failed: <reason>"), since most devices this ships to have no adb/logcat access. A cleanup-only failure (removing an already-migrated legacy plaintext entry) is logged but never reported as a save failure — only the real credential write's own outcome determines success.
 *   **Backup:** Both default credential preferences and the secure ciphertext preferences are excluded from cloud backup and device transfer because restored ciphertext would not have its original Keystore key.
 *   **Explicit export:** User-requested settings export may include the token only inside the `SecurityUtils` payload protected by a password of at least eight characters. Routine logs, WorkManager data, notifications, and automatic backups do not include it.
 
@@ -20,6 +21,7 @@ IDEaz currently operates on a **Bring Your Own Key (BYOK)** model. It does not h
         *   **Git:** `GitManager` (JGit) uses `UsernamePasswordCredentialsProvider` for cloning/pushing private repos.
         *   **API:** `GitHubApiClient` for Releases, Forking, Secrets, and Reporting bugs.
         *   **Header:** `Authorization: Bearer <TOKEN>`
+        *   **Save side effect:** saving a valid token immediately triggers `MainViewModel.fetchGitHubRepos()`, refreshing the Clone tab's repo list without waiting for the tab to remount.
 2.  **Google AI Studio API Key (Gemini)**
     *   **Key:** `google_api_key`
     *   **Usage:** Authenticating requests to the Gemini API (`GeminiApiClient`).
@@ -31,6 +33,12 @@ IDEaz currently operates on a **Bring Your Own Key (BYOK)** model. It does not h
     *   **Usage:** Used for all calls to `jules.googleapis.com`.
     *   **Header:** `X-Goog-Api-Key: <KEY>`
     *   **Interceptor:** `AuthInterceptor` injects the key from `SettingsViewModel` into every request.
+5.  **Free-tier OpenAI-compatible providers** — Groq (`KEY_GROQ_API_KEY`), Cerebras (`KEY_CEREBRAS_API_KEY`), Hugging Face Inference (`KEY_HF_API_KEY`, also gates on-device model downloads), Mistral (`KEY_MISTRAL_API_KEY`).
+6.  **Paid-tier OpenAI-compatible providers** — OpenAI (`KEY_OPENAI_API_KEY`), Anthropic (`KEY_ANTHROPIC_API_KEY`), DeepSeek (`KEY_DEEPSEEK_API_KEY`).
+    *   All six route through `AiAdapterFactory`/`OpenAiCompatibleAdapter`; each key is entered once in Settings and selected per-task via the AI Assignments dropdowns, or picked automatically as the app's default model (see §2.1).
+
+### 2.1 Default model selection
+`SettingsViewModel.getAiAssignment(KEY_AI_ASSIGNMENT_DEFAULT)` no longer hardcodes Gemini. When the user hasn't explicitly chosen a "Default" AI assignment, it walks `AiModels.defaultRanking` (Gemini → Anthropic → OpenAI → DeepSeek → Groq → Cerebras → HF → Mistral → Jules → Gemini CLI, on-device fallbacks last) and picks the highest-ranked model whose required key is actually saved, falling back to Gemini only when no provider key has been entered anywhere. An explicit "Default" choice from the AI Assignments dropdown always wins over the ranked auto-pick.
 
 ## 3. Keystore (Android Signing)
 *   **Format:** JKS / Keystore file.
@@ -43,9 +51,9 @@ IDEaz currently operates on a **Bring Your Own Key (BYOK)** model. It does not h
 ## 4. Security Best Practices
 *   **No Hardcoding:** Never hardcode API keys or tokens in the source code.
 *   **Log Redaction:** Ensure logs (especially those sent to AI or GitHub) do not contain raw API keys. The `LoggingInterceptor` handles basic redaction of sensitive headers.
-*   **Permissions:** The app requests sensitive permissions (Accessibility, Overlay). Respect the user's trust and only use these for their intended purpose.
+*   **Permissions:** The app requests sensitive permissions (Accessibility, Overlay, Post Notifications, Install Unknown Apps). Broad storage permissions (`MANAGE_EXTERNAL_STORAGE`, `READ/WRITE_EXTERNAL_STORAGE`) and `PACKAGE_USAGE_STATS`/`QUERY_ALL_PACKAGES` were removed during the P0.2 permission-minimization pass; SAF pickers cover file access instead, and package visibility is scoped to a `<queries>` block naming only the specific packages IDEaz needs to see. Respect the user's trust and only use the remaining permissions for their intended purpose.
 *   **Encryption:** Use `SecurityUtils` (AES+PBKDF2) for exporting settings.
-*   **At-rest gated tokens:** Use `AndroidKeystoreCredentialStore`; never copy them back into default preferences for convenience.
+*   **At-rest secrets:** Use `AndroidKeystoreCredentialStore` for every key in `SECURE_CREDENTIAL_KEYS` (§2); never copy them back into default preferences for convenience.
 
 ## 5. Social Sign-On (Planned)
 *   **Status:** Not Implemented.

--- a/docs/build_pipeline.md
+++ b/docs/build_pipeline.md
@@ -50,14 +50,50 @@ The boundary is deliberate. A production SBOM must describe the production artif
 
 ---
 
-## 6. Releasing IDEaz itself to Google Play (App Bundle)
+## 6. Releasing IDEaz itself (GitHub Releases + Google Play)
 
 IDEaz can ship to the Play Console as a signed **Android App Bundle (.aab)** in
-addition to the GitHub-Release APK channel described above. The two channels coexist:
-the existing [`build-and-release.yml`](../.github/workflows/build-and-release.yml)
-still builds and publishes a signed **APK** to GitHub Releases on every push, while the
-new [`publish-play.yml`](../.github/workflows/publish-play.yml) builds and (optionally)
+addition to its GitHub-Release APK channel. The two channels coexist:
+[`build-and-release.yml`](../.github/workflows/build-and-release.yml)
+builds and publishes a signed **APK** to GitHub Releases on every push to `master`, while
+[`publish-play.yml`](../.github/workflows/publish-play.yml) builds and (optionally)
 uploads a signed **AAB** to Play on manual dispatch.
+
+### 6.0 GitHub-Release APK channel: debug builds vs. Latest Release
+
+`build-and-release.yml`'s APK channel is itself split by trigger type, so an ordinary
+push never silently becomes "the" release:
+
+| Trigger | Publish step | Tag | Release | `prerelease` |
+|---|---|---|---|---|
+| `push` to `master` (every commit/merge) | **Publish Debug Build** | `debug-v$major.$minor` | "Latest Debug Build ($tag)" | `true` |
+| `workflow_dispatch` (a human runs the workflow manually from the Actions tab) | **Publish Latest Release** | `v$major.$minor` | "Latest Release ($tag)" | `false` |
+
+Both tags are **major.minor only** — no patch or build component — so every build within
+the same minor version rolls into the same release (`gh release view $TAG` finds the
+existing release and `gh release edit`s it in place, uploading the new APK alongside
+prior ones) instead of fragmenting into one release per commit, which is what happened
+before this was fixed. Bumping `minor` in `version.properties` is what starts a fresh
+debug/release pair; see [`version.properties`](../version.properties) and its own "only
+ever bump `minor`, and only when the amount of work warrants it" convention.
+
+Getting a genuine "Latest Release" therefore requires someone to manually trigger the
+workflow — pushing to master only ever updates the debug release.
+
+### 6.0.1 Build-number derivation
+
+Both `build-and-release.yml` and `publish-play.yml` pass `-PversionBuild=$BUILD_NUMBER`
+to Gradle, where `BUILD_NUMBER` is `git rev-list --count HEAD` (total commit count),
+unless the `BUILD_NUMBER_OVERRIDE` repository variable is set, in which case that wins.
+This is a value that only ever grows, matching what `app/build.gradle.kts`'s own comment
+on `versionBuildOverride` has always documented as the intended design. Earlier versions
+of these workflows instead read the static `build` field back out of `version.properties`
+and passed that same value right back in — a circular no-op, since nothing in either
+pipeline ever increments or commits that field — so every CI-built artifact carried the
+exact same version string no matter how many commits/builds had happened. `build` in
+`version.properties` is effectively vestigial for CI now; it only matters for a purely
+local `./gradlew assembleDebug`/`bundleRelease` run made without `-PversionBuild`, where
+`IncrementBuildNumberTask` still bumps it on disk as before.
 
 ### 6.1 Build a signed AAB locally
 

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -35,23 +35,34 @@
 
 * **Scrollable Column with Haze Effect**
     * Description (Looks Like): Standard vertical scrolling settings list.
+* **Saved Settings and Credentials Section**
+    * **Save Settings / Load Settings buttons**: export/import all settings (including every secure credential) as a password-protected encrypted file via `SecurityUtils`.
+* **Signing Configuration Section**
+    * **Select Custom Keystore**: SAF picker; imports a `.keystore`/`.jks` file to `filesDir/user_release.keystore`.
+    * **Keystore Password / Key Alias / Key Password** fields, a **Save** button, and **Reset to Default** (reverts to the debug keystore).
 * **API Keys Section**
-    * **GitHub Personal Access Token**: Input for the GitHub PAT used for repo management and automated issue reporting.
-    * **Jules / AI Studio Keys**: Inputs for other AI providers.
-    * **Hugging Face Token**: Stored as Android-Keystore-backed AES-GCM ciphertext for gated on-device model downloads.
+    * **Jules API Key**, **GitHub Personal Access Token**, **AI Studio API Key** (Gemini), **Google Cloud Project Number** — each with a "Get Key" link to the provider's key-issuance page. Saving the GitHub token also refreshes the Clone tab's repo list (`fetchGitHubRepos()`).
+    * **Free Providers** (Groq, Cerebras, Hugging Face, Mistral) and **Paid Providers** (OpenAI, Anthropic, DeepSeek) — one row each (`FreeProviderKeyRow`), same shape as the keys above: masked input, "Get Key" link, per-row Save.
+    * **Gemini App (Accessibility)**: status button showing whether the Gemini-app accessibility bridge is granted; tapping it when ungranted opens Accessibility settings.
+    * Every save/failure Toast in this section reports the actual underlying error (`SettingsViewModel.lastCredentialError`) on failure — see [`auth.md`](auth.md) §2 for why that matters on devices with no adb access.
+* **AI Assignments Section**
+    * One dropdown per task (Default, Project Initialization, Contextless Chat, Overlay Chat) listing every `AiModel` in `AiModels.availableModels`. An unset "Default" resolves automatically to the highest-ranked provider the user has a key for (`auth.md` §2.1), not a hardcoded model.
+* **On-device Models Section** (`OnDeviceModelsSection`)
+    * Lists locally-downloadable models, gated on AICore support / RAM-ABI requirements / a saved Hugging Face token where the model requires one.
 * **Permissions Section**
-    * ... (Overlay, Accessibility, Notification, Install checks). The Screen Capture
-      (MediaProjection) row was removed — that's a Phase-2 (Android target) feature,
-      dormant in the PWA-only product.
+    * An **"Open App Info"** button and explanatory text at the top: Android can label Accessibility/Overlay grants "restricted" for a sideloaded app until the user visits system App Info and enables them via its overflow menu — this jumps straight there.
+    * Overlay, Accessibility, Post Notifications, and Install Unknown Apps checks, each with a one-line description of why IDEaz needs it. The Screen Capture (MediaProjection) row was removed — that's a Phase-2 (Android target) feature, dormant in the PWA-only product. Broad storage permissions were removed entirely (P0.2 permission-minimization); SAF pickers cover file access instead.
 * **Preferences Section**
     * **Show Cancel Warning Checkbox**: Toggles cancellation dialog.
     * **Auto-report IDE internal errors Checkbox**: Toggles the automated GitHub issue reporting feature (`GithubIssueReporter`).
+    * **Auto-debug build failures with Jules Checkbox**.
+    * **Report IDE errors to HereLiesAz/IDEaz Checkbox**.
 * **Theme Dropdown**
     * ... (Auto, Dark, Light, System)
 * **Log Level Dropdown**
     * ... (Info, Debug, Verbose)
-* **"Clear Build Caches" Button**
-    * ...
+* **Updates Section**
+    * **Check for Experimental Updates** button; an `AlertDialog` shows update progress/prompts to install when one is found.
 
 ---
 
@@ -63,7 +74,7 @@
     * Description (Does): Centralizes application logic. Uses Delegates (`AIDelegate`, `BuildDelegate`, etc.) to handle specific domains.
     * **Implements:** `handleIdeError` to route internal crashes to the `GithubIssueReporter` (via API) while routing build failures to the AI Debugger.
 * **Class: SettingsViewModel**
-    * Description (Does): Manages settings, including the new `KEY_AUTO_REPORT_BUGS` and `KEY_GITHUB_TOKEN`.
+    * Description (Does): Manages settings, secure-credential storage (`SECURE_CREDENTIAL_KEYS`, `AndroidKeystoreCredentialStore`), the ranked default-AI-model resolution (`AiModels.defaultRanking`), and `lastCredentialError` for surfacing real save/read failures in the UI (see [`auth.md`](auth.md)).
 
 ### B. Services and Inter-Process Communication (IPC)
 

--- a/docs/screens.md
+++ b/docs/screens.md
@@ -34,7 +34,7 @@
 
 ## 6. Settings Screen (`SettingsScreen.kt`)
 *   **Role:** Configuration. Opaque background.
-*   **Sections:** Build Configuration, Saved Settings & Credentials (PBKDF2-encrypted export/import), Signing Configuration, API Keys, On-device Models, AI Assignments, Permissions, Preferences/Theme/Logs/Updates/Debug. Gated Hugging Face model tokens are stored through Android Keystore and never copied into WorkManager state.
+*   **Sections:** Saved Settings & Credentials (PBKDF2-encrypted export/import), Signing Configuration, API Keys (Jules/GitHub/AI Studio plus four free-tier and three paid-tier OpenAI-compatible providers), On-device Models, AI Assignments, Permissions (with an "Open App Info" shortcut for Android's restricted-settings block on sideloaded apps), Preferences/Theme/Logs/Updates. Every provider credential and the signing passwords are stored through Android Keystore, never copied into WorkManager state. See [`auth.md`](auth.md) and [`manifest.md`](manifest.md) §V for the full detail.
 
 The Chat tab renders local-provider failures as status cards outside conversational
 history. Cards expose retry availability, whether cloud fallback could be offered

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -54,7 +54,7 @@ The IDEaz project's own CI (`.github/workflows/`) builds the app on every push:
 *   **Unit tests:** `./gradlew :app:testDebugUnitTest`.
 *   **Assemble debug:** `./gradlew :app:assembleDebug`.
 
-Release artifacts ship via tagged builds.
+Release artifacts ship via tagged builds — every push updates a rolling "Latest Debug Build" prerelease, while the actual "Latest Release" only updates on a manually-triggered workflow run. See [`build_pipeline.md`](build_pipeline.md) §6.0 for the tag/trigger details.
 
 The dependency-submission workflow publishes the resolved release-runtime graph for `:app` and `:webruntime`. It does not submit test, lint, Gradle, AGP, or plugin configurations as application dependencies. Those tools run only in CI and are maintained through pinned workflow/plugin versions and Dependabot; the submitted graph is the production APK/AAB software bill of materials.
 


### PR DESCRIPTION
## Summary
Full documentation-freshness pass across `docs/` — bringing everything up to date with this session's fixes (credential storage/IV bug, build-number/release-tag CI fixes, permission minimization, AI edit approval across providers, OperationState/OperationController foundation) and filling in gaps found along the way.

This first commit covers `auth.md`, `build_pipeline.md`, `workflow.md`, `manifest.md`, and `screens.md` (done directly). Several agents are running in parallel over the rest of the doc tree (`architecture.md`, `data_layer.md`, `file_descriptions.md`, `TODO.md`, `ux_userflow_audit.md`, `testing.md`, `error_handling.md`, `performance.md`, `UI_UX.md`, `README.md`, `AGENTS.md`, and the remaining misc docs) — their changes will land as follow-up commits on this same PR.

## Test plan
- [ ] Read through for accuracy — this is a docs-only change, no build/CI impact expected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdR1Kn5HNmKjEwrv82RZ31)_

## Summary by Sourcery

Refresh core documentation to accurately describe current credential handling, AI provider configuration, permissions, UI settings, and release workflows.

Enhancements:
- Update authentication documentation to cover secure storage for all credentials, encryption IV handling, migration behavior, error visibility, provider integrations, and automatic default-model selection.
- Document the current GitHub Release and Google Play build pipelines, including debug-versus-release publishing and monotonic CI build-number derivation.
- Refresh manifest and screen documentation to reflect current settings sections, provider configuration, permissions, on-device models, AI assignments, and update flows.

Documentation:
- Bring authentication, build pipeline, workflow, manifest, and screen documentation in line with current application behavior and recent security, provider, permission, and release-process changes.