### PR TITLE
Pin unit-test JVM heap to fix build-and-release.yml test-executor crash

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -393,3 +393,17 @@ tasks.configureEach {
         dependsOn("incrementBuildNumber")
     }
 }
+
+// build-and-release.yml's `./gradlew build` runs the full release variant (R8,
+// lintVital) and the debug variant (including this test task) in one Gradle
+// daemon session, so by the time the forked unit-test JVM starts, an unbounded
+// heap request competes with whatever the daemon/compiler processes still hold.
+// A CI run on the unchanged code that had just passed the same test task in a
+// lighter job crashed here with "Test process encountered an unexpected
+// problem... Process 'Gradle Test Executor 1' finished with non-zero exit
+// value 1" and zero test output - consistent with the forked JVM failing to
+// even start. Pin an explicit, modest heap so the request is predictable
+// instead of derived from momentary runner memory pressure.
+tasks.withType<Test>().configureEach {
+    maxHeapSize = "1536m"
+}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -394,16 +394,9 @@ tasks.configureEach {
     }
 }
 
-// build-and-release.yml's `./gradlew build` runs the full release variant (R8,
-// lintVital) and the debug variant (including this test task) in one Gradle
-// daemon session, so by the time the forked unit-test JVM starts, an unbounded
-// heap request competes with whatever the daemon/compiler processes still hold.
-// A CI run on the unchanged code that had just passed the same test task in a
-// lighter job crashed here with "Test process encountered an unexpected
-// problem... Process 'Gradle Test Executor 1' finished with non-zero exit
-// value 1" and zero test output - consistent with the forked JVM failing to
-// even start. Pin an explicit, modest heap so the request is predictable
-// instead of derived from momentary runner memory pressure.
+// Pin an explicit, modest test-JVM heap instead of leaving it to the JVM's
+// own memory-derived default, which crashed the forked test executor under
+// build-and-release.yml's heavier combined release+debug build (see PR #850).
 tasks.withType<Test>().configureEach {
     maxHeapSize = "1536m"
 }

--- a/docs/build_pipeline.md
+++ b/docs/build_pipeline.md
@@ -95,6 +95,19 @@ exact same version string no matter how many commits/builds had happened. `build
 local `./gradlew assembleDebug`/`bundleRelease` run made without `-PversionBuild`, where
 `IncrementBuildNumberTask` still bumps it on disk as before.
 
+### 6.0.2 Pinned unit-test JVM heap
+
+`build-and-release.yml` runs `./gradlew build`, which assembles and checks every
+variant — including release R8 minification and `lintVital` — in one Gradle daemon
+session before it reaches the debug unit tests. A CI run once crashed at
+`:app:testDebugUnitTest` with "Test process encountered an unexpected problem" and
+zero test output, 4 seconds after the task started, on a commit that had just passed
+the same test task cleanly in a lighter job — the forked test JVM's unbounded default
+heap request was competing with whatever the daemon and compiler processes still held
+on the runner by that point in the build. `app/build.gradle.kts` pins
+`tasks.withType<Test>().configureEach { maxHeapSize = "1536m" }` so that request is
+predictable instead of derived from momentary runner memory pressure.
+
 ### 6.1 Build a signed AAB locally
 
 ```bash


### PR DESCRIPTION
## Summary

The post-merge "Merged Build & Release" run for PR #849 ([run 32458401642](https://github.com/HereLiesAz/IDEaz/actions/runs/32458401642)) failed at `:app:testDebugUnitTest`:

```
Gradle Test Run :app:testDebugUnitTest FAILED
    org.gradle.process.ProcessExecutionException at DefaultExecHandle.java:460
...
Execution failed for task ':app:testDebugUnitTest' ...
> Test process encountered an unexpected problem.
   > Process 'Gradle Test Executor 1' finished with non-zero exit value 1
```

The task started at `07:33:07Z` and failed at `07:33:11Z` — 4 seconds later, with zero test output. The forked test JVM never got far enough to execute a single test. Notably, the *identical commit* (`ce9e2ef5`) had just passed this exact test task cleanly in the PR's own `check` and `submit-gradle` jobs a few minutes earlier, ruling out a code regression in the tests themselves.

### Root cause

`build-and-release.yml` invokes `./gradlew build`, which assembles and checks **every variant** — including the release variant's R8 minification and `lintVital` analysis (which alone took ~2.5 minutes in the failing run) — in a single Gradle daemon session, before it ever reaches the debug unit tests. By the time `:app:testDebugUnitTest` forks its test-executor JVM, that JVM's *unbounded* default heap request has to compete with whatever the Gradle daemon (`-Xmx3072m`) and lingering compiler/R8/lint sub-processes still hold on the runner. No `maxHeapSize` was ever set on the `Test` task, so its JVM heap sizing was left entirely to the OS/JVM's own memory-derived defaults — a bad idea on an already-squeezed CI runner.

### Fix

`app/build.gradle.kts`: pin an explicit `maxHeapSize = "1536m"` on every `Test` task, so the request is predictable and modest instead of derived from momentary runner memory pressure.

## Test plan
- [x] `./gradlew :app:compileDebugKotlin` — builds clean with the change
- [x] `./gradlew :app:testDebugUnitTest` — full suite green locally with the pinned heap
- [ ] CI (`check`, `submit-gradle`) green on this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdR1Kn5HNmKjEwrv82RZ31)_

## Summary by Sourcery

Pin unit-test JVM memory usage to make combined build-and-release test runs reliable on constrained CI runners.

Bug Fixes:
- Prevent test-executor crashes in resource-constrained CI builds by capping unit-test JVM heap usage.

Documentation:
- Document the pinned unit-test JVM heap and the CI failure it addresses in the build pipeline guide.