### PR TITLE
Fix PatternSyntaxException in sourceLabel regex

### DIFF
--- a/app/src/androidMain/kotlin/com/hereliesaz/ideaz/ui/ContextualChatOverlay.kt
+++ b/app/src/androidMain/kotlin/com/hereliesaz/ideaz/ui/ContextualChatOverlay.kt
@@ -200,7 +200,7 @@ internal fun sourceLabel(element: String?): String? {
     // "lineNumber" actually appears, so that capture group was always empty.
     // Extracting the source block first and searching each key independently
     // (key order in the payload isn't guaranteed anyway) sidesteps that.
-    val block = Regex("\"source\"\\s*:\\s*\\{([^}]*)}").find(element)?.groupValues?.get(1) ?: return null
+    val block = Regex("\"source\"\\s*:\\s*\\{([^}]*)\\}").find(element)?.groupValues?.get(1) ?: return null
     val fileValue = Regex("\"fileName\"\\s*:\\s*\"([^\"]+)\"").find(block)?.groupValues?.get(1) ?: return null
     val file = fileValue.substringAfterLast('/')
     val line = Regex("\"lineNumber\"\\s*:\\s*(\\d+)").find(block)?.groupValues?.get(1)


### PR DESCRIPTION
## Summary
- `ContextualChatOverlay.kt`'s `sourceLabel` used the regex `"source"\s*:\s*\{([^}]*)}`, which crashed with `PatternSyntaxException` on Android's ICU regex engine because the closing `}` was left unescaped even though the opening `{` was escaped.
- Escaped the closing brace (`\\}`) so the pattern compiles under ICU, matching how the opening brace is already handled.

## Test plan
- [ ] Could not run `./gradlew :app:compileDebugKotlinAndroid` in this environment (no Android SDK configured), so verify the build compiles and `ContextualChatOverlay` renders without the crash on a device/emulator.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RPSN21YF4RtB3PGAfePyXJ)_

## Summary by Sourcery

Bug Fixes:
- Prevent Android regex compilation failures when extracting source metadata from contextual chat overlay elements.