### PR TITLE
Make GitHub optional until you publish, and stop signing commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,14 @@ you see what changed, and nothing reaches the preview until you approve it.
 
 **Git**
 
-Every project is a git repository and git is the source of truth. You do **not**
-need a GitHub account to start — scaffold a project, edit it, and see it running
-entirely locally. Connecting GitHub is the *publish* step, which is where a token
-has an obvious purpose.
+Every project is a git repository and git is the source of truth. A new project
+is `git init`-ed and gets an initial commit before it has any remote.
+
+You do **not** need a GitHub account to start. Create a project, scaffold it,
+edit it with the AI, and commit — all offline. **Deploy** is the one action that
+asks for a token, and it creates the repository for you on first publish. That is
+the only place in the app where a token has an obvious purpose, so it is the only
+place that asks.
 
 **Building**
 

--- a/app/src/androidMain/kotlin/com/hereliesaz/ideaz/ui/MainViewModel.kt
+++ b/app/src/androidMain/kotlin/com/hereliesaz/ideaz/ui/MainViewModel.kt
@@ -793,8 +793,7 @@ class MainViewModel(
             val projectDir = context.filesDir.resolve(appName)
             withContext(Dispatchers.IO) {
                 projectDir.mkdirs()
-                val scaffolded =
-                    com.hereliesaz.ideaz.utils.TemplateManager.ensureTemplate(context, projectDir)
+                com.hereliesaz.ideaz.utils.TemplateManager.ensureTemplate(context, projectDir)
 
                 // "Every project is a git repository and git is the source of
                 // truth" - but nothing initialised one on the local path. Only
@@ -802,13 +801,18 @@ class MainViewModel(
                 // created and edited offline had no history to inspect, no undo
                 // below the AI's own checkpoints, and nothing to push when the
                 // user finally did connect an account.
+                //
+                // The initial commit is unconditional, not gated on whether the
+                // starter was just scaffolded. An imported folder is the case
+                // that gating broke: files present, nothing scaffolded, so it got
+                // `init` and no commit - a repository with no HEAD, which is a
+                // worse state than either alternative. An empty directory commits
+                // fine (verified in GitManagerTest), so there is nothing to guard.
                 val git = GitManager(projectDir)
                 if (!git.isRepo()) {
                     git.init()
-                    if (scaffolded) {
-                        runCatching { git.addAll(); git.commit("Initial commit") }
-                            .onFailure { logHandler.onBuildLog("[GIT] Initial commit failed: ${it.message}\n") }
-                    }
+                    runCatching { git.addAll(); git.commit("Initial commit") }
+                        .onFailure { logHandler.onBuildLog("[GIT] Initial commit failed: ${it.message}\n") }
                 }
             }
 

--- a/app/src/androidMain/kotlin/com/hereliesaz/ideaz/ui/MainViewModel.kt
+++ b/app/src/androidMain/kotlin/com/hereliesaz/ideaz/ui/MainViewModel.kt
@@ -531,9 +531,14 @@ class MainViewModel(
             return
         }
         val projectDir = settingsViewModel.getProjectPath(appName)
-        if (!File(projectDir, "index.html").isFile) {
+        // Ask ProjectAnalyzer, not `File(projectDir, "index.html")`. This used to
+        // check the repo root only, so a project whose entry point lives at
+        // public/index.html or src/index.html - which the load gate admits and
+        // launchTargetApp mounts happily - was refused right here. Build and App
+        // View disagreed about the same project.
+        if (ProjectAnalyzer.findWebEntryPoint(projectDir) == null) {
             logHandler.onBuildLog(
-                "[IDE] $appName has no index.html at its root, so there is nothing to preview.\n"
+                "[IDE] $appName has no index.html, so there is nothing to preview.\n"
             )
             return
         }
@@ -564,10 +569,28 @@ class MainViewModel(
         viewModelScope.launch {
             logHandler.onBuildLog("Deploying Web Project (Push to GitHub)...")
             try {
-                // Ensure GitHub Pages workflow / AGENTS.md / setup script are
-                // in the project before deploying. Save & Initialize for PWAs
-                // is local-only now, so the first Deploy is what generates
-                // these and pushes them.
+                if (appName.isNullOrBlank()) {
+                    logHandler.onBuildLog("Deploy failed: no project is open.")
+                    return@launch
+                }
+                // Publishing is the one step that needs an account, so it is the
+                // one step that asks for a token - and it creates the repository
+                // if this project has never been published. Everything before
+                // this point works offline.
+                if (!repoDelegate.ensureRemoteRepository(appName)) {
+                    withContext(Dispatchers.Main) {
+                        Toast.makeText(
+                            getApplication(),
+                            "Deploy needs a GitHub token. Add one in Settings.",
+                            Toast.LENGTH_LONG,
+                        ).show()
+                    }
+                    return@launch
+                }
+
+                // Generate the Pages workflow / AGENTS_SETUP.md / version.properties
+                // before pushing. Creating a project is local-only, so the first
+                // Deploy is what writes and pushes these.
                 repoDelegate.forceUpdateInitFiles()
                 // Ensure latest changes are committed
                 gitDelegate.commit("Deploy: ${System.currentTimeMillis()}")
@@ -723,19 +746,28 @@ class MainViewModel(
     fun scanLocalProjects() = repoDelegate.scanLocalProjects()
     fun getLocalProjectsWithMetadata() = repoDelegate.getLocalProjectsWithMetadata()
     fun forceUpdateInitFiles() = repoDelegate.forceUpdateInitFiles()
-    /** Creates a new repo and initializes the project. */
-    fun createGitHubRepository(name: String, desc: String, priv: Boolean, ctx: Context, initialPrompt: String? = null, onSuccess: () -> Unit) {
-        repoDelegate.createGitHubRepository(name, desc, priv, ctx) { owner, branch ->
-            // Local content is either cloned from the template repo (generate
-            // flow, handled in RepoDelegate) or scaffolded from the bundled
-            // template by saveAndInitialize's ensureTemplate when the directory
-            // is still empty (fallback). Either way ensureTemplate is a no-op
-            // once files are present, so we don't copy here. The initial prompt
-            // is dispatched by saveAndInitialize AFTER scaffolding, so the AI
-            // never runs against an empty project.
-            saveAndInitialize(name, owner, branch, ctx, initialPrompt)
-            onSuccess()
-        }
+    /**
+     * Creates a new project. Entirely local and offline: no GitHub account, no
+     * token, no network.
+     *
+     * This used to be `createGitHubRepository`, which made the remote first and
+     * cloned it back down, so the Create button was hard-gated on a token. The
+     * repository is now created by the first Deploy
+     * ([RepoDelegate.ensureRemoteRepository]), which is where a token has an
+     * obvious purpose.
+     */
+    fun createProject(
+        appName: String,
+        description: String,
+        context: Context,
+        initialPrompt: String? = null,
+        onSuccess: () -> Unit,
+    ) {
+        // Held for the first Deploy - there is no repository to attach it to yet.
+        settingsViewModel.saveRepoDescription(description)
+        val owner = settingsViewModel.getGithubUser().orEmpty()
+        saveAndInitialize(appName, owner, "main", context, initialPrompt)
+        onSuccess()
     }
 
     /** Selects a repo and prepares it for use. */
@@ -761,7 +793,23 @@ class MainViewModel(
             val projectDir = context.filesDir.resolve(appName)
             withContext(Dispatchers.IO) {
                 projectDir.mkdirs()
-                com.hereliesaz.ideaz.utils.TemplateManager.ensureTemplate(context, projectDir)
+                val scaffolded =
+                    com.hereliesaz.ideaz.utils.TemplateManager.ensureTemplate(context, projectDir)
+
+                // "Every project is a git repository and git is the source of
+                // truth" - but nothing initialised one on the local path. Only
+                // forceUpdateInitFiles did, and that runs on Deploy, so a project
+                // created and edited offline had no history to inspect, no undo
+                // below the AI's own checkpoints, and nothing to push when the
+                // user finally did connect an account.
+                val git = GitManager(projectDir)
+                if (!git.isRepo()) {
+                    git.init()
+                    if (scaffolded) {
+                        runCatching { git.addAll(); git.commit("Initial commit") }
+                            .onFailure { logHandler.onBuildLog("[GIT] Initial commit failed: ${it.message}\n") }
+                    }
+                }
             }
 
             // Projects live entirely on-device for the edit loop. No GitHub

--- a/app/src/androidMain/kotlin/com/hereliesaz/ideaz/ui/ProjectScreen.kt
+++ b/app/src/androidMain/kotlin/com/hereliesaz/ideaz/ui/ProjectScreen.kt
@@ -46,7 +46,6 @@ fun ProjectScreen(
     navController: NavController
 ) {
     val context = LocalContext.current
-    val hasToken = !settingsViewModel.getGithubToken().isNullOrBlank()
     val loadingProgress by viewModel.loadingProgress.collectAsState()
 
     // --- TABS LOGIC ---
@@ -200,7 +199,6 @@ fun ProjectScreen(
                         val idx = tabs.indexOf(tabName)
                         if (idx != -1) tabIndex = idx
                     },
-                    onNavigateToSettings = { navController.navigate("settings") },
                 )
                 "Clone" -> ProjectCloneTab(
                     viewModel,

--- a/app/src/androidMain/kotlin/com/hereliesaz/ideaz/ui/SettingsViewModel.kt
+++ b/app/src/androidMain/kotlin/com/hereliesaz/ideaz/ui/SettingsViewModel.kt
@@ -144,6 +144,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
         private const val TAG = "SettingsViewModel"
         const val KEY_API_KEY = "api_key" // Jules
         const val KEY_APP_NAME = "app_name"
+        const val KEY_REPO_DESCRIPTION = "repo_description"
         const val KEY_GITHUB_USER = "github_user"
         const val KEY_BRANCH_NAME = "branch_name"
         const val KEY_PROJECT_LIST = "project_list"
@@ -647,6 +648,19 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
         if (appName.isNotBlank()) addProject(appName)
     }
     fun getAppName() = sharedPreferences.getString(KEY_APP_NAME, null)
+
+    /**
+     * Description for the project's GitHub repository, captured in Create mode
+     * and used later by the first Deploy — which is when the repository is
+     * actually made. Create is local and offline, so there is nothing to attach
+     * it to at the time the user types it.
+     */
+    fun saveRepoDescription(description: String) =
+        sharedPreferences.edit { putString(KEY_REPO_DESCRIPTION, description) }
+
+    fun getRepoDescription() =
+        sharedPreferences.getString(KEY_REPO_DESCRIPTION, null)?.takeIf { it.isNotBlank() }
+            ?: "Created with IDEaz"
     fun setAppName(appName: String) {
         sharedPreferences.edit { putString(KEY_APP_NAME, appName) }
         _currentAppName.value = appName

--- a/app/src/androidMain/kotlin/com/hereliesaz/ideaz/ui/delegates/RepoDelegate.kt
+++ b/app/src/androidMain/kotlin/com/hereliesaz/ideaz/ui/delegates/RepoDelegate.kt
@@ -49,15 +49,6 @@ class RepoDelegate(
     private val onGitProgress: (Int, String) -> Unit
 ) {
 
-    private companion object {
-        /**
-         * The official starter new projects are generated from, via GitHub's
-         * generate-from-template API. See `templates/` in the IDEaz repo.
-         */
-        const val TEMPLATE_OWNER = "HereLiesAz"
-        const val TEMPLATE_REPO = "ideaz-react"
-    }
-
     // --- StateFlows ---
 
     private val _ownedRepos = MutableStateFlow<List<GitHubRepoResponse>>(emptyList())
@@ -117,87 +108,72 @@ class RepoDelegate(
     }
 
     /**
-     * Creates a new repository on GitHub and initializes the local project state.
+     * Makes sure the current project has a GitHub repository and an `origin`
+     * remote pointing at it, creating the repository when it does not exist yet.
      *
-     * @param appName The name of the new repository.
-     * @param description A short description.
-     * @param isPrivate Whether the repo should be private.
-     * @param projectType The type of project (Android, Web, etc.).
-     * @param packageName The target package name (e.g., com.example.app).
-     * @param context Context for file operations.
-     * @param onSuccess Callback invoked with the new owner and branch name.
+     * Creating a project used to go through GitHub first: the Create button was
+     * hard-gated on a token, called `generateFromTemplate` to make a
+     * pre-populated remote, then cloned it back down. That meant a named project
+     * could not be scaffolded at all without an account — the README promised
+     * otherwise, and the local path only worked if you accepted the default
+     * project name, because the App Name field is read-only outside Create mode.
+     *
+     * Projects are created locally now, and this runs on the first Deploy, which
+     * is the point where a token has an obvious purpose.
+     *
+     * @return true when the project is ready to push; false when it is not (no
+     *   token, or the API call failed) — the reason is reported to the log.
      */
-    fun createGitHubRepository(
-        appName: String,
-        description: String,
-        isPrivate: Boolean,
-        context: Context,
-        onSuccess: (owner: String, branch: String) -> Unit
-    ) {
-        scope.launch {
-            onLoadingProgress(0)
-            try {
-                val token = settingsViewModel.getGithubToken()
-                if (token.isNullOrBlank()) {
-                    onOverlayLog("Error: No GitHub Token found.")
-                    return@launch
-                }
+    suspend fun ensureRemoteRepository(appName: String): Boolean = withContext(Dispatchers.IO) {
+        val git = GitManager(settingsViewModel.getProjectPath(appName))
+        if (git.remoteUrl("origin") != null) return@withContext true
 
-                val service = GitHubApiClient.createService(token)
-                val configuredUser = settingsViewModel.getGithubUser()?.takeIf { it.isNotBlank() }
+        val token = settingsViewModel.getGithubToken()
+        if (token.isNullOrBlank()) {
+            onOverlayLog(
+                "Deploy needs a GitHub token to publish $appName. Add one in Settings — " +
+                    "creating, editing and previewing all work without an account."
+            )
+            return@withContext false
+        }
 
-                // Prefer generating the new repo from the official starter (the
-                // remote starts pre-populated). Fall back to an empty auto-init
-                // repo if generation fails, e.g. because the template isn't
-                // marked as a template repository.
-                //
-                // This used to consult a ProjectType -> repo-name table. There is
-                // one starter now, so the table is a constant.
-                var generated = false
-                val repo = try {
-                    onOverlayLog("Creating $appName from $TEMPLATE_OWNER/$TEMPLATE_REPO...")
-                    val generatedRepo = service.generateFromTemplate(
-                        TEMPLATE_OWNER,
-                        TEMPLATE_REPO,
-                        com.hereliesaz.ideaz.api.GenerateFromTemplateRequest(
-                            owner = configuredUser,
-                            name = appName,
-                            description = description,
-                            private = isPrivate
-                        )
-                    )
-                    generated = true
-                    generatedRepo
-                } catch (e: Exception) {
-                    onLog("Template generate failed (${e.message}); creating an empty repository instead.")
-                    service.createRepo(
-                        CreateRepoRequest(name = appName, description = description, private = isPrivate, autoInit = true)
-                    )
-                }
+        try {
+            val service = GitHubApiClient.createService(token)
+            val configuredUser = settingsViewModel.getGithubUser()?.takeIf { it.isNotBlank() }
 
-                val derivedOwner = repo.fullName.split("/")[0]
-                val branch = repo.defaultBranch ?: "main"
-
-                // Update Local Config
-                settingsViewModel.setAppName(appName)
-                settingsViewModel.setGithubUser(derivedOwner)
-                settingsViewModel.saveProjectConfig(appName, derivedOwner, branch)
-
-                // When generated from a template, mirror the populated remote
-                // locally by cloning. Otherwise the caller scaffolds the empty
-                // project from the bundled template.
-                if (generated) {
-                    cloneWithRetry(settingsViewModel.getProjectPath(appName), derivedOwner, appName, token)
-                }
-
-                onOverlayLog("Repository created: ${repo.htmlUrl}")
-                onSuccess(derivedOwner, branch)
-
-            } catch (e: Exception) {
-                onOverlayLog("Failed to create repository: ${e.message}")
-            } finally {
-                onLoadingProgress(null)
+            // Reuse the repository when it already exists — a re-Deploy after the
+            // local remote was dropped, or a repo the user made by hand. Only
+            // create when the lookup genuinely fails.
+            val existing = configuredUser?.let {
+                try { service.getRepo(it, appName) } catch (e: Exception) { null }
             }
+
+            val repo = existing ?: run {
+                onOverlayLog("Creating $appName on GitHub...")
+                service.createRepo(
+                    CreateRepoRequest(
+                        name = appName,
+                        description = settingsViewModel.getRepoDescription(),
+                        private = false,
+                        // No auto-init: the local project already has commits, and
+                        // an auto-initialised remote would need a merge before the
+                        // first push could fast-forward.
+                        autoInit = false,
+                    )
+                )
+            }
+
+            val owner = repo.fullName.split("/")[0]
+            val branch = git.getCurrentBranch() ?: repo.defaultBranch ?: "main"
+            settingsViewModel.setGithubUser(owner)
+            settingsViewModel.saveProjectConfig(appName, owner, branch)
+
+            git.addRemote("origin", "https://github.com/$owner/$appName.git")
+            onOverlayLog("Linked $appName to $owner/$appName.")
+            true
+        } catch (e: Exception) {
+            onOverlayLog("Could not create the GitHub repository: ${e.message}")
+            false
         }
     }
 

--- a/app/src/androidMain/kotlin/com/hereliesaz/ideaz/ui/project/SetupTab.kt
+++ b/app/src/androidMain/kotlin/com/hereliesaz/ideaz/ui/project/SetupTab.kt
@@ -34,13 +34,9 @@ fun ProjectSetupTab(
     isCreateMode: Boolean,
     onCreateModeChanged: (Boolean) -> Unit,
     onNavigateToTab: (String) -> Unit,
-    onNavigateToSettings: () -> Unit,
 ) {
     val currentAppNameState by settingsViewModel.currentAppName.collectAsState()
     val loadingProgress by viewModel.loadingProgress.collectAsState()
-
-    // Explicit state for Token Popup
-    var showTokenRequiredDialog by remember { mutableStateOf(false) }
 
     // Derived state for button loading
     val isBusy = loadingProgress != null
@@ -65,26 +61,6 @@ fun ProjectSetupTab(
     // Derived state for button enablement. This used to also require
     // `selectedType in ProjectType.selectable` - a one-element list.
     val isReadyToCreate = initialPrompt.isNotBlank() && appName.isNotBlank()
-
-    if (showTokenRequiredDialog) {
-        AlertDialog(
-            onDismissRequest = { showTokenRequiredDialog = false },
-            title = { Text("GitHub Token Required") },
-            text = { Text("A GitHub token is required to create a repository and automate secret setup.") },
-            confirmButton = {
-                AzButton(
-                    onClick = {
-                        showTokenRequiredDialog = false
-                        onNavigateToSettings()
-                    },
-                    text = "Go to Settings"
-                )
-            },
-            dismissButton = {
-                TextButton(onClick = { showTokenRequiredDialog = false }) { Text("Cancel") }
-            }
-        )
-    }
 
     LazyColumn(modifier = Modifier.fillMaxSize().padding(16.dp)) {
         item {
@@ -136,7 +112,7 @@ fun ProjectSetupTab(
             AzTextBox(
                 value = githubUser,
                 onValueChange = { githubUser = it },
-                hint = "GitHub User",
+                hint = "GitHub User (optional until you publish)",
                 onSubmit = {},
                 enabled = isCreateMode,
                 keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next)
@@ -159,7 +135,7 @@ fun ProjectSetupTab(
                 AzTextBox(
                     value = repoDescription,
                     onValueChange = { repoDescription = it },
-                    hint = "Description",
+                    hint = "Description (used if you publish to GitHub)",
                     onSubmit = {}
                 )
 
@@ -199,11 +175,12 @@ fun ProjectSetupTab(
             if (isCreateMode) {
                 AzButton(
                     onClick = {
-                        if (settingsViewModel.getGithubToken().isNullOrBlank()) {
-                            showTokenRequiredDialog = true
-                        } else if (onCheckRequirements()) {
-                            viewModel.createGitHubRepository(
-                                appName, repoDescription, false, context,
+                        // No GitHub token check. Creating a project is local and
+                        // offline; the token is asked for by Deploy, which is what
+                        // creates the repository.
+                        if (onCheckRequirements()) {
+                            viewModel.createProject(
+                                appName, repoDescription, context,
                                 initialPrompt = initialPrompt.takeIf { it.isNotBlank() }
                             ) {
                                 onCreateModeChanged(false)

--- a/app/src/androidUnitTest/java/com/hereliesaz/ideaz/git/GitManagerTest.kt
+++ b/app/src/androidUnitTest/java/com/hereliesaz/ideaz/git/GitManagerTest.kt
@@ -114,4 +114,42 @@ class GitManagerTest {
 
         assertTrue(git.getCommitHistory().isNotEmpty())
     }
+
+    /**
+     * saveAndInitialize commits unconditionally after `init`, so this has to
+     * work for a directory with nothing in it. It gated on "did we just scaffold
+     * the starter?" until this test showed the gate was unnecessary — and that
+     * the case it excluded (an imported folder: files present, nothing
+     * scaffolded) was left as a repository with no HEAD.
+     */
+    @Test
+    fun initThenCommitWorksForAnEmptyDirectory() {
+        val dir = tempFolder.newFolder("empty")
+        val git = GitManager(dir)
+        git.init()
+        git.addAll()
+        git.commit("Initial commit")
+
+        assertEquals(1, git.getCommitHistory().size)
+    }
+
+    /**
+     * A repository with no commits is a new repository, not an error. JGit's
+     * `log()` throws `NoHeadException` for it, and GitDelegate.refreshGitData
+     * catches everything silently *and in order* — so this throwing used to take
+     * branches and status down with it, leaving the Git screen blank with no
+     * indication why.
+     */
+    @Test
+    fun commitHistoryIsEmptyRatherThanThrowingForARepoWithNoHead() {
+        val dir = tempFolder.newFolder("no_head")
+        File(dir, "index.html").writeText("<!doctype html>")
+        val git = GitManager(dir)
+        git.init()
+
+        assertTrue(git.getCommitHistory().isEmpty())
+        // The two calls refreshGitData makes *after* it, which a throw skipped.
+        assertTrue(git.getStatus().isNotEmpty())
+        assertTrue(git.getBranches().isEmpty())
+    }
 }

--- a/app/src/androidUnitTest/java/com/hereliesaz/ideaz/git/GitManagerTest.kt
+++ b/app/src/androidUnitTest/java/com/hereliesaz/ideaz/git/GitManagerTest.kt
@@ -1,0 +1,117 @@
+package com.hereliesaz.ideaz.git
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+/**
+ * Covers the two things Deploy's "has this project ever been published?" check
+ * rests on: whether a directory is a repository, and whether it has an `origin`.
+ *
+ * Getting `remoteUrl` wrong is not a visible failure — it is Deploy either
+ * skipping repository creation for a project that has none (and then failing at
+ * push with a confusing error), or creating a second repository for one that is
+ * already linked.
+ */
+class GitManagerTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    @Test
+    fun remoteUrlIsNullForADirectoryThatIsNotARepo() {
+        val dir = tempFolder.newFolder("not_a_repo")
+        val git = GitManager(dir)
+
+        assertFalse(git.isRepo())
+        // Must not throw: this is the state a freshly created local project is
+        // in the first time Deploy asks.
+        assertNull(git.remoteUrl("origin"))
+    }
+
+    @Test
+    fun remoteUrlIsNullForADirectoryThatDoesNotExist() {
+        assertNull(GitManager(File(tempFolder.root, "missing")).remoteUrl("origin"))
+    }
+
+    @Test
+    fun initMakesItARepoWithNoRemote() {
+        val dir = tempFolder.newFolder("fresh")
+        val git = GitManager(dir)
+        git.init()
+
+        assertTrue(git.isRepo())
+        assertTrue(File(dir, ".git").isDirectory)
+        // Created locally, never published.
+        assertNull(git.remoteUrl("origin"))
+    }
+
+    @Test
+    fun addRemoteIsReadBackByRemoteUrl() {
+        val dir = tempFolder.newFolder("linked")
+        val git = GitManager(dir)
+        git.init()
+        git.addRemote("origin", "https://github.com/HereLiesAz/example.git")
+
+        assertEquals("https://github.com/HereLiesAz/example.git", git.remoteUrl("origin"))
+        // Only the remote that was actually added.
+        assertNull(git.remoteUrl("upstream"))
+    }
+
+    @Test
+    fun initThenCommitProducesHistory() {
+        // saveAndInitialize does exactly this for a new local project, so that
+        // "every project is a git repository" holds before any GitHub account
+        // exists. Previously nothing initialised one until Deploy.
+        val dir = tempFolder.newFolder("committed")
+        File(dir, "index.html").writeText("<!doctype html><title>hi</title>")
+
+        val git = GitManager(dir)
+        git.init()
+        git.addAll()
+        git.commit("Initial commit")
+
+        assertTrue(git.isRepo())
+        assertTrue(git.getCommitHistory().isNotEmpty())
+        assertFalse(git.hasChanges())
+    }
+
+    /**
+     * Regression: JGit reads the ambient git config, so on a machine with
+     * `commit.gpgsign = true` every commit threw. With `gpg.format = ssh` it
+     * threw `UnsupportedSigningFormatException` — "No signer for ssh
+     * signatures" — which names nothing the user did.
+     *
+     * IDEaz has no signing key and no way to prompt for a passphrase, so it
+     * opts out explicitly. `IdeTools.checkpoint` always did; `GitManager.commit`
+     * did not, so the AI's checkpoints committed while the user's own commits,
+     * Deploy, and a new project's initial commit all failed.
+     */
+    @Test
+    fun commitSucceedsWithSigningTurnedOnInTheRepoConfig() {
+        val dir = tempFolder.newFolder("signing_on")
+        File(dir, "index.html").writeText("<!doctype html>")
+
+        val git = GitManager(dir)
+        git.init()
+        // Repo-level config outranks the global config, so this reproduces the
+        // failure regardless of how the machine running the test is set up.
+        org.eclipse.jgit.api.Git.open(dir).use {
+            it.repository.config.apply {
+                setBoolean("commit", null, "gpgsign", true)
+                setString("gpg", null, "format", "ssh")
+                save()
+            }
+        }
+
+        git.addAll()
+        git.commit("Initial commit")
+
+        assertTrue(git.getCommitHistory().isNotEmpty())
+    }
+}

--- a/app/src/jvmSharedMain/kotlin/com/hereliesaz/ideaz/git/GitManager.kt
+++ b/app/src/jvmSharedMain/kotlin/com/hereliesaz/ideaz/git/GitManager.kt
@@ -3,6 +3,7 @@ package com.hereliesaz.ideaz.git
 import com.hereliesaz.ideaz.platform.Platform
 
 import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.api.errors.NoHeadException
 import org.eclipse.jgit.api.errors.GitAPIException
 import org.eclipse.jgit.transport.RemoteRefUpdate
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider
@@ -549,16 +550,21 @@ class GitManager(private val projectDir: File) {
      * @return A list of formatted commit strings ("shortSha - message (author)").
      */
     fun getCommitHistory(): List<String> {
-        try {
-            Git.open(projectDir).use { git ->
-                return git.log().call().map { commit ->
+        Git.open(projectDir).use { git ->
+            return try {
+                git.log().call().map { commit ->
                     val author = commit.authorIdent.name
                     val message = commit.shortMessage
                     "${commit.name.substring(0, 7)} - $message ($author)"
                 }
+            } catch (e: NoHeadException) {
+                // A repository with no commits yet is not an error, it is a new
+                // repository. JGit's log() throws NoHeadException for it, and
+                // GitDelegate.refreshGitData catches everything silently and in
+                // order - so this used to take branches and status down with it,
+                // leaving the Git screen blank with no indication why.
+                emptyList()
             }
-        } catch (e: Exception) {
-            throw e
         }
     }
 

--- a/app/src/jvmSharedMain/kotlin/com/hereliesaz/ideaz/git/GitManager.kt
+++ b/app/src/jvmSharedMain/kotlin/com/hereliesaz/ideaz/git/GitManager.kt
@@ -163,7 +163,21 @@ class GitManager(private val projectDir: File) {
     fun commit(message: String, allowEmpty: Boolean = false) {
         configureUser()
         Git.open(projectDir).use { git ->
-            git.commit().setMessage(message).setAllowEmpty(allowEmpty).call()
+            // setSign(false) is not a style preference. JGit reads the ambient
+            // git config, so on any machine with `commit.gpgsign = true` every
+            // commit here threw - and with `gpg.format = ssh` it threw
+            // UnsupportedSigningFormatException ("No signer for ssh signatures")
+            // rather than anything that names the real problem. IDEaz has no
+            // signing key and no way to prompt for a passphrase, so it must
+            // opt out explicitly rather than inherit the user's setting.
+            //
+            // IdeTools.checkpoint already did this; this path did not, so the
+            // AI's checkpoints committed fine while the user's own commits,
+            // Deploy, and the initial commit of a new project all failed. Most
+            // visible on the desktop target, where a developer's global config
+            // is right there - CI runners have no signing configured, which is
+            // why CI never caught it.
+            git.commit().setMessage(message).setAllowEmpty(allowEmpty).setSign(false).call()
         }
     }
 
@@ -392,6 +406,19 @@ class GitManager(private val projectDir: File) {
      */
     fun isRepo(): Boolean {
         return File(projectDir, ".git").exists()
+    }
+
+    /**
+     * The configured URL of remote [name], or null when no such remote exists.
+     *
+     * Used to decide whether a project has ever been published: a locally
+     * created project has no `origin` until the first Deploy creates one.
+     */
+    fun remoteUrl(name: String): String? {
+        if (!isRepo()) return null
+        return Git.open(projectDir).use { git ->
+            git.repository.config.getString("remote", name, "url")?.takeIf { it.isNotBlank() }
+        }
     }
 
     /**

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -133,6 +133,24 @@ resolve to a file and line — and the one bundled starter is a React/Vite app.
 Plain HTML still previews; it falls back to `data-ideaz-source`, then to a
 selector, and the AI's preamble says which it is getting.
 
+## 8. GitHub is optional until you publish
+
+Create, scaffold, edit, preview, approve and commit all work with no account and
+no network. `checkRequiredKeys` asks for an AI key and nothing else.
+
+This was not true until recently, and the README said it was. **Create & Save**
+was hard-gated on a token because it made the repository on GitHub *first*
+(`generateFromTemplate`) and cloned it back down. The local path existed but was
+unreachable for a named project, because the App Name field is read-only outside
+Create mode — so a user without an account could only ever have a project called
+`IDEazProject`.
+
+Creating is now local: scaffold from the bundled starter, `git init`, initial
+commit. `RepoDelegate.ensureRemoteRepository` runs on the first **Deploy**,
+creates the repository if `origin` is missing, and reuses an existing one rather
+than making a second. Deploy is also the only place that reports a missing token,
+and it says so in a toast rather than only in a log tab that may be collapsed.
+
 ## 8. Out of scope
 
 React Native, Flutter, Python, the on-device APK toolchain, VirtualDisplay


### PR DESCRIPTION
The README said you did not need a GitHub account to start. You did.

## The gate

**"Create & Save" was hard-gated on a token** (`SetupTab.kt`), because creating a project went through GitHub *first*: `generateFromTemplate` made a pre-populated remote, then IDEaz cloned it back down.

A local path existed — but it was unreachable for a **named** project. The App Name field is `enabled = isCreateMode`, so outside Create mode it is read-only and filled from `getAppName() ?: "IDEazProject"`. Without an account you could have exactly one project, and it was called `IDEazProject`.

## The fix

Creating is now local and offline: scaffold from the bundled starter → `git init` → initial commit.

`RepoDelegate.ensureRemoteRepository` runs on the **first Deploy**: creates the repository when `origin` is missing, reuses an existing one rather than making a second, and wires up the remote. Deploy is the one action that needs an account, so it is the one action that asks — and it reports a missing token in a **toast**, not only in a log tab that may be collapsed (the same failure mode "Add External Project" had).

The repo description moves to a preference, since Create no longer has a repository to attach it to at the time the user types it.

## Three bugs found on the way

**1. Every commit failed on any machine with commit signing configured.**

`GitManager.commit` inherited the ambient git config. With `commit.gpgsign = true` it threw; with `gpg.format = ssh` it threw `UnsupportedSigningFormatException` — *"No signer for ssh signatures"* — which names nothing the user did.

`IdeTools.checkpoint` already passed `setSign(false)`. This path never did. So **the AI's checkpoints committed while the user's own commits, Deploy, and a new project's initial commit all failed.** Most visible on the desktop target, where a developer's global config is right there. CI runners have no signing configured, which is why CI never caught it — and this dev container does, which is why a new test did, immediately.

**2. Nothing ever ran `git init` on the local path.** Only `forceUpdateInitFiles` did, and that runs on Deploy. So *"every project is a git repository"* was false for any project created and edited offline: no history, no undo below the AI's own checkpoints, nothing to push when the user finally did connect an account.

**3. Build and App View disagreed about the same project.** `openPreview` checked `File(projectDir, "index.html")` at the repo root, while `launchTargetApp` used `ProjectAnalyzer.findWebEntryPoint` and the load gate used `isPreviewable`. A project with `public/index.html` opened, mounted in App View, and was refused by the Build button. **This one is mine** — from the previous PR, where I updated one of the two call sites and not the other.

## Tests

New `GitManagerTest` covers what Deploy's "has this ever been published?" check rests on: `isRepo`, `remoteUrl` on a non-repo, on a repo with no remote, and after `addRemote`. Plus a regression test that sets `gpgsign`/`ssh` **in the repo config** (which outranks the global config, so it reproduces regardless of the machine) and commits.

Reverting `setSign(false)` turns both commit tests red — the only evidence they test anything.

## Verification

**132 unit tests** pass (was 126). `assembleDebug`, `desktopMainClasses`, `lintDebug` green. JSX source-chain test still passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdR1Kn5HNmKjEwrv82RZ31)_

## Summary by Sourcery

Enable offline project creation and defer GitHub repository setup and authentication until Deploy.

New Features:
- Allow projects to be created, scaffolded, edited, previewed, and committed locally without a GitHub account.
- Create and link a GitHub repository automatically on the first Deploy, reusing an existing repository when available.

Bug Fixes:
- Ensure commits work when ambient Git commit signing is enabled.
- Initialize every local project with Git history and handle repositories without a HEAD safely.
- Make Build use the same web entry-point discovery as App View and project loading.
- Show a visible toast when Deploy cannot proceed because no GitHub token is configured.

Enhancements:
- Persist repository descriptions until a project is published and remove the GitHub requirement from project creation.

Documentation:
- Update the README and architecture documentation to describe offline project creation and first-Deploy publishing.

Tests:
- Add GitManager coverage for repository detection, remotes, initial commits, empty repositories, and commits with signing enabled.