### PR TITLE
Fix PatternSyntaxException in ContextualChatOverlay regex

### DIFF
--- a/app/src/androidMain/kotlin/com/hereliesaz/ideaz/ui/ContextualChatOverlay.kt
+++ b/app/src/androidMain/kotlin/com/hereliesaz/ideaz/ui/ContextualChatOverlay.kt
@@ -200,7 +200,7 @@ internal fun sourceLabel(element: String?): String? {
     // "lineNumber" actually appears, so that capture group was always empty.
     // Extracting the source block first and searching each key independently
     // (key order in the payload isn't guaranteed anyway) sidesteps that.
-    val block = Regex("\"source\"\\s*:\\s*\\{([^}]*)}").find(element)?.groupValues?.get(1) ?: return null
+    val block = Regex("\"source\"\\s*:\\s*\\{([^\\}]*)\\}").find(element)?.groupValues?.get(1) ?: return null
     val fileValue = Regex("\"fileName\"\\s*:\\s*\"([^\"]+)\"").find(block)?.groupValues?.get(1) ?: return null
     val file = fileValue.substringAfterLast('/')
     val line = Regex("\"lineNumber\"\\s*:\\s*(\\d+)").find(block)?.groupValues?.get(1)

--- a/version.properties
+++ b/version.properties
@@ -2,4 +2,4 @@
 build=93
 major=1
 minor=18
-patch=67
+patch=68


### PR DESCRIPTION
Fixes java.util.regex.PatternSyntaxException when parsing sourceLabel in ContextualChatOverlay on Android SDK 36.

Fixes #869

---
*PR created automatically by Jules for task [7793630400502700680](https://jules.google.com/task/7793630400502700680) started by @HereLiesAz*

## Summary by Sourcery

Build:
- Bump the patch version from 1.18.67 to 1.18.68.