### PR TITLE
Fix the on-device wasm-preview reload path's whole-cache nuke

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/web/WebProjectHost.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/web/WebProjectHost.kt
@@ -95,10 +95,11 @@ class IdeazJsInterface(private val context: Context) {
  *
  * Android projects are previewed through this same host: when
  * [WasmCompilerService] finishes compiling a project it broadcasts
- * [ACTION_WASM_COMPILE_SUCCESS], and this composable then mounts `filesDir/www`,
- * clears the WebView cache (Wasm binaries are aggressively cached and would
- * otherwise be re-instantiated from the stale copy) and hot-reloads the HTML
- * host page.
+ * [ACTION_WASM_COMPILE_SUCCESS], and this composable mounts `filesDir/www` and
+ * reloads. No cache-clear is needed for that reload to pick up the fresh
+ * .wasm - see [WebProjectPathHandler]'s no-store response headers. This does
+ * not preserve Compose UI state across a reload; the Wasm module (and
+ * everything it renders to its `<canvas>`) is fully reinstantiated each time.
  */
 // Lint's JavascriptInterface check can't resolve the annotated members of
 // IdeazJsInterface/WebViewBridge through a remember<T>-typed local (confirmed:
@@ -357,13 +358,17 @@ fun WebProjectHost(
                     val dir = intent.getStringExtra(EXTRA_WWW_DIR)
                         ?.let { File(it) }
                         ?: File(webView.context.filesDir, WasmCompilerService.WWW_DIR_NAME)
-                    // Mount the compiler's output directory, drop every cached
-                    // copy of the previous binary, then re-enter the host page so
-                    // the fresh .wasm is instantiated.
+                    // Mount the compiler's output directory, then reload. No
+                    // cache to clear: WebProjectPathHandler marks every response
+                    // no-store, so a plain reload always re-fetches the fresh
+                    // .wasm/.js pair even though their filenames (and therefore
+                    // this URL) are unchanged across recompiles. This does not
+                    // preserve UI state - the Wasm module is fully reinstantiated
+                    // - Kotlin/Wasm has no JVM-style live class redefinition to
+                    // build a true state-preserving hot reload on top of.
                     wasmPreviewDir.value = dir
                     projectDirState.value = dir
-                    webView.clearCache(true)
-                    webView.loadUrl(WebProjectUrlUtils.localProjectRootUrl())
+                    webView.reload()
                     return
                 }
 

--- a/app/src/main/kotlin/com/hereliesaz/ideaz/ui/web/WebProjectPathHandler.kt
+++ b/app/src/main/kotlin/com/hereliesaz/ideaz/ui/web/WebProjectPathHandler.kt
@@ -126,13 +126,13 @@ class WebProjectPathHandler(
         // vectors that cost nothing to block.
         return WebResourceResponse(
             mime, encoding, 200, "OK",
-            mapOf("Content-Security-Policy" to CONTENT_SECURITY_POLICY),
+            mapOf("Content-Security-Policy" to CONTENT_SECURITY_POLICY) + NO_CACHE_HEADERS,
             stream,
         )
     }
 
     private fun notFound(): WebResourceResponse = WebResourceResponse(
-        "text/plain", "utf-8", 404, "Not Found", emptyMap(),
+        "text/plain", "utf-8", 404, "Not Found", NO_CACHE_HEADERS,
         ByteArrayInputStream(ByteArray(0))
     )
 
@@ -146,6 +146,21 @@ class WebProjectPathHandler(
         // and fused, its assets stay reachable through the base AssetManager, so
         // this lookup is unchanged from when they were bundled directly in :app.
         private const val RUNTIME_ASSET_DIR = "ideaz-runtime"
+
+        // Every response from this handler serves a project's *current* on-disk
+        // content, re-read on every request - it is never safe for the WebView's
+        // HTTP cache to reuse a prior response for the same URL. Output filenames
+        // are stable across recompiles (WasmCompilerService always writes
+        // `app.wasm`/`app.js`; a project's own index.html keeps its name too), so
+        // without this the WebView previously had to be told to nuke its *entire*
+        // cache (WebProjectHost.clearCache(true)) on every reload just to avoid
+        // re-instantiating a stale Wasm binary under an unchanged URL. Declaring
+        // every response here as never-cacheable makes that whole-cache wipe
+        // unnecessary - a plain reload always re-fetches fresh bytes.
+        private val NO_CACHE_HEADERS = mapOf(
+            "Cache-Control" to "no-store, no-cache, must-revalidate",
+            "Pragma" to "no-cache",
+        )
 
         /** See the comment on [response] for what this does and doesn't restrict. */
         private const val CONTENT_SECURITY_POLICY =


### PR DESCRIPTION
## Summary

Follow-up on a "implement Compose Hot Reload" request. JetBrains' actual `org.jetbrains.compose.hot-reload` tooling turned out not to apply here: it only drives a **JVM desktop preview window** via JetBrains-Runtime class redefinition, never a real Android device — and IDEaz's `:app` module is plain Jetpack Compose (Android-only), not Kotlin Multiplatform, so there's nowhere for that tooling to attach in the first place. After clarifying scope, the real, buildable target was IDEaz's own existing on-device preview loop: `WasmCompilerService` (compiles a user's Android/Compose-Multiplatform project to Wasm) → `WebProjectHost` (WebView preview).

### What was wrong

Every wasm-compile-success reload called `webView.clearCache(true)` before reloading — a workaround for `WebProjectPathHandler` never declaring cache freshness on its responses. Since the compiled binary's filename (`app.wasm`/`app.js`) is stable across recompiles, a plain reload risked re-serving stale bytes at the same URL. Nuking the *entire* WebView HTTP cache on every single recompile to work around that was overkill — it discards everything else cached too (fonts, unrelated assets), and does `clearCache` + `loadUrl` where one call is needed.

### Fix

- `WebProjectPathHandler` now marks every response it serves `Cache-Control: no-store` — all of it is a project's live-editable content, re-read from disk on every request, so it's never actually safe to cache regardless of filename stability.
- `WebProjectHost`'s wasm-compile-success handler now just remounts the output directory and calls `webView.reload()` — no more whole-cache wipe, no more double `clearCache`+`loadUrl`.

### What this does *not* do

This is **not** state-preserving hot reload. Kotlin/Wasm has no JVM-style live class redefinition to build that on top of (unlike JetBrains' CHR, which relies on JBR's bytecode redefinition while the same JVM process stays alive) — the Wasm module, and everything it renders to its `<canvas>`, is still fully reinstantiated on every reload, same as before. What changes is that the reload cycle no longer pays for discarding the entire WebView cache on every recompile.

## Test plan
- [x] `./gradlew :app:compileDebugKotlin` — builds clean
- [x] `./gradlew :app:testDebugUnitTest --tests "com.hereliesaz.ideaz.ui.web.*"` — green (no existing test asserted on response headers, so nothing broke)
- [ ] CI (`check`, `submit-gradle`) green on this PR
- [ ] Manual: compile an Android/CMP project's preview twice in a row and confirm the second compile's output isn't served stale (can't be exercised in this environment — no bundled `assets/wasm-compiler/`, see `docs/data_layer.md` §4)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdR1Kn5HNmKjEwrv82RZ31)_

## Summary by Sourcery

Make on-device Wasm preview recompilation reload fresh output without discarding the entire WebView cache.

Bug Fixes:
- Ensure on-device Wasm preview reloads always fetch fresh compiled content without serving stale binaries.

Enhancements:
- Replace per-reload whole-WebView cache clearing with no-cache response headers and a standard WebView reload, preserving unrelated cached resources while retaining the existing full Wasm reinitialization behavior.